### PR TITLE
[Feat] FCM 푸시 알림 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,11 @@ application-local.yaml
 k8s/app/secret.yaml
 k8s/postgres/secret.yaml
 
+# OMC
 .omc
+
+# Firebase
+src/main/resources/firebase/
+
+## docs
+docs/**

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	// FCM
+	implementation 'com.google.firebase:firebase-admin:9.8.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/semosan/api/common/config/AsyncConfig.java
+++ b/src/main/java/com/semosan/api/common/config/AsyncConfig.java
@@ -21,7 +21,7 @@ public class AsyncConfig {
         executor.setThreadNamePrefix("notif-async-");
         // 큐 가득 차면 호출 스레드가 직접 실행 → 메시지 유실 방지
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
-        executor.initialize();
+        // executor.initialize() 호출 안 함 → Spring이 afterPropertiesSet()에서 자동 호출
         return executor;
     }
 }

--- a/src/main/java/com/semosan/api/common/config/AsyncConfig.java
+++ b/src/main/java/com/semosan/api/common/config/AsyncConfig.java
@@ -1,0 +1,27 @@
+package com.semosan.api.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "notificationTaskExecutor")
+    public Executor notificationTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("notif-async-");
+        // 큐 가득 차면 호출 스레드가 직접 실행 → 메시지 유실 방지
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/semosan/api/common/config/FirebaseConfig.java
+++ b/src/main/java/com/semosan/api/common/config/FirebaseConfig.java
@@ -1,0 +1,40 @@
+package com.semosan.api.common.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+    private static final String SERVICE_ACCOUNT_PATH = "firebase/semosan-b2593-firebase-adminsdk-fbsvc-0d55d3b4e9.json";
+
+    // 이 빈 만들어진 직후에 이 메서드 자동 실행, 앱 시작할 때 딱 한 번 실행됨
+    @PostConstruct
+    public void initialize() throws IOException {
+	if (!FirebaseApp.getApps().isEmpty()) {
+	    log.info("FirebaseApp already initialized, skipping");
+	    return;
+	}
+
+	// new File() 안 쓰는 이유는 jar로 빌드하면 파일들이 jar 안에 들어가는데, new File()은 jar 내부 파일을 못 읽음
+	// ClassPathResource는 잘 읽는다고 함
+	try (InputStream serviceAccount = new ClassPathResource(SERVICE_ACCOUNT_PATH).getInputStream()) {
+	    FirebaseOptions options = FirebaseOptions.builder()
+		    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+		    .build();
+
+	    FirebaseApp.initializeApp(options);
+	    log.info("FirebaseApp initialized successfully");
+	}
+    }
+
+}

--- a/src/main/java/com/semosan/api/common/config/FirebaseConfig.java
+++ b/src/main/java/com/semosan/api/common/config/FirebaseConfig.java
@@ -5,6 +5,7 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 
@@ -15,26 +16,27 @@ import java.io.InputStream;
 @Configuration
 public class FirebaseConfig {
 
-    private static final String SERVICE_ACCOUNT_PATH = "firebase/semosan-b2593-firebase-adminsdk-fbsvc-0d55d3b4e9.json";
+    @Value("${firebase.service-account-path}")
+    private String serviceAccountPath;
 
     // 이 빈 만들어진 직후에 이 메서드 자동 실행, 앱 시작할 때 딱 한 번 실행됨
     @PostConstruct
     public void initialize() throws IOException {
-	if (!FirebaseApp.getApps().isEmpty()) {
-	    log.info("FirebaseApp already initialized, skipping");
-	    return;
-	}
+        if (!FirebaseApp.getApps().isEmpty()) {
+            log.info("FirebaseApp already initialized, skipping");
+            return;
+        }
 
-	// new File() 안 쓰는 이유는 jar로 빌드하면 파일들이 jar 안에 들어가는데, new File()은 jar 내부 파일을 못 읽음
-	// ClassPathResource는 잘 읽는다고 함
-	try (InputStream serviceAccount = new ClassPathResource(SERVICE_ACCOUNT_PATH).getInputStream()) {
-	    FirebaseOptions options = FirebaseOptions.builder()
-		    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-		    .build();
+        // new File() 안 쓰는 이유는 jar로 빌드하면 파일들이 jar 안에 들어가는데, new File()은 jar 내부 파일을 못 읽음
+        // ClassPathResource는 잘 읽는다고 함
+        try (InputStream serviceAccount = new ClassPathResource(serviceAccountPath).getInputStream()) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
 
-	    FirebaseApp.initializeApp(options);
-	    log.info("FirebaseApp initialized successfully");
-	}
+            FirebaseApp.initializeApp(options);
+            log.info("FirebaseApp initialized successfully");
+        }
     }
 
 }

--- a/src/main/java/com/semosan/api/common/fcm/FcmService.java
+++ b/src/main/java/com/semosan/api/common/fcm/FcmService.java
@@ -1,0 +1,35 @@
+package com.semosan.api.common.fcm;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+public class FcmService {
+
+    public String sendMessage(String token, String title, String body, Map<String, String> data) throws FirebaseMessagingException {
+        Notification notification = Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+
+        Message.Builder builder = Message.builder()
+                .setToken(token)
+                .setNotification(notification);
+
+        if (data != null && !data.isEmpty()) {
+            builder.putAllData(data);
+        }
+
+        String response = FirebaseMessaging.getInstance().send(builder.build());
+        log.info("FCM 발송 성공: {}", response);
+        return response;
+    }
+
+}

--- a/src/main/java/com/semosan/api/common/status/ErrorStatus.java
+++ b/src/main/java/com/semosan/api/common/status/ErrorStatus.java
@@ -51,6 +51,11 @@ public enum ErrorStatus implements BaseStatus {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_1", "사용자를 찾을 수 없습니다."),
 
     /**
+     * Notification
+     */
+    NOTIFICATION_PARAMS_INVALID(HttpStatus.BAD_REQUEST, "NOTIF_400_1", "알림 파라미터가 유효하지 않습니다."),
+
+    /**
      * Apple OAuth
      */
     APPLE_PUBLIC_KEY_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "APPLE_502_1", "애플 공개키 조회에 실패했습니다."),

--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -20,7 +20,14 @@ public enum SuccessStatus implements BaseStatus {
     /**
      * User
      */
-    WITHDRAW_SUCCESS(HttpStatus.OK, "USER_200_1", "회원 탈퇴가 완료되었습니다.");
+    WITHDRAW_SUCCESS(HttpStatus.OK, "USER_200_1", "회원 탈퇴가 완료되었습니다."),
+
+    /**
+     * FCM / Notification
+     */
+    FCM_TOKEN_REGISTER_SUCCESS(HttpStatus.OK, "FCM_200_1", "FCM 토큰이 등록되었습니다."),
+    FCM_TOKEN_DELETE_SUCCESS(HttpStatus.OK, "FCM_200_2", "FCM 토큰이 삭제되었습니다."),
+    NOTIFICATION_SEND_SUCCESS(HttpStatus.OK, "NOTIF_200_1", "알림 발송 요청에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/semosan/api/domain/notification/controller/FcmTokenController.java
+++ b/src/main/java/com/semosan/api/domain/notification/controller/FcmTokenController.java
@@ -33,9 +33,10 @@ public class FcmTokenController {
 
     @DeleteMapping("/tokens")
     public ResponseEntity<ApiResponse<Void>> delete(
+            @AuthenticationPrincipal Long userId,
             @Valid @RequestBody FcmTokenDeleteRequest request
     ) {
-        fcmTokenService.delete(request.token());
+        fcmTokenService.delete(userId, request.token());
         return ApiResponse.success(SuccessStatus.FCM_TOKEN_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/com/semosan/api/domain/notification/controller/FcmTokenController.java
+++ b/src/main/java/com/semosan/api/domain/notification/controller/FcmTokenController.java
@@ -1,0 +1,41 @@
+package com.semosan.api.domain.notification.controller;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.notification.dto.FcmTokenDeleteRequest;
+import com.semosan.api.domain.notification.dto.FcmTokenRegisterRequest;
+import com.semosan.api.domain.notification.service.FcmTokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/fcm")
+@RequiredArgsConstructor
+public class FcmTokenController {
+
+    private final FcmTokenService fcmTokenService;
+
+    @PostMapping("/tokens")
+    public ResponseEntity<ApiResponse<Void>> register(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody FcmTokenRegisterRequest request
+    ) {
+        fcmTokenService.register(userId, request.token(), request.deviceType());
+        return ApiResponse.success(SuccessStatus.FCM_TOKEN_REGISTER_SUCCESS);
+    }
+
+    @DeleteMapping("/tokens")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @Valid @RequestBody FcmTokenDeleteRequest request
+    ) {
+        fcmTokenService.delete(request.token());
+        return ApiResponse.success(SuccessStatus.FCM_TOKEN_DELETE_SUCCESS);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/notification/controller/NotificationTestController.java
+++ b/src/main/java/com/semosan/api/domain/notification/controller/NotificationTestController.java
@@ -1,0 +1,34 @@
+package com.semosan.api.domain.notification.controller;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.notification.dto.NotificationTestRequest;
+import com.semosan.api.domain.notification.service.NotificationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 알림 테스트용 컨트롤러. local 프로필에서만 활성화 (운영 배포 시 자동 비활성화).
+ */
+@Profile("local")
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationTestController {
+
+    private final NotificationService notificationService;
+
+    @PostMapping("/test")
+    public ResponseEntity<ApiResponse<Void>> send(
+            @Valid @RequestBody NotificationTestRequest request
+    ) {
+        notificationService.send(request.receiverId(), request.type(), request.params());
+        return ApiResponse.success(SuccessStatus.NOTIFICATION_SEND_SUCCESS);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/notification/dispatcher/AsyncNotificationDispatcher.java
+++ b/src/main/java/com/semosan/api/domain/notification/dispatcher/AsyncNotificationDispatcher.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.semosan.api.common.fcm.FcmService;
-import com.semosan.api.domain.notification.repository.FcmTokenRepository;
+import com.semosan.api.domain.notification.service.FcmTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -20,7 +20,7 @@ import java.util.Map;
 public class AsyncNotificationDispatcher implements NotificationDispatcher {
 
     private final FcmService fcmService;
-    private final FcmTokenRepository fcmTokenRepository;
+    private final FcmTokenService fcmTokenService;
     private final ObjectMapper objectMapper;
 
     /**
@@ -60,7 +60,7 @@ public class AsyncNotificationDispatcher implements NotificationDispatcher {
         MessagingErrorCode code = e.getMessagingErrorCode();
         if (code == MessagingErrorCode.UNREGISTERED || code == MessagingErrorCode.INVALID_ARGUMENT) {
             log.warn("만료/잘못된 토큰 삭제 (token={}, code={})", token, code);
-            fcmTokenRepository.deleteByToken(token);
+            fcmTokenService.deleteExpired(token);
         } else {
             log.error("FCM 발송 실패 (token={}, code={}): {}", token, code, e.getMessage());
         }

--- a/src/main/java/com/semosan/api/domain/notification/dispatcher/AsyncNotificationDispatcher.java
+++ b/src/main/java/com/semosan/api/domain/notification/dispatcher/AsyncNotificationDispatcher.java
@@ -1,0 +1,68 @@
+package com.semosan.api.domain.notification.dispatcher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.semosan.api.common.fcm.FcmService;
+import com.semosan.api.domain.notification.repository.FcmTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AsyncNotificationDispatcher implements NotificationDispatcher {
+
+    private final FcmService fcmService;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * @Async 가 같은 클래스에 있는 함수를 호출 할 때는 비동기로 작동하지 않으니 주의해야함
+     * AOP 프록시를 사용해서 그렇고, 그래서 빈으로 등록된 다른 클래스에서 호출해야함
+     */
+    @Override
+    @Async("notificationTaskExecutor")
+    public void dispatch(NotificationDispatchCommand cmd) {
+        Map<String, String> dataPayload = buildDataPayload(cmd);
+
+        for (String token : cmd.tokens()) {
+            try {
+                fcmService.sendMessage(token, cmd.title(), cmd.body(), dataPayload);
+            } catch (FirebaseMessagingException e) {
+                handleSendError(token, e);
+            } catch (Exception e) {
+                log.error("FCM 발송 중 알 수 없는 에러 (token={}): {}", token, e.getMessage(), e);
+            }
+        }
+    }
+
+    private Map<String, String> buildDataPayload(NotificationDispatchCommand cmd) {
+        Map<String, String> data = new HashMap<>();
+        data.put("type", cmd.type().name());
+        data.put("notificationId", String.valueOf(cmd.notificationId()));
+        try {
+            data.put("extras", objectMapper.writeValueAsString(cmd.extras()));
+        } catch (JsonProcessingException e) {
+            log.error("extras 직렬화 실패", e);
+            data.put("extras", "{}");
+        }
+        return data;
+    }
+
+    private void handleSendError(String token, FirebaseMessagingException e) {
+        MessagingErrorCode code = e.getMessagingErrorCode();
+        if (code == MessagingErrorCode.UNREGISTERED || code == MessagingErrorCode.INVALID_ARGUMENT) {
+            log.warn("만료/잘못된 토큰 삭제 (token={}, code={})", token, code);
+            fcmTokenRepository.deleteByToken(token);
+        } else {
+            log.error("FCM 발송 실패 (token={}, code={}): {}", token, code, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/semosan/api/domain/notification/dispatcher/NotificationDispatchCommand.java
+++ b/src/main/java/com/semosan/api/domain/notification/dispatcher/NotificationDispatchCommand.java
@@ -1,0 +1,21 @@
+package com.semosan.api.domain.notification.dispatcher;
+
+import com.semosan.api.domain.notification.enums.NotificationType;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 발송 일감. 불변(record)이라 비동기/직렬화 안전.
+ * 카프카나 레디스 큐로 갈아탈 때 그대로 메시지 페이로드로 사용 가능.
+ */
+public record NotificationDispatchCommand(
+        Long notificationId,
+        Long receiverId,
+        NotificationType type,
+        String title,
+        String body,
+        Map<String, Object> extras,
+        List<String> tokens
+) {
+}

--- a/src/main/java/com/semosan/api/domain/notification/dispatcher/NotificationDispatcher.java
+++ b/src/main/java/com/semosan/api/domain/notification/dispatcher/NotificationDispatcher.java
@@ -1,0 +1,9 @@
+package com.semosan.api.domain.notification.dispatcher;
+
+/**
+ * 알림 발송 추상화. 현재는 @Async 인메모리 처리, 추후 Redis/Kafka 등으로 교체 가능.
+ * NotificationService는 이 인터페이스에만 의존한다.
+ */
+public interface NotificationDispatcher {
+    void dispatch(NotificationDispatchCommand command);
+}

--- a/src/main/java/com/semosan/api/domain/notification/dto/FcmTokenDeleteRequest.java
+++ b/src/main/java/com/semosan/api/domain/notification/dto/FcmTokenDeleteRequest.java
@@ -1,0 +1,8 @@
+package com.semosan.api.domain.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FcmTokenDeleteRequest(
+        @NotBlank String token
+) {
+}

--- a/src/main/java/com/semosan/api/domain/notification/dto/FcmTokenRegisterRequest.java
+++ b/src/main/java/com/semosan/api/domain/notification/dto/FcmTokenRegisterRequest.java
@@ -1,0 +1,11 @@
+package com.semosan.api.domain.notification.dto;
+
+import com.semosan.api.domain.user.enums.DeviceType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record FcmTokenRegisterRequest(
+        @NotBlank String token,
+        @NotNull DeviceType deviceType
+) {
+}

--- a/src/main/java/com/semosan/api/domain/notification/dto/NotificationTestRequest.java
+++ b/src/main/java/com/semosan/api/domain/notification/dto/NotificationTestRequest.java
@@ -1,0 +1,13 @@
+package com.semosan.api.domain.notification.dto;
+
+import com.semosan.api.domain.notification.enums.NotificationType;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Map;
+
+public record NotificationTestRequest(
+        @NotNull Long receiverId,
+        @NotNull NotificationType type,
+        Map<String, Object> params
+) {
+}

--- a/src/main/java/com/semosan/api/domain/notification/entity/FcmToken.java
+++ b/src/main/java/com/semosan/api/domain/notification/entity/FcmToken.java
@@ -1,0 +1,62 @@
+package com.semosan.api.domain.notification.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.user.enums.DeviceType;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Table(
+        name = "fcm_tokens",
+        indexes = {@Index(name = "idx_fcm_tokens_user_id", columnList = "user_id")}
+)
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FcmToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "token", length = 512, nullable = false, unique = true)
+    private String token;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "device_type", columnDefinition = "device_type_enum", nullable = false)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    private DeviceType deviceType;
+
+    public static FcmToken create(Long userId, String token, DeviceType deviceType) {
+        return FcmToken.builder()
+                .userId(userId)
+                .token(token)
+                .deviceType(deviceType)
+                .build();
+    }
+
+    // 같은 토큰을 다른 유저가 등록 시 (한 기기 → 다른 유저 로그인) 소유자 갱신
+    public void reassignTo(Long userId, DeviceType deviceType) {
+        this.userId = userId;
+        this.deviceType = deviceType;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/notification/entity/Notification.java
+++ b/src/main/java/com/semosan/api/domain/notification/entity/Notification.java
@@ -1,0 +1,89 @@
+package com.semosan.api.domain.notification.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.notification.enums.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Table(
+        name = "notifications",
+        indexes = {
+                @Index(name = "idx_notifications_user_id_created_at", columnList = "user_id, created_at DESC")
+        }
+)
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    // 타입은 VARCHAR로 (PostgreSQL ENUM과 달리 알림 종류 추가 시 ALTER 불필요)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 50, nullable = false)
+    private NotificationType type;
+
+    @Column(name = "title", length = 100, nullable = false)
+    private String title;
+
+    @Column(name = "body", length = 500, nullable = false)
+    private String body;
+
+    @Column(name = "extras", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Map<String, Object> extras;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean read;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    public static Notification create(
+            Long userId,
+            NotificationType type,
+            String title,
+            String body,
+            Map<String, Object> extras
+    ) {
+        return Notification.builder()
+                .userId(userId)
+                .type(type)
+                .title(title)
+                .body(body)
+                .extras(extras)
+                .read(false)
+                .build();
+    }
+
+    public void markAsRead() {
+        if (!this.read) {
+            this.read = true;
+            this.readAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/semosan/api/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/semosan/api/domain/notification/enums/NotificationType.java
@@ -1,0 +1,59 @@
+package com.semosan.api.domain.notification.enums;
+
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
+
+import java.util.Map;
+import java.util.Set;
+
+public enum NotificationType {
+
+    // 테스트 용
+    COMMUNITY_COMMENT(
+            "새 댓글이 달렸어요",
+            "{actorName}: {commentPreview}",
+            Set.of("actorName", "commentPreview")
+    );
+
+    private final String titleTemplate;
+    private final String bodyTemplate;
+    private final Set<String> requiredKeys;
+
+    NotificationType(String titleTemplate, String bodyTemplate, Set<String> requiredKeys) {
+        this.titleTemplate = titleTemplate;
+        this.bodyTemplate = bodyTemplate;
+        this.requiredKeys = requiredKeys;
+    }
+
+    /**
+     * 호출자가 필수 파라미터를 누락했을 때 예외. 알림 발송 전 미리 차단.
+     */
+    public void validate(Map<String, Object> params) {
+        if (params == null) {
+            throw new GeneralException(ErrorStatus.NOTIFICATION_PARAMS_INVALID);
+        }
+        for (String key : requiredKeys) {
+            Object value = params.get(key);
+            if (value == null || (value instanceof String s && s.isBlank())) {
+                throw new GeneralException(ErrorStatus.NOTIFICATION_PARAMS_INVALID);
+            }
+        }
+    }
+
+    public String formatTitle(Map<String, Object> params) {
+        return format(titleTemplate, params);
+    }
+
+    public String formatBody(Map<String, Object> params) {
+        return format(bodyTemplate, params);
+    }
+
+    private static String format(String template, Map<String, Object> params) {
+        if (params == null || params.isEmpty()) return template;
+        String result = template;
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
+            result = result.replace("{" + entry.getKey() + "}", String.valueOf(entry.getValue()));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/notification/event/NotificationCreatedEvent.java
+++ b/src/main/java/com/semosan/api/domain/notification/event/NotificationCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.semosan.api.domain.notification.event;
+
+import com.semosan.api.domain.notification.dispatcher.NotificationDispatchCommand;
+
+/**
+ * 알림 이력이 DB에 저장된 후 발행되는 도메인 이벤트
+ * 이 이벤트는 NotificationEventListener가 트랜잭션 커밋 후(AFTER_COMMIT)에만 처리하므로,
+ * 알림 이력 저장과 실제 FCM 발송의 일관성이 보장된다 (롤백 시 푸시도 안 감)
+ */
+public record NotificationCreatedEvent(NotificationDispatchCommand command) {
+}

--- a/src/main/java/com/semosan/api/domain/notification/event/NotificationEventListener.java
+++ b/src/main/java/com/semosan/api/domain/notification/event/NotificationEventListener.java
@@ -1,0 +1,27 @@
+package com.semosan.api.domain.notification.event;
+
+import com.semosan.api.domain.notification.dispatcher.NotificationDispatcher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationDispatcher dispatcher;
+
+    /**
+     * 알림 이력 저장 트랜잭션이 커밋된 직후에만 실행
+     * 롤백되면 호출 자체가 일어나지 않아 푸시도 안 보내짐 → DB와 푸시 상태 일관성 보장.
+     *
+     * dispatcher 자체가 @Async라 호출 즉시 리턴하므로 커밋 후 응답 지연도 거의 없음.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onNotificationCreated(NotificationCreatedEvent event) {
+        dispatcher.dispatch(event.command());
+    }
+}

--- a/src/main/java/com/semosan/api/domain/notification/repository/FcmTokenRepository.java
+++ b/src/main/java/com/semosan/api/domain/notification/repository/FcmTokenRepository.java
@@ -2,7 +2,9 @@ package com.semosan.api.domain.notification.repository;
 
 import com.semosan.api.domain.notification.entity.FcmToken;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +15,7 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
     List<FcmToken> findAllByUserId(Long userId);
 
-    @Transactional
-    void deleteByToken(String token);
+    @Modifying
+    @Query("DELETE FROM FcmToken f WHERE f.token = :token")
+    void deleteByToken(@Param("token") String token);
 }

--- a/src/main/java/com/semosan/api/domain/notification/repository/FcmTokenRepository.java
+++ b/src/main/java/com/semosan/api/domain/notification/repository/FcmTokenRepository.java
@@ -1,0 +1,18 @@
+package com.semosan.api.domain.notification.repository;
+
+import com.semosan.api.domain.notification.entity.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    Optional<FcmToken> findByToken(String token);
+
+    List<FcmToken> findAllByUserId(Long userId);
+
+    @Transactional
+    void deleteByToken(String token);
+}

--- a/src/main/java/com/semosan/api/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/semosan/api/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package com.semosan.api.domain.notification.repository;
+
+import com.semosan.api.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+// TODO: 알림판 구현할 때 쓸 예정
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/semosan/api/domain/notification/service/FcmTokenService.java
+++ b/src/main/java/com/semosan/api/domain/notification/service/FcmTokenService.java
@@ -42,4 +42,13 @@ public class FcmTokenService {
             fcmTokenRepository.deleteByToken(token);
         });
     }
+
+    /**
+     * FCM 발송 실패(UNREGISTERED 등)로 만료된 토큰 정리.
+     * 시스템 정리용이라 본인 검증 없이 바로 삭제.
+     */
+    @Transactional
+    public void deleteExpired(String token) {
+        fcmTokenRepository.deleteByToken(token);
+    }
 }

--- a/src/main/java/com/semosan/api/domain/notification/service/FcmTokenService.java
+++ b/src/main/java/com/semosan/api/domain/notification/service/FcmTokenService.java
@@ -1,0 +1,38 @@
+package com.semosan.api.domain.notification.service;
+
+import com.semosan.api.domain.notification.entity.FcmToken;
+import com.semosan.api.domain.notification.repository.FcmTokenRepository;
+import com.semosan.api.domain.user.enums.DeviceType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmTokenService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+
+    /**
+     * 토큰 등록
+     * 같은 토큰이 이미 있으면 (다른 유저로 로그인 등) 소유자/디바이스 갱신
+     */
+    @Transactional
+    public void register(Long userId, String token, DeviceType deviceType) {
+        fcmTokenRepository.findByToken(token).ifPresentOrElse(
+                existing -> existing.reassignTo(userId, deviceType),
+                () -> fcmTokenRepository.save(FcmToken.create(userId, token, deviceType))
+        );
+    }
+
+    /**
+     * 토큰 삭제
+     * 로그아웃 시 호출하면 될 듯
+     */
+    @Transactional
+    public void delete(String token) {
+        fcmTokenRepository.deleteByToken(token);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/notification/service/FcmTokenService.java
+++ b/src/main/java/com/semosan/api/domain/notification/service/FcmTokenService.java
@@ -1,5 +1,7 @@
 package com.semosan.api.domain.notification.service;
 
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.notification.entity.FcmToken;
 import com.semosan.api.domain.notification.repository.FcmTokenRepository;
 import com.semosan.api.domain.user.enums.DeviceType;
@@ -28,11 +30,16 @@ public class FcmTokenService {
     }
 
     /**
-     * 토큰 삭제
-     * 로그아웃 시 호출하면 될 듯
+     * 토큰 삭제 (로그아웃 시 호출)
+     * 본인 소유 토큰만 삭제 가능. 토큰 없으면 idempotent하게 noop.
      */
     @Transactional
-    public void delete(String token) {
-        fcmTokenRepository.deleteByToken(token);
+    public void delete(Long userId, String token) {
+        fcmTokenRepository.findByToken(token).ifPresent(fcmToken -> {
+            if (!fcmToken.getUserId().equals(userId)) {
+                throw new GeneralException(ErrorStatus.FORBIDDEN);
+            }
+            fcmTokenRepository.deleteByToken(token);
+        });
     }
 }

--- a/src/main/java/com/semosan/api/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/semosan/api/domain/notification/service/NotificationService.java
@@ -3,15 +3,16 @@ package com.semosan.api.domain.notification.service;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.notification.dispatcher.NotificationDispatchCommand;
-import com.semosan.api.domain.notification.dispatcher.NotificationDispatcher;
 import com.semosan.api.domain.notification.entity.FcmToken;
 import com.semosan.api.domain.notification.entity.Notification;
 import com.semosan.api.domain.notification.enums.NotificationType;
+import com.semosan.api.domain.notification.event.NotificationCreatedEvent;
 import com.semosan.api.domain.notification.repository.FcmTokenRepository;
 import com.semosan.api.domain.notification.repository.NotificationRepository;
 import com.semosan.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,34 +24,38 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class NotificationService {
 
-    private final NotificationDispatcher dispatcher;
     private final NotificationRepository notificationRepository;
     private final FcmTokenRepository fcmTokenRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 서비스로 어디서든 한 줄로 알림 발송 가능
+     *
+     * 흐름:
+     *   1. 받는 사람 / 파라미터 검증
+     *   2. 템플릿 처리 → title/body
+     *   3. Notification 이력 저장
+     *   4. 받는 사람 토큰 조회 (없으면 정상 종료)
+     *   5. NotificationCreatedEvent 발행
+     *      → NotificationEventListener가 트랜잭션 커밋 후에 dispatcher.dispatch() 호출
+     *      → 롤백 시 푸시도 안 보내짐 (DB-푸시 일관성)
      */
     @Transactional
     public void send(Long receiverId, NotificationType type, Map<String, Object> params) {
-        // 1. 받는 사람 검증
         if (!userRepository.existsById(receiverId)) {
             throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
         }
 
-        // 2. 파라미터 검증 (NotificationType별 필수 키)
         type.validate(params);
 
-        // 3. 템플릿 처리
         String title = type.formatTitle(params);
         String body = type.formatBody(params);
 
-        // 4. 이력 저장
         Notification notification = notificationRepository.save(
                 Notification.create(receiverId, type, title, body, params)
         );
 
-        // 5. 토큰 조회, 없으면 정상 종료 (유저가 알림 거부/로그아웃 등 정상 케이스)
         List<String> tokens = fcmTokenRepository.findAllByUserId(receiverId).stream()
                 .map(FcmToken::getToken)
                 .toList();
@@ -60,15 +65,17 @@ public class NotificationService {
             return;
         }
 
-        // 6. 비동기 발송 위임
-        dispatcher.dispatch(new NotificationDispatchCommand(
-                notification.getId(),
-                receiverId,
-                type,
-                title,
-                body,
-                params,
-                tokens
+        // 트랜잭션 커밋 후에만 실제 발송이 일어나도록 이벤트 발행
+        eventPublisher.publishEvent(new NotificationCreatedEvent(
+                new NotificationDispatchCommand(
+                        notification.getId(),
+                        receiverId,
+                        type,
+                        title,
+                        body,
+                        params,
+                        tokens
+                )
         ));
     }
 }

--- a/src/main/java/com/semosan/api/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/semosan/api/domain/notification/service/NotificationService.java
@@ -1,0 +1,74 @@
+package com.semosan.api.domain.notification.service;
+
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.notification.dispatcher.NotificationDispatchCommand;
+import com.semosan.api.domain.notification.dispatcher.NotificationDispatcher;
+import com.semosan.api.domain.notification.entity.FcmToken;
+import com.semosan.api.domain.notification.entity.Notification;
+import com.semosan.api.domain.notification.enums.NotificationType;
+import com.semosan.api.domain.notification.repository.FcmTokenRepository;
+import com.semosan.api.domain.notification.repository.NotificationRepository;
+import com.semosan.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationDispatcher dispatcher;
+    private final NotificationRepository notificationRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 서비스로 어디서든 한 줄로 알림 발송 가능
+     */
+    @Transactional
+    public void send(Long receiverId, NotificationType type, Map<String, Object> params) {
+        // 1. 받는 사람 검증
+        if (!userRepository.existsById(receiverId)) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
+
+        // 2. 파라미터 검증 (NotificationType별 필수 키)
+        type.validate(params);
+
+        // 3. 템플릿 처리
+        String title = type.formatTitle(params);
+        String body = type.formatBody(params);
+
+        // 4. 이력 저장
+        Notification notification = notificationRepository.save(
+                Notification.create(receiverId, type, title, body, params)
+        );
+
+        // 5. 토큰 조회, 없으면 정상 종료 (유저가 알림 거부/로그아웃 등 정상 케이스)
+        List<String> tokens = fcmTokenRepository.findAllByUserId(receiverId).stream()
+                .map(FcmToken::getToken)
+                .toList();
+
+        if (tokens.isEmpty()) {
+            log.info("발송 대상 토큰 없음 (userId={}, type={})", receiverId, type);
+            return;
+        }
+
+        // 6. 비동기 발송 위임
+        dispatcher.dispatch(new NotificationDispatchCommand(
+                notification.getId(),
+                receiverId,
+                type,
+                title,
+                body,
+                params,
+                tokens
+        ));
+    }
+}

--- a/src/main/java/com/semosan/api/domain/user/entity/User.java
+++ b/src/main/java/com/semosan/api/domain/user/entity/User.java
@@ -63,6 +63,8 @@ public class User extends BaseEntity {
     @Column(name = "weight")
     private Double weight;
 
+    // 이거 삭제해야할 듯 -> fcm_tokens 테이블을 따로 뺌
+    // 충돌날까봐 아직 건드리진 않음
     @Column(name = "fcm_token", length = 255)
     private String fcmToken;
 

--- a/src/main/java/com/semosan/api/domain/user/entity/User.java
+++ b/src/main/java/com/semosan/api/domain/user/entity/User.java
@@ -63,11 +63,6 @@ public class User extends BaseEntity {
     @Column(name = "weight")
     private Double weight;
 
-    // 이거 삭제해야할 듯 -> fcm_tokens 테이블을 따로 뺌
-    // 충돌날까봐 아직 건드리진 않음
-    @Column(name = "fcm_token", length = 255)
-    private String fcmToken;
-
     @Column(name = "is_deleted", nullable = false)
     private boolean deleted = false;
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,3 +4,6 @@ spring:
 
   profiles:
     default: local
+
+firebase:
+  service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH:firebase/semosan-b2593-firebase-adminsdk-fbsvc-0d55d3b4e9.json}


### PR DESCRIPTION
## 🧾 요약
- FCM 푸시 알림 시스템을 도입 
- 백엔드 어디서든 `notificationService.send()` 한 줄로 알림을 발송할 수 있고, 한 유저의 여러 기기에 동시 발송됩니다. 
- 발송은 비동기로 처리되며, 추후 Redis/Kafka 등 큐 시스템으로 갈아끼울 수 있도록 `NotificationDispatcher` 인터페이스로 추상화했습니다.
- 알림 이력은 DB에 저장되어 추후 알림함 화면에서 활용 가능합니다.

## 🔗 이슈
- close #11

## ✨ 변경 내용

### 인프라
- `firebase-admin:9.8.0` 의존성 추가
- `FirebaseConfig`: 앱 시작 시 Firebase 초기화 (서비스 계정 JSON 로드)
- `AsyncConfig`: 알림 전용 스레드풀 (`notificationTaskExecutor`) + `@EnableAsync`
- `FcmService`: `FirebaseMessaging.send()` 래퍼 (notification + data 페이로드 지원)

### 도메인
- `NotificationType` enum: 알림 종류별 title/body 템플릿 + 필수 파라미터 검증
- 현재 `COMMUNITY_COMMENT` 테스트 이넘 넣어둠
- `FcmToken` 엔티티: 한 유저당 여러 기기 토큰 저장 (token unique)
- `Notification` 엔티티: 알림 이력 (extras는 jsonb)

### 발송 시스템
- `NotificationDispatcher` 인터페이스 + `NotificationDispatchCommand` (record)
- `AsyncNotificationDispatcher`: `@Async` 기반 구현체. 만료 토큰(UNREGISTERED/INVALID_ARGUMENT) 자동 삭제
- `NotificationService`: 팀원 입구. 받는 사람/파라미터 검증 → 이력 저장 → Dispatcher 위임

### API
- `POST /api/fcm/tokens` — 토큰 등록 (JWT 인증, 같은 토큰이면 소유자/디바이스 갱신)
- `DELETE /api/fcm/tokens` — 토큰 삭제 (로그아웃 시)
- `POST /api/notifications/test` — 테스트 발송 (`@Profile("local")` 로 운영 자동 비활성화)

### 응답 코드
- `FCM_200_1` / `FCM_200_2` / `NOTIF_200_1` — 성공
- `USER_404_1` — 받는 사람 없음
- `NOTIF_400_1` — 필수 파라미터 누락


## 🧪 테스트 방법
1. 테스트 로그인으로 JWT 발급
`POST /api/auth/test/login`

 2. 클라이언트(웹/앱)에서 FCM 토큰 발급

 3. 토큰 등록
`POST /api/fcm/tokens`

4. 알림 발송 (본인에게 푸시 도착 확인)
`POST /api/notifications/test`


  
## 📌 사용 예시

  도메인 서비스에서 아래 함수로 전송 가능
  ```java
  notificationService.send(
   receiverId,
   NotificationType.COMMUNITY_COMMENT,
   Map.of(
       "actorName", commenter.getName(),
       "commentPreview", comment.getContent(),
       "postId", post.getId(),
       "commentId", comment.getId(),
       "actorId", commenter.getId()
   )
  ); 
```
-  새 알림 타입 추가 시 NotificationType enum에 한 줄 추가만 하면 됩니다.

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK

## 📝 참고
  - 구현 방식, FCM 개념 등 세모산 노션 문서에 정리되어 있습니다.
  - 트래픽 증가 시 AsyncNotificationDispatcher를 Redis/Kafka 기반 구현체로 교체 가능 (NotificationService 코드는 변경 없음)
  - 유저-FCM토큰 연관관계는 @ManyToOne 대신 Long userId로 분리 (도메인 결합도 낮춤 -> 좋은지는 모르겠음)
  
