### PR TITLE
[Feat] 산 목록 paging 설정 및 Swagger 명세 정비

### DIFF
--- a/src/main/java/com/semosan/api/common/response/PageResponse.java
+++ b/src/main/java/com/semosan/api/common/response/PageResponse.java
@@ -1,0 +1,25 @@
+package com.semosan.api.common.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean last
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isLast()
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
@@ -1,13 +1,13 @@
 package com.semosan.api.domain.mountain.controller;
 
 import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.response.PageResponse;
 import com.semosan.api.common.status.SuccessStatus;
 import com.semosan.api.domain.mountain.controller.docs.MountainControllerDocs;
 import com.semosan.api.domain.mountain.dto.response.MountainDetailResponse;
 import com.semosan.api.domain.mountain.dto.response.MountainListResponse;
 import com.semosan.api.domain.mountain.service.MountainService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -22,20 +22,20 @@ public class MountainController implements MountainControllerDocs {
 
     @GetMapping
     @Override
-    public ResponseEntity<ApiResponse<Page<MountainListResponse>>> getMountains(
-            @PageableDefault(size = 10) Pageable pageable
+    public ResponseEntity<ApiResponse<PageResponse<MountainListResponse>>> getMountains(
+            @PageableDefault(size = 10, sort = "name") Pageable pageable
     ) {
-        Page<MountainListResponse> response = mountainService.getMountains(pageable);
+        PageResponse<MountainListResponse> response = PageResponse.from(mountainService.getMountains(pageable));
         return ApiResponse.success(SuccessStatus.MOUNTAIN_LIST_SUCCESS, response);
     }
 
     @GetMapping("/search")
     @Override
-    public ResponseEntity<ApiResponse<Page<MountainListResponse>>> searchMountains(
+    public ResponseEntity<ApiResponse<PageResponse<MountainListResponse>>> searchMountains(
             @RequestParam String keyword,
             @PageableDefault(size = 10) Pageable pageable
     ) {
-        Page<MountainListResponse> response = mountainService.searchMountains(keyword, pageable);
+        PageResponse<MountainListResponse> response = PageResponse.from(mountainService.searchMountains(keyword, pageable));
         return ApiResponse.success(SuccessStatus.MOUNTAIN_SEARCH_SUCCESS, response);
     }
 

--- a/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
@@ -1,6 +1,7 @@
 package com.semosan.api.domain.mountain.controller.docs;
 
 import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.response.PageResponse;
 import com.semosan.api.domain.mountain.dto.response.MountainDetailResponse;
 import com.semosan.api.domain.mountain.dto.response.MountainListResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,7 +10,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +29,7 @@ public interface MountainControllerDocs {
                     description = "산 목록 조회 성공"
             )
     })
-    ResponseEntity<ApiResponse<Page<MountainListResponse>>> getMountains(
+    ResponseEntity<ApiResponse<PageResponse<MountainListResponse>>> getMountains(
             @PageableDefault(size = 10) Pageable pageable
     );
 
@@ -43,7 +43,7 @@ public interface MountainControllerDocs {
                     description = "산 검색 성공"
             )
     })
-    ResponseEntity<ApiResponse<Page<MountainListResponse>>> searchMountains(
+    ResponseEntity<ApiResponse<PageResponse<MountainListResponse>>> searchMountains(
             @Parameter(description = "검색 키워드 (산 이름 또는 주소)", required = true)
             @RequestParam String keyword,
             @PageableDefault(size = 10) Pageable pageable

--- a/src/main/java/com/semosan/api/domain/notification/controller/FcmTokenController.java
+++ b/src/main/java/com/semosan/api/domain/notification/controller/FcmTokenController.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.notification.controller;
 
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.notification.controller.docs.FcmTokenControllerDocs;
 import com.semosan.api.domain.notification.dto.FcmTokenDeleteRequest;
 import com.semosan.api.domain.notification.dto.FcmTokenRegisterRequest;
 import com.semosan.api.domain.notification.service.FcmTokenService;
@@ -18,11 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/fcm")
 @RequiredArgsConstructor
-public class FcmTokenController {
+public class FcmTokenController implements FcmTokenControllerDocs {
 
     private final FcmTokenService fcmTokenService;
 
     @PostMapping("/tokens")
+    @Override
     public ResponseEntity<ApiResponse<Void>> register(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody FcmTokenRegisterRequest request
@@ -32,6 +34,7 @@ public class FcmTokenController {
     }
 
     @DeleteMapping("/tokens")
+    @Override
     public ResponseEntity<ApiResponse<Void>> delete(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody FcmTokenDeleteRequest request

--- a/src/main/java/com/semosan/api/domain/notification/controller/NotificationTestController.java
+++ b/src/main/java/com/semosan/api/domain/notification/controller/NotificationTestController.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.notification.controller;
 
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.notification.controller.docs.NotificationTestControllerDocs;
 import com.semosan.api.domain.notification.dto.NotificationTestRequest;
 import com.semosan.api.domain.notification.service.NotificationService;
 import jakarta.validation.Valid;
@@ -13,18 +14,16 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 알림 테스트용 컨트롤러. local 프로필에서만 활성화 (운영 배포 시 자동 비활성화).
- */
 @Profile("local")
 @RestController
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
-public class NotificationTestController {
+public class NotificationTestController implements NotificationTestControllerDocs {
 
     private final NotificationService notificationService;
 
     @PostMapping("/test")
+    @Override
     public ResponseEntity<ApiResponse<Void>> send(
             @Valid @RequestBody NotificationTestRequest request
     ) {

--- a/src/main/java/com/semosan/api/domain/notification/controller/docs/FcmTokenControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/notification/controller/docs/FcmTokenControllerDocs.java
@@ -1,0 +1,34 @@
+package com.semosan.api.domain.notification.controller.docs;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.domain.notification.dto.FcmTokenDeleteRequest;
+import com.semosan.api.domain.notification.dto.FcmTokenRegisterRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "FCM Token", description = "FCM 토큰 관리 API")
+public interface FcmTokenControllerDocs {
+
+    @Operation(summary = "FCM 토큰 등록", description = "클라이언트 FCM 토큰을 등록합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "FCM 토큰 등록 성공")
+    })
+    ResponseEntity<ApiResponse<Void>> register(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody FcmTokenRegisterRequest request
+    );
+
+    @Operation(summary = "FCM 토큰 삭제", description = "로그아웃 시 FCM 토큰을 삭제합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "FCM 토큰 삭제 성공")
+    })
+    ResponseEntity<ApiResponse<Void>> delete(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody FcmTokenDeleteRequest request
+    );
+}

--- a/src/main/java/com/semosan/api/domain/notification/controller/docs/NotificationTestControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/notification/controller/docs/NotificationTestControllerDocs.java
@@ -1,0 +1,22 @@
+package com.semosan.api.domain.notification.controller.docs;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.domain.notification.dto.NotificationTestRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Notification Test", description = "알림 테스트 API (local 전용)")
+public interface NotificationTestControllerDocs {
+
+    @Operation(summary = "테스트 알림 발송", description = "지정한 유저에게 테스트 알림을 발송합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 발송 성공")
+    })
+    ResponseEntity<ApiResponse<Void>> send(
+            @Valid @RequestBody NotificationTestRequest request
+    );
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,3 +34,8 @@ test:
   secret-key: ${TEST_SECRET_KEY}
 firebase:
   service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH:firebase/semosan-b2593-firebase-adminsdk-fbsvc-0d55d3b4e9.json}
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  default-flat-param-object: true


### PR DESCRIPTION
## 🧾 요약                                                                                          
  - 산 목록/검색 API에 페이징 적용 및 응답 구조 개선, Swagger 명세 정비                               
                                              
## 🔗 이슈                                                                                          
- close #15                                                                                         
                                                                                                    
## ✨ 변경 내용
- 산 목록/검색 API에 Pageable 적용 (`@PageableDefault(size = 10)`)                                  
- PageResponse 커스텀 응답 추가 (Spring Page의 불필요한 필드 제거)                    
- FCM/알림 컨트롤러 Swagger Docs 인터페이스 추가
- Swagger 설정 수정 (`application.yaml`)    
                                                                                                    
## ✅ 확인                            
- [x] 빌드 OK                                                                                       
- [x] 테스트 OK  