### PR TITLE
[Feat] 산 관련 기능 추가

### DIFF
--- a/src/main/java/com/semosan/api/common/status/ErrorStatus.java
+++ b/src/main/java/com/semosan/api/common/status/ErrorStatus.java
@@ -66,6 +66,7 @@ public enum ErrorStatus implements BaseStatus {
      * Mountain
      */
     MOUNTAIN_NOT_FOUND(HttpStatus.NOT_FOUND, "MTN_404_1", "산을 찾을 수 없습니다."),
+    MOUNTAIN_LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "MTN_409_1", "이미 좋아요한 산입니다."),
 
     /**
      * Image

--- a/src/main/java/com/semosan/api/common/status/ErrorStatus.java
+++ b/src/main/java/com/semosan/api/common/status/ErrorStatus.java
@@ -67,6 +67,7 @@ public enum ErrorStatus implements BaseStatus {
      */
     MOUNTAIN_NOT_FOUND(HttpStatus.NOT_FOUND, "MTN_404_1", "산을 찾을 수 없습니다."),
     MOUNTAIN_LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "MTN_409_1", "이미 좋아요한 산입니다."),
+    MOUNTAIN_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "MTN_404_2", "좋아요한 산이 아닙니다."),
 
     /**
      * Image

--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -28,6 +28,7 @@ public enum SuccessStatus implements BaseStatus {
     MOUNTAIN_LIST_SUCCESS(HttpStatus.OK, "MTN_200_1", "산 목록 조회에 성공했습니다."),
     MOUNTAIN_SEARCH_SUCCESS(HttpStatus.OK, "MTN_200_2", "산 검색에 성공했습니다."),
     MOUNTAIN_DETAIL_SUCCESS(HttpStatus.OK, "MTN_200_3", "산 상세 정보 조회에 성공했습니다."),
+    MOUNTAIN_LIKE_SUCCESS(HttpStatus.OK, "MTN_200_4", "산 좋아요 등록에 성공했습니다."),
 
     /**
      * Image

--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -30,6 +30,7 @@ public enum SuccessStatus implements BaseStatus {
     MOUNTAIN_DETAIL_SUCCESS(HttpStatus.OK, "MTN_200_3", "산 상세 정보 조회에 성공했습니다."),
     MOUNTAIN_LIKE_SUCCESS(HttpStatus.OK, "MTN_200_4", "산 좋아요 등록에 성공했습니다."),
     MOUNTAIN_UNLIKE_SUCCESS(HttpStatus.OK, "MTN_200_5", "산 좋아요 취소에 성공했습니다."),
+    LIKED_MOUNTAIN_LIST_SUCCESS(HttpStatus.OK, "MTN_200_6", "좋아요한 산 목록 조회에 성공했습니다."),
 
     /**
      * Image

--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -29,6 +29,7 @@ public enum SuccessStatus implements BaseStatus {
     MOUNTAIN_SEARCH_SUCCESS(HttpStatus.OK, "MTN_200_2", "산 검색에 성공했습니다."),
     MOUNTAIN_DETAIL_SUCCESS(HttpStatus.OK, "MTN_200_3", "산 상세 정보 조회에 성공했습니다."),
     MOUNTAIN_LIKE_SUCCESS(HttpStatus.OK, "MTN_200_4", "산 좋아요 등록에 성공했습니다."),
+    MOUNTAIN_UNLIKE_SUCCESS(HttpStatus.OK, "MTN_200_5", "산 좋아요 취소에 성공했습니다."),
 
     /**
      * Image

--- a/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import com.semosan.api.domain.auth.dto.request.LoginRequest;
 import com.semosan.api.domain.auth.dto.response.LoginResponse;
 import com.semosan.api.domain.auth.dto.response.ReissueResponse;
 import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.service.UserReader;
 import com.semosan.api.domain.user.service.UserService;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import java.security.MessageDigest;
 public class AuthService {
 
     private final UserService userService;
+    private final UserReader userReader;
     private final JwtService jwtService;
 
     @Value("${test.secret-key}")
@@ -47,7 +49,7 @@ public class AuthService {
         Claims claims = jwtService.validateRefreshTokenSignature(refreshToken);
         Long userId = Long.parseLong(claims.getSubject());
 
-        User user = userService.findActiveUserById(userId);
+        User user = userReader.findActiveUserById(userId);
         jwtService.validateRefreshToken(refreshToken, userId);
 
         TokenIssuance tokens = jwtService.issueTokens(user);
@@ -63,7 +65,7 @@ public class AuthService {
     public void withdraw(Long userId, String accessToken) {
         jwtService.blacklistAccessToken(accessToken);
         jwtService.deleteRefreshToken(userId);
-        User user = userService.findActiveUserById(userId);
+        User user = userReader.findActiveUserById(userId);
         user.withdraw();
     }
 

--- a/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
@@ -6,11 +6,13 @@ import com.semosan.api.common.status.SuccessStatus;
 import com.semosan.api.domain.mountain.controller.docs.MountainControllerDocs;
 import com.semosan.api.domain.mountain.dto.response.MountainDetailResponse;
 import com.semosan.api.domain.mountain.dto.response.MountainListResponse;
+import com.semosan.api.domain.mountain.service.MountainLikeService;
 import com.semosan.api.domain.mountain.service.MountainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 public class MountainController implements MountainControllerDocs {
 
     private final MountainService mountainService;
+    private final MountainLikeService mountainLikeService;
 
     @GetMapping
     @Override
@@ -46,5 +49,15 @@ public class MountainController implements MountainControllerDocs {
     ) {
         MountainDetailResponse response = mountainService.getMountainDetail(mountainId);
         return ApiResponse.success(SuccessStatus.MOUNTAIN_DETAIL_SUCCESS, response);
+    }
+
+    @PostMapping("/{mountainId}/like")
+    @Override
+    public ResponseEntity<ApiResponse<Void>> likeMountain(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long mountainId
+    ) {
+        mountainLikeService.likeMountain(userId, mountainId);
+        return ApiResponse.success(SuccessStatus.MOUNTAIN_LIKE_SUCCESS);
     }
 }

--- a/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
@@ -4,6 +4,7 @@ import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.response.PageResponse;
 import com.semosan.api.common.status.SuccessStatus;
 import com.semosan.api.domain.mountain.controller.docs.MountainControllerDocs;
+import com.semosan.api.domain.mountain.dto.response.LikedMountainResponse;
 import com.semosan.api.domain.mountain.dto.response.MountainDetailResponse;
 import com.semosan.api.domain.mountain.dto.response.MountainListResponse;
 import com.semosan.api.domain.mountain.service.MountainLikeService;
@@ -40,6 +41,16 @@ public class MountainController implements MountainControllerDocs {
     ) {
         PageResponse<MountainListResponse> response = PageResponse.from(mountainService.searchMountains(keyword, pageable));
         return ApiResponse.success(SuccessStatus.MOUNTAIN_SEARCH_SUCCESS, response);
+    }
+
+    @GetMapping("/likes")
+    @Override
+    public ResponseEntity<ApiResponse<PageResponse<LikedMountainResponse>>> getLikedMountains(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        PageResponse<LikedMountainResponse> response = PageResponse.from(mountainLikeService.getLikedMountains(userId, pageable));
+        return ApiResponse.success(SuccessStatus.LIKED_MOUNTAIN_LIST_SUCCESS, response);
     }
 
     @GetMapping("/{mountainId}")

--- a/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
@@ -60,4 +60,14 @@ public class MountainController implements MountainControllerDocs {
         mountainLikeService.likeMountain(userId, mountainId);
         return ApiResponse.success(SuccessStatus.MOUNTAIN_LIKE_SUCCESS);
     }
+
+    @DeleteMapping("/{mountainId}/like")
+    @Override
+    public ResponseEntity<ApiResponse<Void>> unlikeMountain(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long mountainId
+    ) {
+        mountainLikeService.unlikeMountain(userId, mountainId);
+        return ApiResponse.success(SuccessStatus.MOUNTAIN_UNLIKE_SUCCESS);
+    }
 }

--- a/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.mountain.controller.docs;
 
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.response.PageResponse;
+import com.semosan.api.domain.mountain.dto.response.LikedMountainResponse;
 import com.semosan.api.domain.mountain.dto.response.MountainDetailResponse;
 import com.semosan.api.domain.mountain.dto.response.MountainListResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -47,6 +48,21 @@ public interface MountainControllerDocs {
     ResponseEntity<ApiResponse<PageResponse<MountainListResponse>>> searchMountains(
             @Parameter(description = "검색 키워드 (산 이름 또는 주소)", required = true)
             @RequestParam String keyword,
+            @PageableDefault(size = 10) Pageable pageable
+    );
+
+    @Operation(
+            summary = "좋아요한 산 목록 조회",
+            description = "로그인한 사용자가 좋아요한 산 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "좋아요한 산 목록 조회 성공"
+            )
+    })
+    ResponseEntity<ApiResponse<PageResponse<LikedMountainResponse>>> getLikedMountains(
+            @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 10) Pageable pageable
     );
 

--- a/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
@@ -90,4 +90,25 @@ public interface MountainControllerDocs {
             @Parameter(description = "산 ID", required = true)
             @PathVariable Long mountainId
     );
+
+    @Operation(
+            summary = "산 좋아요 취소",
+            description = "로그인한 사용자가 산 좋아요를 취소합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "산 좋아요 취소 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "좋아요한 산이 아니거나 산을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    ResponseEntity<ApiResponse<Void>> unlikeMountain(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "산 ID", required = true)
+            @PathVariable Long mountainId
+    );
 }

--- a/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -65,6 +66,27 @@ public interface MountainControllerDocs {
             )
     })
     ResponseEntity<ApiResponse<MountainDetailResponse>> getMountainDetail(
+            @Parameter(description = "산 ID", required = true)
+            @PathVariable Long mountainId
+    );
+
+    @Operation(
+            summary = "산 좋아요 등록",
+            description = "로그인한 사용자가 산에 좋아요를 등록합니다. 이미 좋아요한 산이면 성공 처리합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "산 좋아요 등록 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "산을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    ResponseEntity<ApiResponse<Void>> likeMountain(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "산 ID", required = true)
             @PathVariable Long mountainId
     );

--- a/src/main/java/com/semosan/api/domain/mountain/dto/response/LikedMountainResponse.java
+++ b/src/main/java/com/semosan/api/domain/mountain/dto/response/LikedMountainResponse.java
@@ -1,0 +1,27 @@
+package com.semosan.api.domain.mountain.dto.response;
+
+import com.semosan.api.domain.mountain.entity.Mountain;
+import com.semosan.api.domain.mountain.entity.MountainLike;
+import com.semosan.api.domain.mountain.enums.Difficulty;
+
+public record LikedMountainResponse(
+        Long mountainId,
+        String name,
+        String address,
+        Double altitude,
+        Difficulty difficulty,
+        String imageUrl
+) {
+    // 좋아요한 산 정보로 응답 DTO를 생성합니다.
+    public static LikedMountainResponse from(MountainLike mountainLike) {
+        Mountain mountain = mountainLike.getMountain();
+        return new LikedMountainResponse(
+                mountain.getId(),
+                mountain.getName(),
+                mountain.getAddress(),
+                mountain.getAltitude(),
+                mountain.getDifficulty(),
+                mountain.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/mountain/entity/MountainLike.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/MountainLike.java
@@ -1,0 +1,59 @@
+package com.semosan.api.domain.mountain.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(
+        name = "mountain_likes",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_mountain_likes_user_id_mountain_id",
+                        columnNames = {"user_id", "mountain_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_mountain_likes_user_id_created_at", columnList = "user_id, created_at DESC")
+        }
+)
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MountainLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mountain_id", nullable = false)
+    private Mountain mountain;
+
+    // 사용자와 산 정보로 MountainLike 엔티티를 생성합니다.
+    public static MountainLike create(User user, Mountain mountain) {
+        return MountainLike.builder()
+                .user(user)
+                .mountain(mountain)
+                .build();
+    }
+}

--- a/src/main/java/com/semosan/api/domain/mountain/repository/MountainLikeRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/MountainLikeRepository.java
@@ -1,0 +1,9 @@
+package com.semosan.api.domain.mountain.repository;
+
+import com.semosan.api.domain.mountain.entity.MountainLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MountainLikeRepository extends JpaRepository<MountainLike, Long> {
+
+    boolean existsByUser_IdAndMountain_Id(Long userId, Long mountainId);
+}

--- a/src/main/java/com/semosan/api/domain/mountain/repository/MountainLikeRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/MountainLikeRepository.java
@@ -3,7 +3,11 @@ package com.semosan.api.domain.mountain.repository;
 import com.semosan.api.domain.mountain.entity.MountainLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MountainLikeRepository extends JpaRepository<MountainLike, Long> {
 
     boolean existsByUser_IdAndMountain_Id(Long userId, Long mountainId);
+
+    Optional<MountainLike> findByUser_IdAndMountain_Id(Long userId, Long mountainId);
 }

--- a/src/main/java/com/semosan/api/domain/mountain/repository/MountainLikeRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/MountainLikeRepository.java
@@ -1,7 +1,12 @@
 package com.semosan.api.domain.mountain.repository;
 
 import com.semosan.api.domain.mountain.entity.MountainLike;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,4 +15,11 @@ public interface MountainLikeRepository extends JpaRepository<MountainLike, Long
     boolean existsByUser_IdAndMountain_Id(Long userId, Long mountainId);
 
     Optional<MountainLike> findByUser_IdAndMountain_Id(Long userId, Long mountainId);
+
+    @EntityGraph(attributePaths = "mountain")
+    @Query(
+            value = "SELECT ml FROM MountainLike ml WHERE ml.user.id = :userId",
+            countQuery = "SELECT COUNT(ml) FROM MountainLike ml WHERE ml.user.id = :userId"
+    )
+    Page<MountainLike> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
@@ -8,7 +8,7 @@ import com.semosan.api.domain.mountain.entity.MountainLike;
 import com.semosan.api.domain.mountain.repository.MountainLikeRepository;
 import com.semosan.api.domain.mountain.repository.MountainRepository;
 import com.semosan.api.domain.user.entity.User;
-import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -22,12 +22,12 @@ public class MountainLikeService {
 
     private final MountainLikeRepository mountainLikeRepository;
     private final MountainRepository mountainRepository;
-    private final UserRepository userRepository;
+    private final UserReader userReader;
 
     // 로그인한 사용자가 산에 좋아요를 등록합니다.
     @Transactional
     public void likeMountain(Long userId, Long mountainId) {
-        User user = findActiveUserById(userId);
+        User user = userReader.findActiveUserById(userId);
         Mountain mountain = findMountainById(mountainId);
         if (mountainLikeRepository.existsByUser_IdAndMountain_Id(userId, mountainId)) {
             throw new GeneralException(ErrorStatus.MOUNTAIN_LIKE_ALREADY_EXISTS);
@@ -44,7 +44,7 @@ public class MountainLikeService {
     @Transactional
     public void unlikeMountain(Long userId, Long mountainId) {
         // 탈퇴 후 남은 access token으로 조회되는 것을 방지합니다.
-        findActiveUserById(userId);
+        userReader.findActiveUserById(userId);
         MountainLike mountainLike = mountainLikeRepository.findByUser_IdAndMountain_Id(userId, mountainId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MOUNTAIN_LIKE_NOT_FOUND));
         mountainLikeRepository.delete(mountainLike);
@@ -54,15 +54,9 @@ public class MountainLikeService {
     @Transactional(readOnly = true)
     public Page<LikedMountainResponse> getLikedMountains(Long userId, Pageable pageable) {
         // 탈퇴 후 남은 access token으로 조회되는 것을 방지합니다.
-        findActiveUserById(userId);
+        userReader.findActiveUserById(userId);
         return mountainLikeRepository.findAllByUserId(userId, pageable)
                 .map(LikedMountainResponse::from);
-    }
-
-    // userId로 삭제되지 않은 유저를 조회하고, 없으면 예외를 발생시킵니다.
-    private User findActiveUserById(Long userId) {
-        return userRepository.findByIdAndDeletedFalse(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 
     // mountainId로 산을 조회하고, 없으면 예외를 발생시킵니다.

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.mountain.service;
 
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.mountain.dto.response.LikedMountainResponse;
 import com.semosan.api.domain.mountain.entity.Mountain;
 import com.semosan.api.domain.mountain.entity.MountainLike;
 import com.semosan.api.domain.mountain.repository.MountainLikeRepository;
@@ -10,6 +11,8 @@ import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,10 +43,20 @@ public class MountainLikeService {
     // 로그인한 사용자가 산 좋아요를 취소합니다.
     @Transactional
     public void unlikeMountain(Long userId, Long mountainId) {
+        // 탈퇴 후 남은 access token으로 조회되는 것을 방지합니다.
         findActiveUserById(userId);
         MountainLike mountainLike = mountainLikeRepository.findByUser_IdAndMountain_Id(userId, mountainId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MOUNTAIN_LIKE_NOT_FOUND));
         mountainLikeRepository.delete(mountainLike);
+    }
+
+    // 로그인한 사용자가 좋아요한 산 목록을 조회합니다.
+    @Transactional(readOnly = true)
+    public Page<LikedMountainResponse> getLikedMountains(Long userId, Pageable pageable) {
+        // 탈퇴 후 남은 access token으로 조회되는 것을 방지합니다.
+        findActiveUserById(userId);
+        return mountainLikeRepository.findAllByUserId(userId, pageable)
+                .map(LikedMountainResponse::from);
     }
 
     // userId로 삭제되지 않은 유저를 조회하고, 없으면 예외를 발생시킵니다.

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
@@ -1,0 +1,51 @@
+package com.semosan.api.domain.mountain.service;
+
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.mountain.entity.Mountain;
+import com.semosan.api.domain.mountain.entity.MountainLike;
+import com.semosan.api.domain.mountain.repository.MountainLikeRepository;
+import com.semosan.api.domain.mountain.repository.MountainRepository;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MountainLikeService {
+
+    private final MountainLikeRepository mountainLikeRepository;
+    private final MountainRepository mountainRepository;
+    private final UserRepository userRepository;
+
+    // 로그인한 사용자가 산에 좋아요를 등록합니다.
+    @Transactional
+    public void likeMountain(Long userId, Long mountainId) {
+        User user = findActiveUserById(userId);
+        Mountain mountain = findMountainById(mountainId);
+        if (mountainLikeRepository.existsByUser_IdAndMountain_Id(userId, mountainId)) {
+            throw new GeneralException(ErrorStatus.MOUNTAIN_LIKE_ALREADY_EXISTS);
+        }
+
+        try {
+            mountainLikeRepository.save(MountainLike.create(user, mountain));
+        } catch (DataIntegrityViolationException e) {
+            throw new GeneralException(ErrorStatus.MOUNTAIN_LIKE_ALREADY_EXISTS);
+        }
+    }
+
+    // userId로 삭제되지 않은 유저를 조회하고, 없으면 예외를 발생시킵니다.
+    private User findActiveUserById(Long userId) {
+        return userRepository.findByIdAndDeletedFalse(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    // mountainId로 산을 조회하고, 없으면 예외를 발생시킵니다.
+    private Mountain findMountainById(Long mountainId) {
+        return mountainRepository.findById(mountainId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MOUNTAIN_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
@@ -37,6 +37,15 @@ public class MountainLikeService {
         }
     }
 
+    // 로그인한 사용자가 산 좋아요를 취소합니다.
+    @Transactional
+    public void unlikeMountain(Long userId, Long mountainId) {
+        findActiveUserById(userId);
+        MountainLike mountainLike = mountainLikeRepository.findByUser_IdAndMountain_Id(userId, mountainId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MOUNTAIN_LIKE_NOT_FOUND));
+        mountainLikeRepository.delete(mountainLike);
+    }
+
     // userId로 삭제되지 않은 유저를 조회하고, 없으면 예외를 발생시킵니다.
     private User findActiveUserById(Long userId) {
         return userRepository.findByIdAndDeletedFalse(userId)

--- a/src/main/java/com/semosan/api/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/semosan/api/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByOauthIdAndOauthProvider(String oauthId, OAuthProvider oauthProvider);
 
+    Optional<User> findByIdAndDeletedFalse(Long id);
+
 }

--- a/src/main/java/com/semosan/api/domain/user/service/UserService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserService.java
@@ -57,12 +57,6 @@ public class UserService {
                 ));
     }
 
-    // userId로 삭제되지 않은 유저를 조회하고, 없으면 예외를 발생시킵니다.
-    @Transactional(readOnly = true)
-    public User findActiveUserById(Long userId) {
-        return userReader.findActiveUserById(userId);
-    }
-
     // 테스트 유저 조회 후 없으면 신규 생성
     @Transactional
     public User findOrCreateTestUser(String testUserId, DeviceType deviceType) {
@@ -81,7 +75,7 @@ public class UserService {
     // 닉네임 사용 가능 여부를 조회합니다.
     @Transactional(readOnly = true)
     public void checkNickname(Long userId, String nickname) {
-        findActiveUserById(userId);
+        userReader.findActiveUserById(userId);
         nicknamePolicy.validate(nickname);
     }
 
@@ -90,7 +84,7 @@ public class UserService {
     public void updateUserProfile(Long userId, UpdateUserProfileRequest request) {
         validateProfileUpdateRequest(request);
         validateNicknameIfPresent(request.nickname());
-        User user = findActiveUserById(userId);
+        User user = userReader.findActiveUserById(userId);
         user.updateProfile(toUpdateUserProfileCommand(request));
         updateUserOnboardingProfile(userId, request);
     }


### PR DESCRIPTION
## 🧾 요약
- 산 좋아요 등록, 취소, 좋아요한 산 목록 조회 API를 추가

## 🔗 이슈
- close #26 

## ✨ 변경 내용
- `POST /api/mountains/{mountainId}/like` 산 좋아요 등록 API 추가
- `DELETE /api/mountains/{mountainId}/like` 산 좋아요 취소 API 추가
- `GET /api/mountains/likes` 내가 좋아요한 산 목록 조회 API 추가
- `MountainLike` 엔티티 및 Repository 추가
- 중복 좋아요 등록 시 `409 Conflict` 응답 처리
- 좋아요하지 않은 산 취소 시 `404 Not Found` 응답 처리
- 좋아요한 산 목록 조회 시 `@EntityGraph`와 명시적 `countQuery`로 산 정보 함께 조회

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK
<img width="1409" height="883" alt="image" src="https://github.com/user-attachments/assets/7405995c-929e-4f74-9eeb-f28f55640a96" />
<img width="1409" height="883" alt="image" src="https://github.com/user-attachments/assets/dfc133c6-2fae-4bba-891e-65e39edbcd76" />
<img width="1409" height="865" alt="image" src="https://github.com/user-attachments/assets/0a0aecdb-d1b7-4bb9-b270-d4a50422293f" />
<img width="1409" height="865" alt="image" src="https://github.com/user-attachments/assets/fbbe6bb6-85cb-4a21-a784-484f8f18d89d" />
<img width="1409" height="916" alt="image" src="https://github.com/user-attachments/assets/ed3ec8a3-7f11-4cd8-8060-0f2d19b9c788" />
