### PR TITLE
[Feat] 로그아웃 기능 추가

### DIFF
--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -16,6 +16,7 @@ public enum SuccessStatus implements BaseStatus {
      */
     LOGIN_SUCCESS(HttpStatus.OK, "AUTH_200_1", "로그인에 성공했습니다."),
     REISSUE_SUCCESS(HttpStatus.OK, "AUTH_200_2", "토큰 재발급에 성공했습니다."),
+    LOGOUT_SUCCESS(HttpStatus.OK, "AUTH_200_3", "로그아웃에 성공했습니다."),
 
     /**
      * User

--- a/src/main/java/com/semosan/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/semosan/api/domain/auth/controller/AuthController.java
@@ -46,6 +46,15 @@ public class AuthController implements AuthControllerDocs {
         return ApiResponse.success(SuccessStatus.REISSUE_SUCCESS, response);
     }
 
+    @PostMapping("/logout")
+    @Override
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal Long userId
+    ) {
+        authService.logout(userId);
+        return ApiResponse.success(SuccessStatus.LOGOUT_SUCCESS);
+    }
+
     @DeleteMapping("/withdraw")
     @Override
     public ResponseEntity<ApiResponse<Void>> withdraw(

--- a/src/main/java/com/semosan/api/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/auth/controller/docs/AuthControllerDocs.java
@@ -66,6 +66,25 @@ public interface AuthControllerDocs {
     );
 
     @Operation(
+            summary = "로그아웃",
+            description = "로그인한 사용자의 리프레시 토큰을 무효화합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그아웃 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal Long userId
+    );
+
+    @Operation(
             summary = "회원 탈퇴",
             description = "회원을 탈퇴 처리합니다. soft delete 방식으로 처리되며 동일 소셜 계정으로 재가입이 가능합니다."
     )

--- a/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
@@ -51,7 +51,7 @@ public class AuthService {
         Claims claims = jwtService.validateRefreshTokenSignature(refreshToken);
         Long userId = Long.parseLong(claims.getSubject());
 
-        User user = userService.findById(userId);
+        User user = userService.findActiveUserById(userId);
 
         if (user.getRefreshToken() == null)
             throw new GeneralException(ErrorStatus.REFRESH_TOKEN_NOT_FOUND);
@@ -64,8 +64,15 @@ public class AuthService {
     // 유저 조회 후 soft delete 및 리프레시 토큰 무효화
     @Transactional
     public void withdraw(Long userId) {
-        User user = userService.findById(userId);
+        User user = userService.findActiveUserById(userId);
         user.withdraw();
+    }
+
+    // 유저 조회 후 리프레시 토큰 무효화
+    @Transactional
+    public void logout(Long userId) {
+        User user = userService.findActiveUserById(userId);
+        user.logout();
     }
 
 }

--- a/src/main/java/com/semosan/api/domain/user/entity/User.java
+++ b/src/main/java/com/semosan/api/domain/user/entity/User.java
@@ -133,6 +133,11 @@ public class User extends BaseEntity {
         this.refreshToken = null;
     }
 
+    // 로그아웃 처리
+    public void logout() {
+        this.refreshToken = null;
+    }
+
     // 리프레시 토큰 업데이트
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;

--- a/src/main/java/com/semosan/api/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/semosan/api/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByOauthIdAndOauthProvider(String oauthId, OAuthProvider oauthProvider);
 
+    Optional<User> findByIdAndDeletedFalse(Long id);
+
 }

--- a/src/main/java/com/semosan/api/domain/user/service/UserService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserService.java
@@ -53,6 +53,13 @@ public class UserService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 
+    // userId로 삭제되지 않은 유저를 조회하고, 없으면 예외를 발생시킵니다.
+    @Transactional(readOnly = true)
+    public User findActiveUserById(Long userId) {
+        return userRepository.findByIdAndDeletedFalse(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+
     // 테스트 유저 조회 후 없으면 신규 생성
     @Transactional
     public User findOrCreateTestUser(String testUserId, DeviceType deviceType) {


### PR DESCRIPTION
## 🧾 요약
- 로그아웃 API를 추가하고, 인증 관련 유저 조회 시 탈퇴 유저가 처리되지 않도록 수정

## 🔗 이슈
- close #27 

## ✨ 변경 내용
- `POST /api/auth/logout` 로그아웃 API 추가
- 로그아웃 시 사용자 refresh token 무효화 처리
- `User.logout()` 메서드 추가
- `LOGOUT_SUCCESS` 성공 상태 코드 추가
- `UserRepository.findByIdAndDeletedFalse()` 추가
- `UserService.findActiveUserById()` 추가
- 토큰 재발급, 회원 탈퇴, 로그아웃에서 활성 유저만 조회하도록 수정

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK
<img width="1406" height="640" alt="image" src="https://github.com/user-attachments/assets/9c1b2589-8be3-4baa-9272-7639f3d979f7" />
