### PR TITLE
[Feat] 등산 기록 관련 기능 추가

### DIFF
--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -32,8 +32,9 @@ public enum SuccessStatus implements BaseStatus {
     /**
      * Hiking Record
      */
-    GET_HIKING_RECORD_LIST_SUCCESS(HttpStatus.OK, "HIKING_200_1", "내가 다녀온 산 목록 조회에 성공했습니다."),
+    GET_HIKING_RECORD_MOUNTAIN_LIST_SUCCESS(HttpStatus.OK, "HIKING_200_1", "내가 다녀온 산 목록 조회에 성공했습니다."),
     GET_HIKING_RECORD_SUMMARY_SUCCESS(HttpStatus.OK, "HIKING_200_2", "나의 등산 기록 요약 조회에 성공했습니다."),
+    GET_HIKING_RECORD_LIST_SUCCESS(HttpStatus.OK, "HIKING_200_3", "나의 등산 기록 목록 조회에 성공했습니다."),
 
     /**
      * Image

--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -30,6 +30,11 @@ public enum SuccessStatus implements BaseStatus {
     MOUNTAIN_DETAIL_SUCCESS(HttpStatus.OK, "MTN_200_3", "산 상세 정보 조회에 성공했습니다."),
 
     /**
+     * Hiking Record
+     */
+    GET_HIKING_RECORD_LIST_SUCCESS(HttpStatus.OK, "HIKING_200_1", "내가 다녀온 산 목록 조회에 성공했습니다."),
+
+    /**
      * Image
      */
     PRESIGNED_URL_SUCCESS(HttpStatus.OK, "IMG_200_1", "Presigned URL 발급에 성공했습니다."),

--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -33,6 +33,7 @@ public enum SuccessStatus implements BaseStatus {
      * Hiking Record
      */
     GET_HIKING_RECORD_LIST_SUCCESS(HttpStatus.OK, "HIKING_200_1", "내가 다녀온 산 목록 조회에 성공했습니다."),
+    GET_HIKING_RECORD_SUMMARY_SUCCESS(HttpStatus.OK, "HIKING_200_2", "나의 등산 기록 요약 조회에 성공했습니다."),
 
     /**
      * Image

--- a/src/main/java/com/semosan/api/domain/hiking/controller/HikingRecordController.java
+++ b/src/main/java/com/semosan/api/domain/hiking/controller/HikingRecordController.java
@@ -1,0 +1,35 @@
+package com.semosan.api.domain.hiking.controller;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.response.PageResponse;
+import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.hiking.controller.docs.HikingRecordControllerDocs;
+import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordResponse;
+import com.semosan.api.domain.hiking.service.HikingRecordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/hiking-records")
+@RequiredArgsConstructor
+public class HikingRecordController implements HikingRecordControllerDocs {
+
+    private final HikingRecordService hikingRecordService;
+
+    // 내가 다녀온 산 목록을 조회합니다.
+    @GetMapping("/me/mountains")
+    @Override
+    public ResponseEntity<ApiResponse<PageResponse<GetUserHikingRecordResponse>>> getUserHikingRecords(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        PageResponse<GetUserHikingRecordResponse> response = PageResponse.from(hikingRecordService.getUserHikingRecords(userId, pageable));
+        return ApiResponse.success(SuccessStatus.GET_HIKING_RECORD_LIST_SUCCESS, response);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/hiking/controller/HikingRecordController.java
+++ b/src/main/java/com/semosan/api/domain/hiking/controller/HikingRecordController.java
@@ -5,6 +5,7 @@ import com.semosan.api.common.response.PageResponse;
 import com.semosan.api.common.status.SuccessStatus;
 import com.semosan.api.domain.hiking.controller.docs.HikingRecordControllerDocs;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordResponse;
+import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordSummaryResponse;
 import com.semosan.api.domain.hiking.service.HikingRecordService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -31,5 +32,15 @@ public class HikingRecordController implements HikingRecordControllerDocs {
     ) {
         PageResponse<GetUserHikingRecordResponse> response = PageResponse.from(hikingRecordService.getUserHikingRecords(userId, pageable));
         return ApiResponse.success(SuccessStatus.GET_HIKING_RECORD_LIST_SUCCESS, response);
+    }
+
+    // 나의 등산 기록 요약 정보를 조회합니다.
+    @GetMapping("/me/summary")
+    @Override
+    public ResponseEntity<ApiResponse<GetUserHikingRecordSummaryResponse>> getUserHikingRecordSummary(
+            @AuthenticationPrincipal Long userId
+    ) {
+        GetUserHikingRecordSummaryResponse response = hikingRecordService.getUserHikingRecordSummary(userId);
+        return ApiResponse.success(SuccessStatus.GET_HIKING_RECORD_SUMMARY_SUCCESS, response);
     }
 }

--- a/src/main/java/com/semosan/api/domain/hiking/controller/HikingRecordController.java
+++ b/src/main/java/com/semosan/api/domain/hiking/controller/HikingRecordController.java
@@ -5,6 +5,7 @@ import com.semosan.api.common.response.PageResponse;
 import com.semosan.api.common.status.SuccessStatus;
 import com.semosan.api.domain.hiking.controller.docs.HikingRecordControllerDocs;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordResponse;
+import com.semosan.api.domain.hiking.dto.response.GetUserHikingMountainRecordResponse;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordSummaryResponse;
 import com.semosan.api.domain.hiking.service.HikingRecordService;
 import lombok.RequiredArgsConstructor;
@@ -23,8 +24,8 @@ public class HikingRecordController implements HikingRecordControllerDocs {
 
     private final HikingRecordService hikingRecordService;
 
-    // 내가 다녀온 산 목록을 조회합니다.
-    @GetMapping("/me/mountains")
+    // 나의 등산 기록 목록을 조회합니다.
+    @GetMapping("/me")
     @Override
     public ResponseEntity<ApiResponse<PageResponse<GetUserHikingRecordResponse>>> getUserHikingRecords(
             @AuthenticationPrincipal Long userId,
@@ -32,6 +33,17 @@ public class HikingRecordController implements HikingRecordControllerDocs {
     ) {
         PageResponse<GetUserHikingRecordResponse> response = PageResponse.from(hikingRecordService.getUserHikingRecords(userId, pageable));
         return ApiResponse.success(SuccessStatus.GET_HIKING_RECORD_LIST_SUCCESS, response);
+    }
+
+    // 내가 다녀온 산 목록을 조회합니다.
+    @GetMapping("/me/mountains")
+    @Override
+    public ResponseEntity<ApiResponse<PageResponse<GetUserHikingMountainRecordResponse>>> getUserHikingMountainRecords(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        PageResponse<GetUserHikingMountainRecordResponse> response = PageResponse.from(hikingRecordService.getUserHikingMountainRecords(userId, pageable));
+        return ApiResponse.success(SuccessStatus.GET_HIKING_RECORD_MOUNTAIN_LIST_SUCCESS, response);
     }
 
     // 나의 등산 기록 요약 정보를 조회합니다.

--- a/src/main/java/com/semosan/api/domain/hiking/controller/docs/HikingRecordControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/hiking/controller/docs/HikingRecordControllerDocs.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.hiking.controller.docs;
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.response.PageResponse;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordResponse;
+import com.semosan.api.domain.hiking.dto.response.GetUserHikingMountainRecordResponse;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,6 +18,22 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 public interface HikingRecordControllerDocs {
 
     @Operation(
+            summary = "나의 등산 기록 목록 조회",
+            description = "사용자가 참여한 등산 기록을 기록 단위로 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "나의 등산 기록 목록 조회 성공"
+            )
+    })
+    ResponseEntity<ApiResponse<PageResponse<GetUserHikingRecordResponse>>> getUserHikingRecords(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 10) Pageable pageable
+    );
+
+    @Operation(
             summary = "내가 다녀온 산 목록 조회",
             description = "사용자가 등산 기록을 남긴 산 목록을 산 단위로 묶어 조회합니다."
     )
@@ -26,7 +43,7 @@ public interface HikingRecordControllerDocs {
                     description = "내가 다녀온 산 목록 조회 성공"
             )
     })
-    ResponseEntity<ApiResponse<PageResponse<GetUserHikingRecordResponse>>> getUserHikingRecords(
+    ResponseEntity<ApiResponse<PageResponse<GetUserHikingMountainRecordResponse>>> getUserHikingMountainRecords(
             @Parameter(hidden = true)
             @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 10) Pageable pageable

--- a/src/main/java/com/semosan/api/domain/hiking/controller/docs/HikingRecordControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/hiking/controller/docs/HikingRecordControllerDocs.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.hiking.controller.docs;
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.response.PageResponse;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordResponse;
+import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -29,5 +30,20 @@ public interface HikingRecordControllerDocs {
             @Parameter(hidden = true)
             @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 10) Pageable pageable
+    );
+
+    @Operation(
+            summary = "나의 등산 기록 요약 조회",
+            description = "마이페이지에서 사용하는 누적 등산 횟수, 정복한 산 수, 누적 등산 고도를 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "나의 등산 기록 요약 조회 성공"
+            )
+    })
+    ResponseEntity<ApiResponse<GetUserHikingRecordSummaryResponse>> getUserHikingRecordSummary(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long userId
     );
 }

--- a/src/main/java/com/semosan/api/domain/hiking/controller/docs/HikingRecordControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/hiking/controller/docs/HikingRecordControllerDocs.java
@@ -1,0 +1,33 @@
+package com.semosan.api.domain.hiking.controller.docs;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.response.PageResponse;
+import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "Hiking Record", description = "등산 기록 관련 API")
+public interface HikingRecordControllerDocs {
+
+    @Operation(
+            summary = "내가 다녀온 산 목록 조회",
+            description = "사용자가 등산 기록을 남긴 산 목록을 산 단위로 묶어 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "내가 다녀온 산 목록 조회 성공"
+            )
+    })
+    ResponseEntity<ApiResponse<PageResponse<GetUserHikingRecordResponse>>> getUserHikingRecords(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 10) Pageable pageable
+    );
+}

--- a/src/main/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingMountainRecordResponse.java
+++ b/src/main/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingMountainRecordResponse.java
@@ -1,0 +1,25 @@
+package com.semosan.api.domain.hiking.dto.response;
+
+import com.semosan.api.domain.hiking.repository.projection.UserHikingMountainRecordProjection;
+
+import java.time.LocalDate;
+
+public record GetUserHikingMountainRecordResponse(
+        Long mountainId,
+        String mountainName,
+        String imageUrl,
+        Long hikingCount,
+        LocalDate lastHikedAt
+) {
+
+    // 조회 projection을 API 응답 DTO로 변환합니다.
+    public static GetUserHikingMountainRecordResponse from(UserHikingMountainRecordProjection projection) {
+        return new GetUserHikingMountainRecordResponse(
+                projection.getMountainId(),
+                projection.getMountainName(),
+                projection.getImageUrl(),
+                projection.getHikingCount(),
+                projection.getLastHikedAt().toLocalDate()
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingRecordResponse.java
+++ b/src/main/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingRecordResponse.java
@@ -5,21 +5,29 @@ import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordProje
 import java.time.LocalDate;
 
 public record GetUserHikingRecordResponse(
+        Long hikingRecordId,
         Long mountainId,
         String mountainName,
+        Long courseId,
+        String courseName,
         String imageUrl,
-        Long hikingCount,
-        LocalDate lastHikedAt
+        Double distance,
+        Integer duration,
+        LocalDate hikedAt
 ) {
 
-    // 조회 projection을 API 응답 DTO로 변환합니다.
+    // 조회 projection을 나의 등산 기록 상세 응답 DTO로 변환합니다.
     public static GetUserHikingRecordResponse from(UserHikingRecordProjection projection) {
         return new GetUserHikingRecordResponse(
+                projection.getHikingRecordId(),
                 projection.getMountainId(),
                 projection.getMountainName(),
+                projection.getCourseId(),
+                projection.getCourseName(),
                 projection.getImageUrl(),
-                projection.getHikingCount(),
-                projection.getLastHikedAt().toLocalDate()
+                projection.getDistance(),
+                projection.getDuration(),
+                projection.getHikedAt().toLocalDate()
         );
     }
 }

--- a/src/main/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingRecordResponse.java
+++ b/src/main/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingRecordResponse.java
@@ -1,0 +1,25 @@
+package com.semosan.api.domain.hiking.dto.response;
+
+import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordProjection;
+
+import java.time.LocalDate;
+
+public record GetUserHikingRecordResponse(
+        Long mountainId,
+        String mountainName,
+        String imageUrl,
+        Long hikingCount,
+        LocalDate lastHikedAt
+) {
+
+    // 조회 projection을 API 응답 DTO로 변환합니다.
+    public static GetUserHikingRecordResponse from(UserHikingRecordProjection projection) {
+        return new GetUserHikingRecordResponse(
+                projection.getMountainId(),
+                projection.getMountainName(),
+                projection.getImageUrl(),
+                projection.getHikingCount(),
+                projection.getLastHikedAt().toLocalDate()
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingRecordSummaryResponse.java
+++ b/src/main/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingRecordSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.semosan.api.domain.hiking.dto.response;
+
+import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordSummaryProjection;
+
+public record GetUserHikingRecordSummaryResponse(
+        Long totalHikingCount,
+        Long conqueredMountainCount,
+        Double totalAltitude
+) {
+
+    // 조회 projection을 등산 기록 요약 응답 DTO로 변환합니다.
+    public static GetUserHikingRecordSummaryResponse from(UserHikingRecordSummaryProjection projection) {
+        return new GetUserHikingRecordSummaryResponse(
+                projection.getTotalHikingCount(),
+                projection.getConqueredMountainCount(),
+                projection.getTotalAltitude()
+        );
+    }
+
+    // 등산 기록이 없는 유저의 빈 요약 응답을 생성합니다.
+    public static GetUserHikingRecordSummaryResponse empty() {
+        return new GetUserHikingRecordSummaryResponse(0L, 0L, 0.0);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/hiking/entity/HikingMember.java
+++ b/src/main/java/com/semosan/api/domain/hiking/entity/HikingMember.java
@@ -1,0 +1,44 @@
+package com.semosan.api.domain.hiking.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(
+        name = "hiking_members",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_hiking_member_record_user",
+                        columnNames = {"hiking_record_id", "user_id"}
+                )
+        },
+        indexes = @Index(name = "idx_hiking_member_user_id", columnList = "user_id")
+)
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HikingMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hiking_record_id", nullable = false)
+    private HikingRecord hikingRecord;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 등산 기록에 참여한 유저를 생성합니다.
+    public static HikingMember create(HikingRecord hikingRecord, User user) {
+        return HikingMember.builder()
+                .hikingRecord(hikingRecord)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/semosan/api/domain/hiking/entity/HikingRecord.java
+++ b/src/main/java/com/semosan/api/domain/hiking/entity/HikingRecord.java
@@ -1,0 +1,67 @@
+package com.semosan.api.domain.hiking.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.mountain.entity.Course;
+import com.semosan.api.domain.mountain.entity.Mountain;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "hiking_records")
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HikingRecord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mountain_id", nullable = false)
+    private Mountain mountain;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    /** 실제 소요 시간 (초) */
+    @Column(name = "duration", nullable = false)
+    private Integer duration;
+
+    /** 등산 중 도달한 최고 고도 (m) */
+    @Column(name = "max_altitude", nullable = false)
+    private Double altitude;
+
+    /** 소모 칼로리 (kcal) */
+    @Column(name = "calories", nullable = false)
+    private Integer calories;
+
+    @Column(name = "clive_image_url", length = 500)
+    private String cliveImageUrl;
+
+    @Column(name = "photo_report_image_url", length = 500)
+    private String photoReportImageUrl;
+
+    // 등산 기록을 생성합니다.
+    public static HikingRecord create(
+            Mountain mountain,
+            Course course,
+            Integer duration,
+            Double altitude,
+            Integer calories,
+            String cliveImageUrl,
+            String photoReportImageUrl
+    ) {
+        return HikingRecord.builder()
+                .mountain(mountain)
+                .course(course)
+                .duration(duration)
+                .altitude(altitude)
+                .calories(calories)
+                .cliveImageUrl(cliveImageUrl)
+                .photoReportImageUrl(photoReportImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.hiking.repository;
 
 import com.semosan.api.domain.hiking.entity.HikingRecord;
 import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordProjection;
+import com.semosan.api.domain.hiking.repository.projection.UserHikingMountainRecordProjection;
 import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordSummaryProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,10 +25,42 @@ public interface HikingRecordRepository extends JpaRepository<HikingRecord, Long
                     JOIN mountains m ON m.id = hr.mountain_id
                     WHERE hm.user_id = :userId
                     GROUP BY hr.mountain_id, m.name, m.image_url
-                    ORDER BY lastHikedAt DESC
+                    ORDER BY MAX(hr.created_at) DESC, hr.mountain_id DESC
                     """,
             countQuery = """
                     SELECT COUNT(DISTINCT hr.mountain_id)
+                    FROM hiking_records hr
+                    JOIN hiking_members hm ON hm.hiking_record_id = hr.id
+                    WHERE hm.user_id = :userId
+                    """,
+            nativeQuery = true
+    )
+    Page<UserHikingMountainRecordProjection> findUserHikingMountainRecordsByUserId(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
+
+    @Query(
+            value = """
+                    SELECT
+                        hr.id AS hikingRecordId,
+                        m.id AS mountainId,
+                        m.name AS mountainName,
+                        c.id AS courseId,
+                        c.name AS courseName,
+                        COALESCE(hr.photo_report_image_url, hr.clive_image_url, m.image_url) AS imageUrl,
+                        c.distance AS distance,
+                        hr.duration AS duration,
+                        hr.created_at AS hikedAt
+                    FROM hiking_records hr
+                    JOIN hiking_members hm ON hm.hiking_record_id = hr.id
+                    JOIN mountains m ON m.id = hr.mountain_id
+                    JOIN courses c ON c.id = hr.course_id
+                    WHERE hm.user_id = :userId
+                    ORDER BY hr.created_at DESC, hr.id DESC
+            """,
+            countQuery = """
+                    SELECT COUNT(DISTINCT hr.id)
                     FROM hiking_records hr
                     JOIN hiking_members hm ON hm.hiking_record_id = hr.id
                     WHERE hm.user_id = :userId

--- a/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
@@ -1,0 +1,40 @@
+package com.semosan.api.domain.hiking.repository;
+
+import com.semosan.api.domain.hiking.entity.HikingRecord;
+import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordProjection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface HikingRecordRepository extends JpaRepository<HikingRecord, Long> {
+
+    @Query(
+            value = """
+                    SELECT
+                        hr.mountain_id AS mountainId,
+                        m.name AS mountainName,
+                        m.image_url AS imageUrl,
+                        COUNT(hr.id) AS hikingCount,
+                        MAX(hr.created_at) AS lastHikedAt
+                    FROM hiking_records hr
+                    JOIN hiking_members hm ON hm.hiking_record_id = hr.id
+                    JOIN mountains m ON m.id = hr.mountain_id
+                    WHERE hm.user_id = :userId
+                    GROUP BY hr.mountain_id, m.name, m.image_url
+                    ORDER BY lastHikedAt DESC
+                    """,
+            countQuery = """
+                    SELECT COUNT(DISTINCT hr.mountain_id)
+                    FROM hiking_records hr
+                    JOIN hiking_members hm ON hm.hiking_record_id = hr.id
+                    WHERE hm.user_id = :userId
+                    """,
+            nativeQuery = true
+    )
+    Page<UserHikingRecordProjection> findUserHikingRecordsByUserId(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.hiking.repository;
 
 import com.semosan.api.domain.hiking.entity.HikingRecord;
 import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordProjection;
+import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordSummaryProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -37,4 +38,18 @@ public interface HikingRecordRepository extends JpaRepository<HikingRecord, Long
             @Param("userId") Long userId,
             Pageable pageable
     );
+
+    @Query(
+            value = """
+                    SELECT
+                        COUNT(hm.id) AS totalHikingCount,
+                        COUNT(DISTINCT hr.mountain_id) AS conqueredMountainCount,
+                        COALESCE(SUM(hr.max_altitude), 0) AS totalAltitude
+                    FROM hiking_members hm
+                    JOIN hiking_records hr ON hm.hiking_record_id = hr.id
+                    WHERE hm.user_id = :userId
+                    """,
+            nativeQuery = true
+    )
+    UserHikingRecordSummaryProjection findUserHikingRecordSummaryByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/semosan/api/domain/hiking/repository/projection/UserHikingMountainRecordProjection.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/projection/UserHikingMountainRecordProjection.java
@@ -1,0 +1,16 @@
+package com.semosan.api.domain.hiking.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface UserHikingMountainRecordProjection {
+
+    Long getMountainId();
+
+    String getMountainName();
+
+    String getImageUrl();
+
+    Long getHikingCount();
+
+    LocalDateTime getLastHikedAt();
+}

--- a/src/main/java/com/semosan/api/domain/hiking/repository/projection/UserHikingRecordProjection.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/projection/UserHikingRecordProjection.java
@@ -1,0 +1,16 @@
+package com.semosan.api.domain.hiking.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface UserHikingRecordProjection {
+
+    Long getMountainId();
+
+    String getMountainName();
+
+    String getImageUrl();
+
+    Long getHikingCount();
+
+    LocalDateTime getLastHikedAt();
+}

--- a/src/main/java/com/semosan/api/domain/hiking/repository/projection/UserHikingRecordProjection.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/projection/UserHikingRecordProjection.java
@@ -4,13 +4,21 @@ import java.time.LocalDateTime;
 
 public interface UserHikingRecordProjection {
 
+    Long getHikingRecordId();
+
     Long getMountainId();
 
     String getMountainName();
 
+    Long getCourseId();
+
+    String getCourseName();
+
     String getImageUrl();
 
-    Long getHikingCount();
+    Double getDistance();
 
-    LocalDateTime getLastHikedAt();
+    Integer getDuration();
+
+    LocalDateTime getHikedAt();
 }

--- a/src/main/java/com/semosan/api/domain/hiking/repository/projection/UserHikingRecordSummaryProjection.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/projection/UserHikingRecordSummaryProjection.java
@@ -1,0 +1,10 @@
+package com.semosan.api.domain.hiking.repository.projection;
+
+public interface UserHikingRecordSummaryProjection {
+
+    Long getTotalHikingCount();
+
+    Long getConqueredMountainCount();
+
+    Double getTotalAltitude();
+}

--- a/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
+++ b/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
@@ -3,7 +3,9 @@ package com.semosan.api.domain.hiking.service;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordResponse;
+import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordSummaryResponse;
 import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
+import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordSummaryProjection;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,18 @@ public class HikingRecordService {
         findActiveUserById(userId);
         return hikingRecordRepository.findUserHikingRecordsByUserId(userId, pageable)
                 .map(GetUserHikingRecordResponse::from);
+    }
+
+    // 유저의 등산 기록 요약 정보를 조회합니다.
+    @Transactional(readOnly = true)
+    public GetUserHikingRecordSummaryResponse getUserHikingRecordSummary(Long userId) {
+        findActiveUserById(userId);
+        UserHikingRecordSummaryProjection projection =
+                hikingRecordRepository.findUserHikingRecordSummaryByUserId(userId);
+        if (projection == null) {
+            return GetUserHikingRecordSummaryResponse.empty();
+        }
+        return GetUserHikingRecordSummaryResponse.from(projection);
     }
 
     // 활성 상태의 유저를 조회합니다.

--- a/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
+++ b/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
@@ -1,14 +1,11 @@
 package com.semosan.api.domain.hiking.service;
 
-import com.semosan.api.common.exception.GeneralException;
-import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordResponse;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingMountainRecordResponse;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordSummaryResponse;
 import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
 import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordSummaryProjection;
-import com.semosan.api.domain.user.entity.User;
-import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,12 +17,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class HikingRecordService {
 
     private final HikingRecordRepository hikingRecordRepository;
-    private final UserRepository userRepository;
+    private final UserReader userReader;
 
     // 유저가 다녀온 산 목록을 산 단위로 묶어 조회합니다.
     @Transactional(readOnly = true)
     public Page<GetUserHikingMountainRecordResponse> getUserHikingMountainRecords(Long userId, Pageable pageable) {
-        findActiveUserById(userId);
+        userReader.findActiveUserById(userId);
         return hikingRecordRepository.findUserHikingMountainRecordsByUserId(userId, pageable)
                 .map(GetUserHikingMountainRecordResponse::from);
     }
@@ -33,7 +30,7 @@ public class HikingRecordService {
     // 유저의 등산 기록 목록을 기록 단위로 조회합니다.
     @Transactional(readOnly = true)
     public Page<GetUserHikingRecordResponse> getUserHikingRecords(Long userId, Pageable pageable) {
-        findActiveUserById(userId);
+        userReader.findActiveUserById(userId);
         return hikingRecordRepository.findUserHikingRecordsByUserId(userId, pageable)
                 .map(GetUserHikingRecordResponse::from);
     }
@@ -41,18 +38,12 @@ public class HikingRecordService {
     // 유저의 등산 기록 요약 정보를 조회합니다.
     @Transactional(readOnly = true)
     public GetUserHikingRecordSummaryResponse getUserHikingRecordSummary(Long userId) {
-        findActiveUserById(userId);
+        userReader.findActiveUserById(userId);
         UserHikingRecordSummaryProjection projection =
                 hikingRecordRepository.findUserHikingRecordSummaryByUserId(userId);
         if (projection == null) {
             return GetUserHikingRecordSummaryResponse.empty();
         }
         return GetUserHikingRecordSummaryResponse.from(projection);
-    }
-
-    // 활성 상태의 유저를 조회합니다.
-    private User findActiveUserById(Long userId) {
-        return userRepository.findByIdAndDeletedFalse(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
+++ b/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.hiking.service;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordResponse;
+import com.semosan.api.domain.hiking.dto.response.GetUserHikingMountainRecordResponse;
 import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordSummaryResponse;
 import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
 import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordSummaryProjection;
@@ -22,6 +23,14 @@ public class HikingRecordService {
     private final UserRepository userRepository;
 
     // 유저가 다녀온 산 목록을 산 단위로 묶어 조회합니다.
+    @Transactional(readOnly = true)
+    public Page<GetUserHikingMountainRecordResponse> getUserHikingMountainRecords(Long userId, Pageable pageable) {
+        findActiveUserById(userId);
+        return hikingRecordRepository.findUserHikingMountainRecordsByUserId(userId, pageable)
+                .map(GetUserHikingMountainRecordResponse::from);
+    }
+
+    // 유저의 등산 기록 목록을 기록 단위로 조회합니다.
     @Transactional(readOnly = true)
     public Page<GetUserHikingRecordResponse> getUserHikingRecords(Long userId, Pageable pageable) {
         findActiveUserById(userId);

--- a/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
+++ b/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
@@ -1,0 +1,35 @@
+package com.semosan.api.domain.hiking.service;
+
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.hiking.dto.response.GetUserHikingRecordResponse;
+import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HikingRecordService {
+
+    private final HikingRecordRepository hikingRecordRepository;
+    private final UserRepository userRepository;
+
+    // 유저가 다녀온 산 목록을 산 단위로 묶어 조회합니다.
+    @Transactional(readOnly = true)
+    public Page<GetUserHikingRecordResponse> getUserHikingRecords(Long userId, Pageable pageable) {
+        findActiveUserById(userId);
+        return hikingRecordRepository.findUserHikingRecordsByUserId(userId, pageable)
+                .map(GetUserHikingRecordResponse::from);
+    }
+
+    // 활성 상태의 유저를 조회합니다.
+    private User findActiveUserById(Long userId) {
+        return userRepository.findByIdAndDeletedFalse(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/semosan/api/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/semosan/api/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByOauthIdAndOauthProvider(String oauthId, OAuthProvider oauthProvider);
 
+    Optional<User> findByIdAndDeletedFalse(Long id);
+
 }


### PR DESCRIPTION
## 🧾 요약
- 나의 등산 기록 요약, 내가 다녀온 산 목록, 나의 등산 기록 목록 조회 API 추가

## 🔗 이슈
- close #24 

## ✨ 변경 내용
- `GET /api/hiking-records/me/summary` 나의 등산 기록 요약 조회 API 추가
- `GET /api/hiking-records/me/mountains` 내가 다녀온 산 목록 조회 API 추가
- `GET /api/hiking-records/me` 나의 등산 기록 목록 조회 API 추가
- `HikingRecord`, `HikingMember` 엔티티 추가
- 등산 기록 조회용 Response DTO 및 Projection 추가
- 등산 기록 집계/목록 조회를 위한 native query 추가
- `hiking_members.user_id` 단독 인덱스 추가

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK
<img width="1395" height="794" alt="image" src="https://github.com/user-attachments/assets/21657d0c-5a1d-49c8-b6f8-02f7f148efa8" />
<img width="1395" height="566" alt="image" src="https://github.com/user-attachments/assets/6594cd6f-1205-4a37-9cef-ef1dda5d6183" />
<img width="1395" height="794" alt="image" src="https://github.com/user-attachments/assets/4a5c5af6-1258-4e3d-908e-3dd7a631f28a" />