### PR TITLE
[Feat] 산 목록 관련 기능 구현

### DIFF
--- a/src/main/java/com/semosan/api/common/status/ErrorStatus.java
+++ b/src/main/java/com/semosan/api/common/status/ErrorStatus.java
@@ -58,6 +58,16 @@ public enum ErrorStatus implements BaseStatus {
     APPLE_IDENTITY_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "APPLE_401_2", "애플 identity token이 유효하지 않습니다."),
 
     /**
+     * Mountain
+     */
+    MOUNTAIN_NOT_FOUND(HttpStatus.NOT_FOUND, "MTN_404_1", "산을 찾을 수 없습니다."),
+
+    /**
+     * Image
+     */
+    IMAGE_UPLOAD_FAILED(HttpStatus.BAD_GATEWAY, "IMG_502_1", "이미지 업로드 URL 생성에 실패했습니다."),
+
+    /**
      * Withdraw
      */
     KAKAO_UNLINK_FAILED(HttpStatus.BAD_GATEWAY, "KAKAO_502_3", "카카오 연동 해제에 실패했습니다."),

--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -20,7 +20,19 @@ public enum SuccessStatus implements BaseStatus {
     /**
      * User
      */
-    WITHDRAW_SUCCESS(HttpStatus.OK, "USER_200_1", "회원 탈퇴가 완료되었습니다.");
+    WITHDRAW_SUCCESS(HttpStatus.OK, "USER_200_1", "회원 탈퇴가 완료되었습니다."),
+
+    /**
+     * Mountain
+     */
+    MOUNTAIN_LIST_SUCCESS(HttpStatus.OK, "MTN_200_1", "산 목록 조회에 성공했습니다."),
+    MOUNTAIN_SEARCH_SUCCESS(HttpStatus.OK, "MTN_200_2", "산 검색에 성공했습니다."),
+    MOUNTAIN_DETAIL_SUCCESS(HttpStatus.OK, "MTN_200_3", "산 상세 정보 조회에 성공했습니다."),
+
+    /**
+     * Image
+     */
+    PRESIGNED_URL_SUCCESS(HttpStatus.OK, "IMG_200_1", "Presigned URL 발급에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
@@ -1,0 +1,46 @@
+package com.semosan.api.domain.mountain.controller;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.mountain.controller.docs.MountainControllerDocs;
+import com.semosan.api.domain.mountain.dto.response.MountainDetailResponse;
+import com.semosan.api.domain.mountain.dto.response.MountainListResponse;
+import com.semosan.api.domain.mountain.service.MountainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/mountains")
+@RequiredArgsConstructor
+public class MountainController implements MountainControllerDocs {
+
+    private final MountainService mountainService;
+
+    @GetMapping
+    @Override
+    public ResponseEntity<ApiResponse<List<MountainListResponse>>> getMountains() {
+        List<MountainListResponse> response = mountainService.getMountains();
+        return ApiResponse.success(SuccessStatus.MOUNTAIN_LIST_SUCCESS, response);
+    }
+
+    @GetMapping("/search")
+    @Override
+    public ResponseEntity<ApiResponse<List<MountainListResponse>>> searchMountains(
+            @RequestParam String keyword
+    ) {
+        List<MountainListResponse> response = mountainService.searchMountains(keyword);
+        return ApiResponse.success(SuccessStatus.MOUNTAIN_SEARCH_SUCCESS, response);
+    }
+
+    @GetMapping("/{mountainId}")
+    @Override
+    public ResponseEntity<ApiResponse<MountainDetailResponse>> getMountainDetail(
+            @PathVariable Long mountainId
+    ) {
+        MountainDetailResponse response = mountainService.getMountainDetail(mountainId);
+        return ApiResponse.success(SuccessStatus.MOUNTAIN_DETAIL_SUCCESS, response);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
@@ -1,0 +1,67 @@
+package com.semosan.api.domain.mountain.controller.docs;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.domain.mountain.dto.response.MountainDetailResponse;
+import com.semosan.api.domain.mountain.dto.response.MountainListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "Mountain", description = "산 관련 API")
+public interface MountainControllerDocs {
+
+    @Operation(
+            summary = "산 목록 조회",
+            description = "등록된 모든 산의 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "산 목록 조회 성공"
+            )
+    })
+    ResponseEntity<ApiResponse<List<MountainListResponse>>> getMountains();
+
+    @Operation(
+            summary = "산 검색",
+            description = "산 이름 또는 주소로 검색합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "산 검색 성공"
+            )
+    })
+    ResponseEntity<ApiResponse<List<MountainListResponse>>> searchMountains(
+            @Parameter(description = "검색 키워드 (산 이름 또는 주소)", required = true)
+            @RequestParam String keyword
+    );
+
+    @Operation(
+            summary = "산 상세 정보 조회",
+            description = "산의 상세 정보를 조회합니다. 코스, 교통, 편의시설, 맛집, 리뷰 정보를 포함합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "산 상세 정보 조회 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "산을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    ResponseEntity<ApiResponse<MountainDetailResponse>> getMountainDetail(
+            @Parameter(description = "산 ID", required = true)
+            @PathVariable Long mountainId
+    );
+}

--- a/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainDetailResponse.java
+++ b/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainDetailResponse.java
@@ -1,0 +1,156 @@
+package com.semosan.api.domain.mountain.dto.response;
+
+import com.semosan.api.domain.mountain.entity.*;
+import com.semosan.api.domain.mountain.enums.AmenityType;
+import com.semosan.api.domain.mountain.enums.Difficulty;
+import com.semosan.api.domain.mountain.enums.TransportationType;
+import com.semosan.api.domain.review.entity.Review;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public record MountainDetailResponse(
+        MountainInfo mountain,
+        List<CourseInfo> courses,
+        TransportationGroup transportations,
+        Map<String, List<AmenityType>> amenities,
+        List<RestaurantSectionInfo> restaurantSections,
+        List<ReviewInfo> reviews
+) {
+
+    public record MountainInfo(
+            Long mountainId,
+            String name,
+            String address,
+            Double altitude,
+            Difficulty difficulty,
+            Integer duration,
+            String imageUrl
+    ) {
+        public static MountainInfo from(Mountain mountain) {
+            return new MountainInfo(
+                    mountain.getId(),
+                    mountain.getName(),
+                    mountain.getAddress(),
+                    mountain.getAltitude(),
+                    mountain.getDifficulty(),
+                    mountain.getDuration(),
+                    mountain.getImageUrl()
+            );
+        }
+    }
+
+    public record CourseInfo(
+            Long courseId,
+            String name,
+            Difficulty difficulty,
+            Double distance,
+            Integer duration
+    ) {
+        public static CourseInfo from(Course course) {
+            return new CourseInfo(
+                    course.getId(),
+                    course.getName(),
+                    course.getDifficulty(),
+                    course.getDistance(),
+                    course.getDuration()
+            );
+        }
+    }
+
+    public record TransportationGroup(
+            Map<String, List<TransportationItem>> publicTransport,
+            Map<String, List<TransportationItem>> parking
+    ) {
+        public static TransportationGroup from(List<Transportation> transportations) {
+            Map<String, List<TransportationItem>> publicTransport = transportations.stream()
+                    .filter(t -> t.getType() == TransportationType.SUBWAY || t.getType() == TransportationType.BUS)
+                    .collect(Collectors.groupingBy(
+                            Transportation::getDirection,
+                            Collectors.mapping(TransportationItem::from, Collectors.toList())
+                    ));
+            Map<String, List<TransportationItem>> parking = transportations.stream()
+                    .filter(t -> t.getType() == TransportationType.PARKING)
+                    .collect(Collectors.groupingBy(
+                            Transportation::getDirection,
+                            Collectors.mapping(TransportationItem::from, Collectors.toList())
+                    ));
+            return new TransportationGroup(publicTransport, parking);
+        }
+    }
+
+    public record TransportationItem(
+            Long transportationId,
+            TransportationType type,
+            String name,
+            String description
+    ) {
+        public static TransportationItem from(Transportation transportation) {
+            return new TransportationItem(
+                    transportation.getId(),
+                    transportation.getType(),
+                    transportation.getName(),
+                    transportation.getDescription()
+            );
+        }
+    }
+
+    public static Map<String, List<AmenityType>> groupAmenities(List<Amenity> amenities) {
+        return amenities.stream()
+                .collect(Collectors.groupingBy(
+                        Amenity::getDirection,
+                        Collectors.mapping(Amenity::getType, Collectors.toList())
+                ));
+    }
+
+    public record RestaurantSectionInfo(
+            String title,
+            List<RestaurantInfo> restaurants
+    ) {
+        public static RestaurantSectionInfo from(RestaurantSection section) {
+            return new RestaurantSectionInfo(
+                    section.getTitle(),
+                    section.getRestaurants().stream()
+                            .map(RestaurantInfo::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record RestaurantInfo(
+            Long restaurantId,
+            String name,
+            String category,
+            String imageUrl
+    ) {
+        public static RestaurantInfo from(Restaurant restaurant) {
+            return new RestaurantInfo(
+                    restaurant.getId(),
+                    restaurant.getName(),
+                    restaurant.getCategory(),
+                    restaurant.getImageUrl()
+            );
+        }
+    }
+
+    public record ReviewInfo(
+            Long reviewId,
+            String imageUrl,
+            String authorName,
+            String content,
+            Difficulty difficulty,
+            String courseName
+    ) {
+        public static ReviewInfo from(Review review) {
+            return new ReviewInfo(
+                    review.getId(),
+                    review.getImageUrl(),
+                    review.getUser().getName(),
+                    review.getContent(),
+                    review.getDifficulty(),
+                    review.getCourse() != null ? review.getCourse().getName() : null
+            );
+        }
+    }
+}

--- a/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainListResponse.java
+++ b/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainListResponse.java
@@ -1,0 +1,31 @@
+package com.semosan.api.domain.mountain.dto.response;
+
+import com.semosan.api.domain.mountain.entity.Mountain;
+import com.semosan.api.domain.mountain.enums.Difficulty;
+
+public record MountainListResponse(
+        Long mountainId,
+        String name,
+        String address,
+        Double altitude,
+        Difficulty difficulty,
+        Integer duration,
+        String imageUrl,
+        Double latitude,
+        Double longitude
+) {
+
+    public static MountainListResponse from(Mountain mountain) {
+        return new MountainListResponse(
+                mountain.getId(),
+                mountain.getName(),
+                mountain.getAddress(),
+                mountain.getAltitude(),
+                mountain.getDifficulty(),
+                mountain.getDuration(),
+                mountain.getImageUrl(),
+                mountain.getLatitude(),
+                mountain.getLongitude()
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/mountain/entity/Amenity.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/Amenity.java
@@ -1,0 +1,30 @@
+package com.semosan.api.domain.mountain.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.mountain.enums.AmenityType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "amenities")
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Amenity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mountain_id", nullable = false)
+    private Mountain mountain;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private AmenityType type;
+
+    @Column(name = "direction", nullable = false, length = 50)
+    private String direction;
+}

--- a/src/main/java/com/semosan/api/domain/mountain/entity/Course.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/Course.java
@@ -1,0 +1,36 @@
+package com.semosan.api.domain.mountain.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.mountain.enums.Difficulty;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "courses")
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Course extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mountain_id", nullable = false)
+    private Mountain mountain;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty", nullable = false, length = 20)
+    private Difficulty difficulty;
+
+    @Column(name = "distance", nullable = false)
+    private Double distance;
+
+    @Column(name = "duration", nullable = false)
+    private Integer duration;
+}

--- a/src/main/java/com/semosan/api/domain/mountain/entity/Mountain.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/Mountain.java
@@ -1,0 +1,44 @@
+package com.semosan.api.domain.mountain.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.mountain.enums.Difficulty;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "mountains")
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Mountain extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "address", nullable = false, length = 255)
+    private String address;
+
+    @Column(name = "altitude", nullable = false)
+    private Double altitude;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty", nullable = false, length = 20)
+    private Difficulty difficulty;
+
+    @Column(name = "duration")
+    private Integer duration;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
+}

--- a/src/main/java/com/semosan/api/domain/mountain/entity/Restaurant.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/Restaurant.java
@@ -1,0 +1,31 @@
+package com.semosan.api.domain.mountain.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "restaurants")
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Restaurant extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "section_id", nullable = false)
+    private RestaurantSection section;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "category", length = 50)
+    private String category;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+}

--- a/src/main/java/com/semosan/api/domain/mountain/entity/RestaurantSection.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/RestaurantSection.java
@@ -1,0 +1,32 @@
+package com.semosan.api.domain.mountain.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Table(name = "restaurant_sections")
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RestaurantSection extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mountain_id", nullable = false)
+    private Mountain mountain;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @OneToMany(mappedBy = "section", fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<Restaurant> restaurants = new ArrayList<>();
+}

--- a/src/main/java/com/semosan/api/domain/mountain/entity/Transportation.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/Transportation.java
@@ -1,0 +1,36 @@
+package com.semosan.api.domain.mountain.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.mountain.enums.TransportationType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "transportations")
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Transportation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mountain_id", nullable = false)
+    private Mountain mountain;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private TransportationType type;
+
+    @Column(name = "direction", nullable = false, length = 50)
+    private String direction;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "description", length = 500)
+    private String description;
+}

--- a/src/main/java/com/semosan/api/domain/mountain/enums/AmenityType.java
+++ b/src/main/java/com/semosan/api/domain/mountain/enums/AmenityType.java
@@ -1,0 +1,5 @@
+package com.semosan.api.domain.mountain.enums;
+
+public enum AmenityType {
+    RESTROOM, INFORMATION, SHELTER, PARKING, STORE
+}

--- a/src/main/java/com/semosan/api/domain/mountain/enums/Difficulty.java
+++ b/src/main/java/com/semosan/api/domain/mountain/enums/Difficulty.java
@@ -1,0 +1,5 @@
+package com.semosan.api.domain.mountain.enums;
+
+public enum Difficulty {
+    EASY, NORMAL, HARD
+}

--- a/src/main/java/com/semosan/api/domain/mountain/enums/TransportationType.java
+++ b/src/main/java/com/semosan/api/domain/mountain/enums/TransportationType.java
@@ -1,0 +1,5 @@
+package com.semosan.api.domain.mountain.enums;
+
+public enum TransportationType {
+    SUBWAY, BUS, PARKING
+}

--- a/src/main/java/com/semosan/api/domain/mountain/repository/AmenityRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/AmenityRepository.java
@@ -1,0 +1,11 @@
+package com.semosan.api.domain.mountain.repository;
+
+import com.semosan.api.domain.mountain.entity.Amenity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AmenityRepository extends JpaRepository<Amenity, Long> {
+
+    List<Amenity> findByMountainId(Long mountainId);
+}

--- a/src/main/java/com/semosan/api/domain/mountain/repository/CourseRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/CourseRepository.java
@@ -1,0 +1,11 @@
+package com.semosan.api.domain.mountain.repository;
+
+import com.semosan.api.domain.mountain.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+
+    List<Course> findByMountainId(Long mountainId);
+}

--- a/src/main/java/com/semosan/api/domain/mountain/repository/MountainRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/MountainRepository.java
@@ -1,0 +1,14 @@
+package com.semosan.api.domain.mountain.repository;
+
+import com.semosan.api.domain.mountain.entity.Mountain;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MountainRepository extends JpaRepository<Mountain, Long> {
+
+    @Query("SELECT m FROM Mountain m WHERE m.name LIKE CONCAT('%', :keyword, '%') OR m.address LIKE CONCAT('%', :keyword, '%')")
+    List<Mountain> searchByKeyword(@Param("keyword") String keyword);
+}

--- a/src/main/java/com/semosan/api/domain/mountain/repository/RestaurantRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/RestaurantRepository.java
@@ -1,0 +1,7 @@
+package com.semosan.api.domain.mountain.repository;
+
+import com.semosan.api.domain.mountain.entity.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+}

--- a/src/main/java/com/semosan/api/domain/mountain/repository/RestaurantSectionRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/RestaurantSectionRepository.java
@@ -1,0 +1,14 @@
+package com.semosan.api.domain.mountain.repository;
+
+import com.semosan.api.domain.mountain.entity.RestaurantSection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface RestaurantSectionRepository extends JpaRepository<RestaurantSection, Long> {
+
+    @Query("SELECT DISTINCT s FROM RestaurantSection s LEFT JOIN FETCH s.restaurants WHERE s.mountain.id = :mountainId")
+    List<RestaurantSection> findByMountainIdWithRestaurants(@Param("mountainId") Long mountainId);
+}

--- a/src/main/java/com/semosan/api/domain/mountain/repository/TransportationRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/TransportationRepository.java
@@ -1,0 +1,11 @@
+package com.semosan.api.domain.mountain.repository;
+
+import com.semosan.api.domain.mountain.entity.Transportation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TransportationRepository extends JpaRepository<Transportation, Long> {
+
+    List<Transportation> findByMountainId(Long mountainId);
+}

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
@@ -1,0 +1,89 @@
+package com.semosan.api.domain.mountain.service;
+
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.mountain.dto.response.MountainDetailResponse;
+import com.semosan.api.domain.mountain.dto.response.MountainDetailResponse.*;
+import com.semosan.api.domain.mountain.dto.response.MountainListResponse;
+import com.semosan.api.domain.mountain.entity.Mountain;
+import com.semosan.api.domain.mountain.enums.AmenityType;
+import com.semosan.api.domain.mountain.repository.*;
+import com.semosan.api.domain.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MountainService {
+
+    private final MountainRepository mountainRepository;
+    private final CourseRepository courseRepository;
+    private final TransportationRepository transportationRepository;
+    private final AmenityRepository amenityRepository;
+    private final RestaurantSectionRepository restaurantSectionRepository;
+    private final ReviewService reviewService;
+
+    public List<MountainListResponse> getMountains() {
+        return mountainRepository.findAll().stream()
+                .map(MountainListResponse::from)
+                .toList();
+    }
+
+    public List<MountainListResponse> searchMountains(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            throw new GeneralException(ErrorStatus.BAD_REQUEST);
+        }
+        return mountainRepository.searchByKeyword(keyword.trim()).stream()
+                .map(MountainListResponse::from)
+                .toList();
+    }
+
+    public MountainDetailResponse getMountainDetail(Long mountainId) {
+        Mountain mountain = findMountainById(mountainId);
+
+        return new MountainDetailResponse(
+                MountainInfo.from(mountain),
+                findCourses(mountainId),
+                findTransportationGroup(mountainId),
+                findAmenitiesByDirection(mountainId),
+                findRestaurantSections(mountainId),
+                findReviews(mountainId)
+        );
+    }
+
+    private Mountain findMountainById(Long mountainId) {
+        return mountainRepository.findById(mountainId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MOUNTAIN_NOT_FOUND));
+    }
+
+    private List<CourseInfo> findCourses(Long mountainId) {
+        return courseRepository.findByMountainId(mountainId).stream()
+                .map(CourseInfo::from)
+                .toList();
+    }
+
+    private TransportationGroup findTransportationGroup(Long mountainId) {
+        return TransportationGroup.from(transportationRepository.findByMountainId(mountainId));
+    }
+
+    private Map<String, List<AmenityType>> findAmenitiesByDirection(Long mountainId) {
+        return MountainDetailResponse.groupAmenities(amenityRepository.findByMountainId(mountainId));
+    }
+
+    private List<RestaurantSectionInfo> findRestaurantSections(Long mountainId) {
+        return restaurantSectionRepository.findByMountainIdWithRestaurants(mountainId).stream()
+                .map(RestaurantSectionInfo::from)
+                .toList();
+    }
+
+    private List<ReviewInfo> findReviews(Long mountainId) {
+        return reviewService.getReviewsByMountainId(mountainId).stream()
+                .map(ReviewInfo::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/semosan/api/domain/review/entity/Review.java
+++ b/src/main/java/com/semosan/api/domain/review/entity/Review.java
@@ -1,0 +1,44 @@
+package com.semosan.api.domain.review.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.mountain.entity.Course;
+import com.semosan.api.domain.mountain.entity.Mountain;
+import com.semosan.api.domain.mountain.enums.Difficulty;
+import com.semosan.api.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "reviews")
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mountain_id", nullable = false)
+    private Mountain mountain;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id")
+    private Course course;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty", nullable = false, length = 20)
+    private Difficulty difficulty;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+}

--- a/src/main/java/com/semosan/api/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/semosan/api/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,16 @@
+package com.semosan.api.domain.review.repository;
+
+import com.semosan.api.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    @EntityGraph(attributePaths = {"user", "course"})
+    @Query("SELECT r FROM Review r WHERE r.mountain.id = :mountainId ORDER BY r.createdAt DESC LIMIT :limit")
+    List<Review> findRecentByMountainId(@Param("mountainId") Long mountainId, @Param("limit") int limit);
+}

--- a/src/main/java/com/semosan/api/domain/review/service/ReviewService.java
+++ b/src/main/java/com/semosan/api/domain/review/service/ReviewService.java
@@ -1,0 +1,23 @@
+package com.semosan.api.domain.review.service;
+
+import com.semosan.api.domain.review.entity.Review;
+import com.semosan.api.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private static final int DEFAULT_REVIEW_LIMIT = 20;
+
+    private final ReviewRepository reviewRepository;
+
+    public List<Review> getReviewsByMountainId(Long mountainId) {
+        return reviewRepository.findRecentByMountainId(mountainId, DEFAULT_REVIEW_LIMIT);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,3 +4,31 @@ spring:
 
   profiles:
     default: local
+
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}
+  refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION}
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  admin-key: ${KAKAO_ADMIN_KEY}
+
+test:
+  secret-key: ${TEST_SECRET_KEY}


### PR DESCRIPTION
 ## 🧾 요약                                                                   
  - 산 목록 조회, 키워드 검색(이름/주소), 상세 조회 API 구현                    
  - 상세 조회 시 코스, 교통, 편의시설, 맛집, 리뷰를 방면 기준으로 그룹핑하여 프론트엔드 파싱
  친화적으로 응답합니다.                                                        
                                                                                                      
  ## 🔗 이슈                            
  - close #13                                                                                         
                                                                                                      
  ## ✨ 변경 내용                                                                                      
                                                                                                      
  ### 도메인                                                                               
  - `Mountain`, `Course`, `Transportation`, `Amenity`, `RestaurantSection`, `Restaurant` 엔티티 추가
  - `Review` 엔티티 추가 (커뮤니티 연결 전까지 산 상세 조회용으로만 사용)      
  - `Difficulty`, `TransportationType`, `AmenityType` 열거형 추가               
                                                                                
  ### API                               
  - `GET /api/mountains` — 산 목록 조회                                                               
  - `GET /api/mountains/search?keyword=` — 산 이름/주소 키워드 검색                                   
  - `GET /api/mountains/{mountainId}` — 산 상세 조회                                                  
                                                                                                      
  ### 응답 구조                                                                            
  - 교통: `publicTransport` / `parking`을 방면별로 그룹핑 (`Map<String, List<TransportationItem>>`)
  - 편의시설: 방면별 편의시설 타입 리스트 (`Map<String, List<AmenityType>>`)                          
  - 맛집: 섹션(제목) → 맛집 리스트 구조                                                               
  - 리뷰: `@EntityGraph`로 N+1 방지, 최대 20개 제한                                                   
                                                                                                      
  ### 응답 코드                                                                                       
  - `MOUNTAIN_200_1` / `MOUNTAIN_200_2` / `MOUNTAIN_200_3` — 성공                                     
  - `MOUNTAIN_404_1` — 산 없음                                                                        
  - `BAD_REQUEST` — 검색 키워드 누락                                                                  
                                                                                                      
  ### 설정                                                                                            
  - `application.yaml` 데이터소스, JWT, 카카오, MinIO 환경변수 설정 추가                              
                                                                               
  ## ✅ 확인    
  - [x] 빌드 OK                                                                            
  - [x] 테스트 OK                                                                                     
                                                                                                      
  ## 📝 참고                             
  - 이미지 업로드(MinIO/Presigned URL) 관련 코드는 별도 커밋 예정                                     
  - 리뷰 작성 API는 커뮤니티 기능 연결 시 구현 예정                                                   
  - 위도/경도 필드 추가됨 (추후 가까운 순 정렬용) 