### PR TITLE
[Feat] 기록 공유 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,15 @@ k8s/postgres/secret.yaml
 # OMC
 .omc
 
+# Claude Code
+.claude/
+
 # Firebase
 src/main/resources/firebase/
 
 ## docs
 docs/**
+
+## Local data / scripts (산림청 수집 데이터, 수집 스크립트)
+data/
+scripts/

--- a/src/main/java/com/semosan/api/common/status/ErrorStatus.java
+++ b/src/main/java/com/semosan/api/common/status/ErrorStatus.java
@@ -76,7 +76,29 @@ public enum ErrorStatus implements BaseStatus {
      * Withdraw
      */
     KAKAO_UNLINK_FAILED(HttpStatus.BAD_GATEWAY, "KAKAO_502_3", "카카오 연동 해제에 실패했습니다."),
-    APPLE_REVOKE_FAILED(HttpStatus.BAD_GATEWAY, "APPLE_502_1", "애플 토큰 폐기에 실패했습니다.");
+    APPLE_REVOKE_FAILED(HttpStatus.BAD_GATEWAY, "APPLE_502_1", "애플 토큰 폐기에 실패했습니다."),
+
+    /**
+     * Hiking (등산 기록)
+     */
+    HIKING_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "HIKE_404_1", "등산 기록을 찾을 수 없습니다."),
+
+    /**
+     * Post (게시글 공통)
+     */
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_404_1", "게시글을 찾을 수 없습니다."),
+    POST_DELETED(HttpStatus.NOT_FOUND, "POST_404_2", "삭제된 게시글입니다."),
+    POST_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_403_1", "본인의 게시글만 처리할 수 있습니다."),
+    POST_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "POST_400_1", "본문은 비어있을 수 없습니다."),
+    POST_IMAGE_INDEX_INVALID(HttpStatus.BAD_REQUEST, "POST_400_2", "대표 이미지 인덱스가 잘못되었습니다."),
+
+    /**
+     * Comment (댓글/대댓글)
+     */
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CMT_404_1", "댓글을 찾을 수 없습니다."),
+    COMMENT_DELETED(HttpStatus.NOT_FOUND, "CMT_404_2", "삭제된 댓글입니다."),
+    COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "CMT_403_1", "본인의 댓글만 처리할 수 있습니다."),
+    COMMENT_PARENT_POST_MISMATCH(HttpStatus.BAD_REQUEST, "CMT_400_1", "부모 댓글이 같은 게시글의 댓글이 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/semosan/api/common/status/ErrorStatus.java
+++ b/src/main/java/com/semosan/api/common/status/ErrorStatus.java
@@ -76,7 +76,27 @@ public enum ErrorStatus implements BaseStatus {
      * Withdraw
      */
     KAKAO_UNLINK_FAILED(HttpStatus.BAD_GATEWAY, "KAKAO_502_3", "카카오 연동 해제에 실패했습니다."),
-    APPLE_REVOKE_FAILED(HttpStatus.BAD_GATEWAY, "APPLE_502_1", "애플 토큰 폐기에 실패했습니다.");
+    APPLE_REVOKE_FAILED(HttpStatus.BAD_GATEWAY, "APPLE_502_1", "애플 토큰 폐기에 실패했습니다."),
+
+    /**
+     * Hiking (등산 기록)
+     */
+    HIKING_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "HIKE_404_1", "등산 기록을 찾을 수 없습니다."),
+    HIKING_RECORD_FORBIDDEN(HttpStatus.FORBIDDEN, "HIKE_403_1", "본인이 참여한 등산 기록만 공유할 수 있습니다."),
+
+    /**
+     * Post (게시글 공통)
+     */
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_404_1", "게시글을 찾을 수 없습니다."),
+    POST_DELETED(HttpStatus.NOT_FOUND, "POST_404_2", "삭제된 게시글입니다."),
+    POST_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_403_1", "본인의 게시글만 처리할 수 있습니다."),
+
+    /**
+     * Comment (댓글/대댓글)
+     */
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CMT_404_1", "댓글을 찾을 수 없습니다."),
+    COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "CMT_403_1", "본인의 댓글만 처리할 수 있습니다."),
+    COMMENT_PARENT_POST_MISMATCH(HttpStatus.BAD_REQUEST, "CMT_400_1", "부모 댓글이 같은 게시글의 댓글이 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -39,7 +39,31 @@ public enum SuccessStatus implements BaseStatus {
      */
     FCM_TOKEN_REGISTER_SUCCESS(HttpStatus.OK, "FCM_200_1", "FCM 토큰이 등록되었습니다."),
     FCM_TOKEN_DELETE_SUCCESS(HttpStatus.OK, "FCM_200_2", "FCM 토큰이 삭제되었습니다."),
-    NOTIFICATION_SEND_SUCCESS(HttpStatus.OK, "NOTIF_200_1", "알림 발송 요청에 성공했습니다.");
+    NOTIFICATION_SEND_SUCCESS(HttpStatus.OK, "NOTIF_200_1", "알림 발송 요청에 성공했습니다."),
+
+    /**
+     * Record Post (기록공유 게시글)
+     */
+    RECORD_POST_CREATE_SUCCESS(HttpStatus.CREATED, "RPOST_201_1", "기록공유 게시글이 작성되었습니다."),
+    RECORD_POST_LIST_SUCCESS(HttpStatus.OK, "RPOST_200_1", "기록공유 게시글 목록 조회에 성공했습니다."),
+    RECORD_POST_MY_LIST_SUCCESS(HttpStatus.OK, "RPOST_200_2", "내 기록공유 게시글 목록 조회에 성공했습니다."),
+    RECORD_POST_DETAIL_SUCCESS(HttpStatus.OK, "RPOST_200_3", "기록공유 게시글 상세 조회에 성공했습니다."),
+    RECORD_POST_DELETE_SUCCESS(HttpStatus.OK, "RPOST_200_4", "기록공유 게시글이 삭제되었습니다."),
+
+    /**
+     * Comment (댓글/대댓글)
+     */
+    COMMENT_CREATE_SUCCESS(HttpStatus.CREATED, "CMT_201_1", "댓글이 작성되었습니다."),
+    COMMENT_REPLY_SUCCESS(HttpStatus.CREATED, "CMT_201_2", "대댓글이 작성되었습니다."),
+    COMMENT_LIST_SUCCESS(HttpStatus.OK, "CMT_200_1", "댓글 목록 조회에 성공했습니다."),
+    COMMENT_REPLY_LIST_SUCCESS(HttpStatus.OK, "CMT_200_2", "대댓글 목록 조회에 성공했습니다."),
+    COMMENT_DELETE_SUCCESS(HttpStatus.OK, "CMT_200_3", "댓글이 삭제되었습니다."),
+
+    /**
+     * Post Like (좋아요)
+     */
+    POST_LIKE_TOGGLE_SUCCESS(HttpStatus.OK, "LIKE_200_1", "좋아요 처리에 성공했습니다."),
+    POST_LIKE_COUNT_SUCCESS(HttpStatus.OK, "LIKE_200_2", "좋아요 수 조회에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -63,7 +63,16 @@ public enum SuccessStatus implements BaseStatus {
      * Post Like (좋아요)
      */
     POST_LIKE_TOGGLE_SUCCESS(HttpStatus.OK, "LIKE_200_1", "좋아요 처리에 성공했습니다."),
-    POST_LIKE_COUNT_SUCCESS(HttpStatus.OK, "LIKE_200_2", "좋아요 수 조회에 성공했습니다.");
+    POST_LIKE_COUNT_SUCCESS(HttpStatus.OK, "LIKE_200_2", "좋아요 수 조회에 성공했습니다."),
+
+    /**
+     * Free Post (자유게시판 게시글)
+     */
+    FREE_POST_CREATE_SUCCESS(HttpStatus.CREATED, "FPOST_201_1", "자유게시판 게시글이 작성되었습니다."),
+    FREE_POST_LIST_SUCCESS(HttpStatus.OK, "FPOST_200_1", "자유게시판 게시글 목록 조회에 성공했습니다."),
+    FREE_POST_MY_LIST_SUCCESS(HttpStatus.OK, "FPOST_200_2", "내 자유게시판 게시글 목록 조회에 성공했습니다."),
+    FREE_POST_DETAIL_SUCCESS(HttpStatus.OK, "FPOST_200_3", "자유게시판 게시글 상세 조회에 성공했습니다."),
+    FREE_POST_DELETE_SUCCESS(HttpStatus.OK, "FPOST_200_4", "자유게시판 게시글이 삭제되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/semosan/api/domain/community/comment/controller/CommentController.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/controller/CommentController.java
@@ -1,0 +1,79 @@
+package com.semosan.api.domain.community.comment.controller;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.response.PageResponse;
+import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.community.comment.dto.CommentCreateRequest;
+import com.semosan.api.domain.community.comment.dto.CommentReplyRequest;
+import com.semosan.api.domain.community.comment.dto.CommentResponse;
+import com.semosan.api.domain.community.comment.entity.Comment;
+import com.semosan.api.domain.community.comment.service.CommentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/community")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<CommentResponse>> create(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateRequest request
+    ) {
+        Comment comment = commentService.create(postId, userId, request.content());
+        return ApiResponse.success(SuccessStatus.COMMENT_CREATE_SUCCESS, CommentResponse.from(comment));
+    }
+
+    @PostMapping("/posts/{postId}/comments/replies")
+    public ResponseEntity<ApiResponse<CommentResponse>> reply(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentReplyRequest request
+    ) {
+        Comment reply = commentService.reply(
+                postId, userId, request.parentId(), request.mentionedUserId(), request.content()
+        );
+        return ApiResponse.success(SuccessStatus.COMMENT_REPLY_SUCCESS, CommentResponse.from(reply));
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<PageResponse<CommentResponse>>> getComments(
+            @PathVariable Long postId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        Page<CommentResponse> page = commentService.getCommentsByPost(postId, pageable).map(CommentResponse::from);
+        return ApiResponse.success(SuccessStatus.COMMENT_LIST_SUCCESS, PageResponse.from(page));
+    }
+
+    @GetMapping("/comments/{commentId}/replies")
+    public ResponseEntity<ApiResponse<List<CommentResponse>>> getReplies(
+            @PathVariable Long commentId
+    ) {
+        List<CommentResponse> replies = commentService.getReplies(commentId).stream()
+                .map(CommentResponse::from)
+                .toList();
+        return ApiResponse.success(SuccessStatus.COMMENT_REPLY_LIST_SUCCESS, replies);
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long commentId
+    ) {
+        commentService.delete(commentId, userId);
+        return ApiResponse.success(SuccessStatus.COMMENT_DELETE_SUCCESS);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/comment/controller/CommentController.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.community.comment.controller;
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.response.PageResponse;
 import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.community.comment.controller.docs.CommentControllerDocs;
 import com.semosan.api.domain.community.comment.dto.CommentCreateRequest;
 import com.semosan.api.domain.community.comment.dto.CommentReplyRequest;
 import com.semosan.api.domain.community.comment.dto.CommentResponse;
@@ -23,7 +24,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/community")
 @RequiredArgsConstructor
-public class CommentController {
+public class CommentController implements CommentControllerDocs {
 
     private final CommentService commentService;
 

--- a/src/main/java/com/semosan/api/domain/community/comment/controller/docs/CommentControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/controller/docs/CommentControllerDocs.java
@@ -1,0 +1,74 @@
+package com.semosan.api.domain.community.comment.controller.docs;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.response.PageResponse;
+import com.semosan.api.domain.community.comment.dto.CommentCreateRequest;
+import com.semosan.api.domain.community.comment.dto.CommentReplyRequest;
+import com.semosan.api.domain.community.comment.dto.CommentResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "Comment", description = "댓글/대댓글 API (자유게시판/기록공유 공용)")
+public interface CommentControllerDocs {
+
+    @Operation(summary = "댓글 작성", description = "게시글에 1뎁스 댓글을 작성합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "작성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 또는 유저 없음")
+    })
+    ResponseEntity<ApiResponse<CommentResponse>> create(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateRequest request
+    );
+
+    @Operation(
+            summary = "대댓글 작성",
+            description = "특정 댓글에 답글을 답니다. 부모가 대댓글이면 1뎁스 댓글로 자동 정규화 (트리 깊이 2 유지)."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "작성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "부모 댓글이 다른 게시글의 댓글"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글/댓글/유저 없음")
+    })
+    ResponseEntity<ApiResponse<CommentResponse>> reply(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentReplyRequest request
+    );
+
+    @Operation(summary = "댓글 목록", description = "특정 게시글의 1뎁스 댓글 목록 (페이징).")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<ApiResponse<PageResponse<CommentResponse>>> getComments(
+            @PathVariable Long postId,
+            Pageable pageable
+    );
+
+    @Operation(summary = "대댓글 목록", description = "특정 1뎁스 댓글의 대댓글 목록 (시간순).")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<ApiResponse<List<CommentResponse>>> getReplies(@PathVariable Long commentId);
+
+    @Operation(summary = "댓글 삭제", description = "본인의 댓글/대댓글을 soft delete 합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "본인 댓글 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "댓글 없음")
+    })
+    ResponseEntity<ApiResponse<Void>> delete(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long commentId
+    );
+}

--- a/src/main/java/com/semosan/api/domain/community/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,8 @@
+package com.semosan.api.domain.community.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentCreateRequest(
+        @NotBlank String content
+) {
+}

--- a/src/main/java/com/semosan/api/domain/community/comment/dto/CommentReplyRequest.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/dto/CommentReplyRequest.java
@@ -1,0 +1,11 @@
+package com.semosan.api.domain.community.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CommentReplyRequest(
+        @NotNull Long parentId,
+        Long mentionedUserId,
+        @NotBlank String content
+) {
+}

--- a/src/main/java/com/semosan/api/domain/community/comment/dto/CommentResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/dto/CommentResponse.java
@@ -1,0 +1,26 @@
+package com.semosan.api.domain.community.comment.dto;
+
+import com.semosan.api.domain.community.comment.entity.Comment;
+import com.semosan.api.domain.community.post.dto.AuthorResponse;
+
+import java.time.LocalDateTime;
+
+public record CommentResponse(
+        Long id,
+        AuthorResponse author,
+        String content,
+        Long parentId,
+        AuthorResponse mentionedUser,
+        LocalDateTime createdAt
+) {
+    public static CommentResponse from(Comment comment) {
+        return new CommentResponse(
+                comment.getId(),
+                AuthorResponse.from(comment.getAuthor()),
+                comment.getContent(),
+                comment.getParent() != null ? comment.getParent().getId() : null,
+                comment.getMentionedUser() != null ? AuthorResponse.from(comment.getMentionedUser()) : null,
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/comment/entity/Comment.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/entity/Comment.java
@@ -1,0 +1,75 @@
+package com.semosan.api.domain.community.comment.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.community.post.entity.Post;
+import com.semosan.api.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "comments")
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentioned_user_id")
+    private User mentionedUser;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private boolean deleted = false;
+
+    public static Comment create(Post post, User author, String content) {
+        return Comment.builder()
+                .post(post)
+                .author(author)
+                .content(content)
+                .build();
+    }
+
+    public static Comment reply(
+            Post post,
+            User author,
+            Comment parent,
+            User mentionedUser,
+            String content
+    ) {
+        return Comment.builder()
+                .post(post)
+                .author(author)
+                .parent(parent)
+                .mentionedUser(mentionedUser)
+                .content(content)
+                .build();
+    }
+
+    public void softDelete() {
+        this.deleted = true;
+    }
+
+    public boolean isReply() {
+        return this.parent != null;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/repository/CommentRepository.java
@@ -1,0 +1,16 @@
+package com.semosan.api.domain.community.comment.repository;
+
+import com.semosan.api.domain.community.comment.entity.Comment;
+import com.semosan.api.domain.community.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    Page<Comment> findByPostAndParentIsNullAndDeletedFalse(Post post, Pageable pageable);
+
+    List<Comment> findByParentAndDeletedFalseOrderByCreatedAtAsc(Comment parent);
+}

--- a/src/main/java/com/semosan/api/domain/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/repository/CommentRepository.java
@@ -5,6 +5,8 @@ import com.semosan.api.domain.community.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -13,4 +15,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findByPostAndParentIsNullAndDeletedFalse(Post post, Pageable pageable);
 
     List<Comment> findByParentAndDeletedFalseOrderByCreatedAtAsc(Comment parent);
+
+    long countByPostAndDeletedFalse(Post post);
+
+    @Query("SELECT c.post.id, COUNT(c) FROM Comment c WHERE c.post.id IN :postIds AND c.deleted = false GROUP BY c.post.id")
+    List<Object[]> countByPostIdsGrouped(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/com/semosan/api/domain/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/repository/CommentRepository.java
@@ -7,8 +7,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    Optional<Comment> findByIdAndDeletedFalse(Long id);
 
     Page<Comment> findByPostAndParentIsNullAndDeletedFalse(Post post, Pageable pageable);
 

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -1,5 +1,7 @@
 package com.semosan.api.domain.community.comment.service;
 
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.comment.entity.Comment;
 import com.semosan.api.domain.community.comment.repository.CommentRepository;
 import com.semosan.api.domain.community.post.entity.Post;
@@ -39,7 +41,7 @@ public class CommentService {
         Comment requestedParent = findActiveCommentOrThrow(parentId);
 
         if (!requestedParent.getPost().getId().equals(postId)) {
-            throw new IllegalArgumentException("부모 댓글이 같은 게시글의 댓글이 아닙니다.");
+            throw new GeneralException(ErrorStatus.COMMENT_PARENT_POST_MISMATCH);
         }
 
         // 대댓글에 답글을 달면 트리 깊이를 2로 유지하기 위해 1뎁스 댓글로 정규화
@@ -65,23 +67,23 @@ public class CommentService {
     public void delete(Long commentId, Long requesterId) {
         Comment comment = findActiveCommentOrThrow(commentId);
         if (!comment.getAuthor().getId().equals(requesterId)) {
-            throw new IllegalStateException("본인의 댓글만 삭제할 수 있습니다.");
+            throw new GeneralException(ErrorStatus.COMMENT_FORBIDDEN);
         }
         comment.softDelete();
     }
 
     private Post findPostOrThrow(Long postId) {
         return postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
     }
 
     private User findUserOrThrow(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 
     private Comment findActiveCommentOrThrow(Long commentId) {
         return commentRepository.findByIdAndDeletedFalse(commentId)
-                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -1,0 +1,91 @@
+package com.semosan.api.domain.community.comment.service;
+
+import com.semosan.api.domain.community.comment.entity.Comment;
+import com.semosan.api.domain.community.comment.repository.CommentRepository;
+import com.semosan.api.domain.community.post.entity.Post;
+import com.semosan.api.domain.community.post.repository.PostRepository;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Comment create(Long postId, Long authorId, String content) {
+        Post post = findPostOrThrow(postId);
+        User author = findUserOrThrow(authorId);
+
+        Comment comment = Comment.create(post, author, content);
+        return commentRepository.save(comment);
+    }
+
+    @Transactional
+    public Comment reply(Long postId, Long authorId, Long parentId, Long mentionedUserId, String content) {
+        Post post = findPostOrThrow(postId);
+        User author = findUserOrThrow(authorId);
+        Comment requestedParent = findActiveCommentOrThrow(parentId);
+
+        if (!requestedParent.getPost().getId().equals(postId)) {
+            throw new IllegalArgumentException("부모 댓글이 같은 게시글의 댓글이 아닙니다.");
+        }
+
+        // 대댓글에 답글을 달면 트리 깊이를 2로 유지하기 위해 1뎁스 댓글로 정규화
+        Comment actualParent = requestedParent.isReply() ? requestedParent.getParent() : requestedParent;
+
+        User mentionedUser = mentionedUserId != null ? findUserOrThrow(mentionedUserId) : null;
+
+        Comment reply = Comment.reply(post, author, actualParent, mentionedUser, content);
+        return commentRepository.save(reply);
+    }
+
+    public Page<Comment> getCommentsByPost(Long postId, Pageable pageable) {
+        Post post = findPostOrThrow(postId);
+        return commentRepository.findByPostAndParentIsNullAndDeletedFalse(post, pageable);
+    }
+
+    public List<Comment> getReplies(Long parentId) {
+        Comment parent = findActiveCommentOrThrow(parentId);
+        return commentRepository.findByParentAndDeletedFalseOrderByCreatedAtAsc(parent);
+    }
+
+    @Transactional
+    public void delete(Long commentId, Long requesterId) {
+        Comment comment = findActiveCommentOrThrow(commentId);
+        if (!comment.getAuthor().getId().equals(requesterId)) {
+            throw new IllegalStateException("본인의 댓글만 삭제할 수 있습니다.");
+        }
+        comment.softDelete();
+    }
+
+    private Post findPostOrThrow(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+    }
+
+    private User findUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+    }
+
+    private Comment findActiveCommentOrThrow(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+        if (comment.isDeleted()) {
+            throw new IllegalArgumentException("삭제된 댓글입니다.");
+        }
+        return comment;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -1,5 +1,7 @@
 package com.semosan.api.domain.community.comment.service;
 
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.comment.entity.Comment;
 import com.semosan.api.domain.community.comment.repository.CommentRepository;
 import com.semosan.api.domain.community.post.entity.Post;
@@ -39,7 +41,7 @@ public class CommentService {
         Comment requestedParent = findActiveCommentOrThrow(parentId);
 
         if (!requestedParent.getPost().getId().equals(postId)) {
-            throw new IllegalArgumentException("부모 댓글이 같은 게시글의 댓글이 아닙니다.");
+            throw new GeneralException(ErrorStatus.COMMENT_PARENT_POST_MISMATCH);
         }
 
         // 대댓글에 답글을 달면 트리 깊이를 2로 유지하기 위해 1뎁스 댓글로 정규화
@@ -65,26 +67,26 @@ public class CommentService {
     public void delete(Long commentId, Long requesterId) {
         Comment comment = findActiveCommentOrThrow(commentId);
         if (!comment.getAuthor().getId().equals(requesterId)) {
-            throw new IllegalStateException("본인의 댓글만 삭제할 수 있습니다.");
+            throw new GeneralException(ErrorStatus.COMMENT_FORBIDDEN);
         }
         comment.softDelete();
     }
 
     private Post findPostOrThrow(Long postId) {
         return postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
     }
 
     private User findUserOrThrow(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 
     private Comment findActiveCommentOrThrow(Long commentId) {
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
         if (comment.isDeleted()) {
-            throw new IllegalArgumentException("삭제된 댓글입니다.");
+            throw new GeneralException(ErrorStatus.COMMENT_DELETED);
         }
         return comment;
     }

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -81,11 +81,7 @@ public class CommentService {
     }
 
     private Comment findActiveCommentOrThrow(Long commentId) {
-        Comment comment = commentRepository.findById(commentId)
+        return commentRepository.findByIdAndDeletedFalse(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
-        if (comment.isDeleted()) {
-            throw new IllegalArgumentException("삭제된 댓글입니다.");
-        }
-        return comment;
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/like/controller/PostLikeController.java
+++ b/src/main/java/com/semosan/api/domain/community/like/controller/PostLikeController.java
@@ -21,11 +21,10 @@ public class PostLikeController {
             @AuthenticationPrincipal Long userId,
             @PathVariable Long postId
     ) {
-        boolean liked = postLikeService.toggle(postId, userId);
-        long count = postLikeService.count(postId);
+
         return ApiResponse.success(
                 SuccessStatus.POST_LIKE_TOGGLE_SUCCESS,
-                new PostLikeToggleResponse(liked, count)
+                postLikeService.toggleWithCount(postId, userId)
         );
     }
 

--- a/src/main/java/com/semosan/api/domain/community/like/controller/PostLikeController.java
+++ b/src/main/java/com/semosan/api/domain/community/like/controller/PostLikeController.java
@@ -1,0 +1,38 @@
+package com.semosan.api.domain.community.like.controller;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.community.like.dto.PostLikeToggleResponse;
+import com.semosan.api.domain.community.like.service.PostLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/community/posts/{postId}/likes")
+@RequiredArgsConstructor
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<PostLikeToggleResponse>> toggle(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    ) {
+        boolean liked = postLikeService.toggle(postId, userId);
+        long count = postLikeService.count(postId);
+        return ApiResponse.success(
+                SuccessStatus.POST_LIKE_TOGGLE_SUCCESS,
+                new PostLikeToggleResponse(liked, count)
+        );
+    }
+
+    @GetMapping("/count")
+    public ResponseEntity<ApiResponse<Long>> getCount(
+            @PathVariable Long postId
+    ) {
+        return ApiResponse.success(SuccessStatus.POST_LIKE_COUNT_SUCCESS, postLikeService.count(postId));
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/like/controller/PostLikeController.java
+++ b/src/main/java/com/semosan/api/domain/community/like/controller/PostLikeController.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.community.like.controller;
 
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.community.like.controller.docs.PostLikeControllerDocs;
 import com.semosan.api.domain.community.like.dto.PostLikeToggleResponse;
 import com.semosan.api.domain.community.like.service.PostLikeService;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/community/posts/{postId}/likes")
 @RequiredArgsConstructor
-public class PostLikeController {
+public class PostLikeController implements PostLikeControllerDocs {
 
     private final PostLikeService postLikeService;
 

--- a/src/main/java/com/semosan/api/domain/community/like/controller/docs/PostLikeControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/community/like/controller/docs/PostLikeControllerDocs.java
@@ -1,0 +1,34 @@
+package com.semosan.api.domain.community.like.controller.docs;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.domain.community.like.dto.PostLikeToggleResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Post Like", description = "게시글 좋아요 API (자유게시판/기록공유 공용)")
+public interface PostLikeControllerDocs {
+
+    @Operation(
+            summary = "좋아요 토글",
+            description = "이미 눌렀으면 취소, 안 눌렀으면 좋아요. 응답으로 결과 상태와 총 카운트 반환."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토글 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 또는 유저 없음")
+    })
+    ResponseEntity<ApiResponse<PostLikeToggleResponse>> toggle(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    );
+
+    @Operation(summary = "좋아요 수 조회", description = "특정 게시글의 좋아요 수.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 없음")
+    })
+    ResponseEntity<ApiResponse<Long>> getCount(@PathVariable Long postId);
+}

--- a/src/main/java/com/semosan/api/domain/community/like/dto/PostLikeToggleResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/like/dto/PostLikeToggleResponse.java
@@ -1,0 +1,7 @@
+package com.semosan.api.domain.community.like.dto;
+
+public record PostLikeToggleResponse(
+        boolean liked,
+        long count
+) {
+}

--- a/src/main/java/com/semosan/api/domain/community/like/entity/PostLike.java
+++ b/src/main/java/com/semosan/api/domain/community/like/entity/PostLike.java
@@ -1,0 +1,43 @@
+package com.semosan.api.domain.community.like.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.community.post.entity.Post;
+import com.semosan.api.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(
+        name = "post_likes",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_post_like_post_user",
+                        columnNames = {"post_id", "user_id"}
+                )
+        }
+)
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public static PostLike create(Post post, User user) {
+        return PostLike.builder()
+                .post(post)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/like/repository/PostLikeRepository.java
@@ -1,0 +1,17 @@
+package com.semosan.api.domain.community.like.repository;
+
+import com.semosan.api.domain.community.like.entity.PostLike;
+import com.semosan.api.domain.community.post.entity.Post;
+import com.semosan.api.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    boolean existsByPostAndUser(Post post, User user);
+
+    long countByPost(Post post);
+
+    Optional<PostLike> findByPostAndUser(Post post, User user);
+}

--- a/src/main/java/com/semosan/api/domain/community/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/like/repository/PostLikeRepository.java
@@ -4,7 +4,10 @@ import com.semosan.api.domain.community.like.entity.PostLike;
 import com.semosan.api.domain.community.post.entity.Post;
 import com.semosan.api.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
@@ -14,4 +17,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     long countByPost(Post post);
 
     Optional<PostLike> findByPostAndUser(Post post, User user);
+
+    @Query("SELECT pl.post.id, COUNT(pl) FROM PostLike pl WHERE pl.post.id IN :postIds GROUP BY pl.post.id")
+    List<Object[]> countByPostIdsGrouped(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -1,0 +1,61 @@
+package com.semosan.api.domain.community.like.service;
+
+import com.semosan.api.domain.community.like.entity.PostLike;
+import com.semosan.api.domain.community.like.repository.PostLikeRepository;
+import com.semosan.api.domain.community.post.entity.Post;
+import com.semosan.api.domain.community.post.repository.PostRepository;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostLikeService {
+
+    private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * @return true = 좋아요 누름 / false = 좋아요 취소
+     */
+    @Transactional
+    public boolean toggle(Long postId, Long userId) {
+        Post post = findPostOrThrow(postId);
+        User user = findUserOrThrow(userId);
+
+        Optional<PostLike> existing = postLikeRepository.findByPostAndUser(post, user);
+        if (existing.isPresent()) {
+            postLikeRepository.delete(existing.get());
+            return false;
+        }
+        postLikeRepository.save(PostLike.create(post, user));
+        return true;
+    }
+
+    public long count(Long postId) {
+        Post post = findPostOrThrow(postId);
+        return postLikeRepository.countByPost(post);
+    }
+
+    public boolean hasLiked(Long postId, Long userId) {
+        Post post = findPostOrThrow(postId);
+        User user = findUserOrThrow(userId);
+        return postLikeRepository.existsByPostAndUser(post, user);
+    }
+
+    private Post findPostOrThrow(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+    }
+
+    private User findUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -1,5 +1,7 @@
 package com.semosan.api.domain.community.like.service;
 
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.like.dto.PostLikeToggleResponse;
 import com.semosan.api.domain.community.like.entity.PostLike;
 import com.semosan.api.domain.community.like.repository.PostLikeRepository;
@@ -67,11 +69,11 @@ public class PostLikeService {
 
     private Post findPostOrThrow(Long postId) {
         return postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
     }
 
     private User findUserOrThrow(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -8,11 +8,14 @@ import com.semosan.api.domain.community.post.repository.PostRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -34,8 +37,14 @@ public class PostLikeService {
             postLikeRepository.delete(existing.get());
             return false;
         }
-        postLikeRepository.save(PostLike.create(post, user));
-        return true;
+
+        try {
+            postLikeRepository.save(PostLike.create(post, user));
+            return true;
+        } catch (DataIntegrityViolationException e) {
+            log.warn("PostLike 동시 요청 감지: postId={}, userId={}", postId, userId);
+            return true;
+        }
     }
 
     public long count(Long postId) {
@@ -43,7 +52,7 @@ public class PostLikeService {
         return postLikeRepository.countByPost(post);
     }
 
-    @Transactional
+    @Transactional(noRollbackFor = DataIntegrityViolationException.class)
     public PostLikeToggleResponse toggleWithCount(Long postId, Long userId) {
         boolean liked = this.toggle(postId, userId);
         long count = this.count(postId);

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -1,5 +1,7 @@
 package com.semosan.api.domain.community.like.service;
 
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.like.entity.PostLike;
 import com.semosan.api.domain.community.like.repository.PostLikeRepository;
 import com.semosan.api.domain.community.post.entity.Post;
@@ -51,11 +53,11 @@ public class PostLikeService {
 
     private Post findPostOrThrow(Long postId) {
         return postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
     }
 
     private User findUserOrThrow(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -1,5 +1,6 @@
 package com.semosan.api.domain.community.like.service;
 
+import com.semosan.api.domain.community.like.dto.PostLikeToggleResponse;
 import com.semosan.api.domain.community.like.entity.PostLike;
 import com.semosan.api.domain.community.like.repository.PostLikeRepository;
 import com.semosan.api.domain.community.post.entity.Post;
@@ -24,8 +25,7 @@ public class PostLikeService {
     /**
      * @return true = 좋아요 누름 / false = 좋아요 취소
      */
-    @Transactional
-    public boolean toggle(Long postId, Long userId) {
+    private boolean toggle(Long postId, Long userId) {
         Post post = findPostOrThrow(postId);
         User user = findUserOrThrow(userId);
 
@@ -41,6 +41,13 @@ public class PostLikeService {
     public long count(Long postId) {
         Post post = findPostOrThrow(postId);
         return postLikeRepository.countByPost(post);
+    }
+
+    @Transactional
+    public PostLikeToggleResponse toggleWithCount(Long postId, Long userId) {
+        boolean liked = this.toggle(postId, userId);
+        long count = this.count(postId);
+        return new PostLikeToggleResponse(liked, count);
     }
 
     public boolean hasLiked(Long postId, Long userId) {

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -68,7 +68,7 @@ public class PostLikeService {
     }
 
     private Post findPostOrThrow(Long postId) {
-        return postRepository.findById(postId)
+        return postRepository.findByIdAndDeletedFalse(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
     }
 

--- a/src/main/java/com/semosan/api/domain/community/post/controller/FreePostController.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/FreePostController.java
@@ -1,0 +1,80 @@
+package com.semosan.api.domain.community.post.controller;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.response.PageResponse;
+import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.community.post.dto.FreePostCreateRequest;
+import com.semosan.api.domain.community.post.dto.FreePostDetailResponse;
+import com.semosan.api.domain.community.post.dto.FreePostListResponse;
+import com.semosan.api.domain.community.post.service.FreePostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/community/free-posts")
+@RequiredArgsConstructor
+public class FreePostController {
+
+    private final FreePostService freePostService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<FreePostDetailResponse>> create(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody FreePostCreateRequest request
+    ) {
+        FreePostDetailResponse response = freePostService.create(
+                userId,
+                request.title(),
+                request.content(),
+                request.imageUrls(),
+                request.mainImageIndex()
+        );
+        return ApiResponse.success(SuccessStatus.FREE_POST_CREATE_SUCCESS, response);
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<FreePostListResponse>>> getList(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ApiResponse.success(
+                SuccessStatus.FREE_POST_LIST_SUCCESS,
+                PageResponse.from(freePostService.getList(pageable))
+        );
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<PageResponse<FreePostListResponse>>> getMyList(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ApiResponse.success(
+                SuccessStatus.FREE_POST_MY_LIST_SUCCESS,
+                PageResponse.from(freePostService.getMyList(userId, pageable))
+        );
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<ApiResponse<FreePostDetailResponse>> getDetail(
+            @PathVariable Long postId
+    ) {
+        return ApiResponse.success(
+                SuccessStatus.FREE_POST_DETAIL_SUCCESS,
+                freePostService.getDetail(postId)
+        );
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    ) {
+        freePostService.delete(postId, userId);
+        return ApiResponse.success(SuccessStatus.FREE_POST_DELETE_SUCCESS);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/controller/FreePostController.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/FreePostController.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.community.post.controller;
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.response.PageResponse;
 import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.community.post.controller.docs.FreePostControllerDocs;
 import com.semosan.api.domain.community.post.dto.FreePostCreateRequest;
 import com.semosan.api.domain.community.post.dto.FreePostDetailResponse;
 import com.semosan.api.domain.community.post.dto.FreePostListResponse;
@@ -19,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/community/free-posts")
 @RequiredArgsConstructor
-public class FreePostController {
+public class FreePostController implements FreePostControllerDocs {
 
     private final FreePostService freePostService;
 

--- a/src/main/java/com/semosan/api/domain/community/post/controller/FreePostController.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/FreePostController.java
@@ -29,14 +29,14 @@ public class FreePostController implements FreePostControllerDocs {
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody FreePostCreateRequest request
     ) {
-        FreePostDetailResponse response = freePostService.create(
+
+        return ApiResponse.success(SuccessStatus.FREE_POST_CREATE_SUCCESS, freePostService.create(
                 userId,
                 request.title(),
                 request.content(),
                 request.imageUrls(),
                 request.mainImageIndex()
-        );
-        return ApiResponse.success(SuccessStatus.FREE_POST_CREATE_SUCCESS, response);
+        ));
     }
 
     @GetMapping

--- a/src/main/java/com/semosan/api/domain/community/post/controller/RecordPostController.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/RecordPostController.java
@@ -1,0 +1,69 @@
+package com.semosan.api.domain.community.post.controller;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.response.PageResponse;
+import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.community.post.dto.RecordPostCreateRequest;
+import com.semosan.api.domain.community.post.dto.RecordPostResponse;
+import com.semosan.api.domain.community.post.entity.RecordPost;
+import com.semosan.api.domain.community.post.service.RecordPostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/community/record-posts")
+@RequiredArgsConstructor
+public class RecordPostController {
+
+    private final RecordPostService recordPostService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<RecordPostResponse>> create(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody RecordPostCreateRequest request
+    ) {
+        RecordPost post = recordPostService.create(userId, request.hikingRecordId(), request.content());
+        return ApiResponse.success(SuccessStatus.RECORD_POST_CREATE_SUCCESS, RecordPostResponse.from(post));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<RecordPostResponse>>> getList(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<RecordPostResponse> page = recordPostService.getList(pageable).map(RecordPostResponse::from);
+        return ApiResponse.success(SuccessStatus.RECORD_POST_LIST_SUCCESS, PageResponse.from(page));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<PageResponse<RecordPostResponse>>> getMyList(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<RecordPostResponse> page = recordPostService.getMyList(userId, pageable).map(RecordPostResponse::from);
+        return ApiResponse.success(SuccessStatus.RECORD_POST_MY_LIST_SUCCESS, PageResponse.from(page));
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<ApiResponse<RecordPostResponse>> getDetail(
+            @PathVariable Long postId
+    ) {
+        RecordPost post = recordPostService.getDetail(postId);
+        return ApiResponse.success(SuccessStatus.RECORD_POST_DETAIL_SUCCESS, RecordPostResponse.from(post));
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    ) {
+        recordPostService.delete(postId, userId);
+        return ApiResponse.success(SuccessStatus.RECORD_POST_DELETE_SUCCESS);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/controller/RecordPostController.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/RecordPostController.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.community.post.controller;
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.response.PageResponse;
 import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.community.post.controller.docs.RecordPostControllerDocs;
 import com.semosan.api.domain.community.post.dto.RecordPostCreateRequest;
 import com.semosan.api.domain.community.post.dto.RecordPostResponse;
 import com.semosan.api.domain.community.post.entity.RecordPost;
@@ -20,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/community/record-posts")
 @RequiredArgsConstructor
-public class RecordPostController {
+public class RecordPostController implements RecordPostControllerDocs {
 
     private final RecordPostService recordPostService;
 

--- a/src/main/java/com/semosan/api/domain/community/post/controller/docs/FreePostControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/docs/FreePostControllerDocs.java
@@ -1,0 +1,64 @@
+package com.semosan.api.domain.community.post.controller.docs;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.response.PageResponse;
+import com.semosan.api.domain.community.post.dto.FreePostCreateRequest;
+import com.semosan.api.domain.community.post.dto.FreePostDetailResponse;
+import com.semosan.api.domain.community.post.dto.FreePostListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Free Post", description = "자유게시판 API")
+public interface FreePostControllerDocs {
+
+    @Operation(summary = "자유게시판 작성", description = "제목/본문/이미지(여러 장 + 대표 인덱스)로 게시글을 작성합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "작성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "본문 누락 또는 대표 이미지 인덱스 오류"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 없음")
+    })
+    ResponseEntity<ApiResponse<FreePostDetailResponse>> create(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody FreePostCreateRequest request
+    );
+
+    @Operation(summary = "자유게시판 목록", description = "최신순 페이징. 응답에 대표이미지/좋아요수/댓글수가 함께 내려갑니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<ApiResponse<PageResponse<FreePostListResponse>>> getList(Pageable pageable);
+
+    @Operation(summary = "내 자유게시판 목록", description = "내가 쓴 자유게시판 게시글 목록.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<ApiResponse<PageResponse<FreePostListResponse>>> getMyList(
+            @AuthenticationPrincipal Long userId,
+            Pageable pageable
+    );
+
+    @Operation(summary = "자유게시판 상세", description = "게시글 상세 (전체 이미지 + 카운트). 호출 시 조회수 +1.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 없음 또는 삭제됨")
+    })
+    ResponseEntity<ApiResponse<FreePostDetailResponse>> getDetail(@PathVariable Long postId);
+
+    @Operation(summary = "자유게시판 삭제", description = "본인의 게시글을 soft delete 합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "본인 게시글 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 없음")
+    })
+    ResponseEntity<ApiResponse<Void>> delete(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    );
+}

--- a/src/main/java/com/semosan/api/domain/community/post/controller/docs/RecordPostControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/docs/RecordPostControllerDocs.java
@@ -1,0 +1,62 @@
+package com.semosan.api.domain.community.post.controller.docs;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.response.PageResponse;
+import com.semosan.api.domain.community.post.dto.RecordPostCreateRequest;
+import com.semosan.api.domain.community.post.dto.RecordPostResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Record Post", description = "기록공유 게시글 API")
+public interface RecordPostControllerDocs {
+
+    @Operation(summary = "기록공유 작성", description = "등산 기록을 기반으로 게시글을 작성합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "작성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 또는 등산 기록 없음")
+    })
+    ResponseEntity<ApiResponse<RecordPostResponse>> create(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody RecordPostCreateRequest request
+    );
+
+    @Operation(summary = "기록공유 목록", description = "기록공유 게시글 목록을 페이징으로 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<ApiResponse<PageResponse<RecordPostResponse>>> getList(Pageable pageable);
+
+    @Operation(summary = "내 기록공유 목록", description = "내가 쓴 기록공유 게시글 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<ApiResponse<PageResponse<RecordPostResponse>>> getMyList(
+            @AuthenticationPrincipal Long userId,
+            Pageable pageable
+    );
+
+    @Operation(summary = "기록공유 상세", description = "게시글 상세를 조회합니다. 호출 시 조회수가 1 증가합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 없음 또는 삭제됨")
+    })
+    ResponseEntity<ApiResponse<RecordPostResponse>> getDetail(@PathVariable Long postId);
+
+    @Operation(summary = "기록공유 삭제", description = "본인의 게시글을 soft delete 합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "본인 게시글 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 없음")
+    })
+    ResponseEntity<ApiResponse<Void>> delete(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    );
+}

--- a/src/main/java/com/semosan/api/domain/community/post/dto/AuthorResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/AuthorResponse.java
@@ -5,9 +5,19 @@ import com.semosan.api.domain.user.entity.User;
 public record AuthorResponse(
         Long id,
         String name,
-        String profileUrl
+        String profileUrl,
+        boolean isDeleted
 ) {
+
+    //TODO: 앱 정책에 따라서 탈퇴한 회원 이름 어떻게 보내줄지 결정되면 통일하기
+    private static final String DELETED_USER_NAME = "탈퇴한 사용자";
+    private static final String UNKNOWN_USER_NAME = "이름없음";
+
     public static AuthorResponse from(User user) {
-        return new AuthorResponse(user.getId(), user.getName(), user.getProfileUrl());
+        if (user.isDeleted()) {
+            return new AuthorResponse(user.getId(), DELETED_USER_NAME, null, true);
+        }
+        String name = user.getName() != null ? user.getName() : UNKNOWN_USER_NAME;
+        return new AuthorResponse(user.getId(), name, user.getProfileUrl(), false);
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/post/dto/AuthorResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/AuthorResponse.java
@@ -1,0 +1,13 @@
+package com.semosan.api.domain.community.post.dto;
+
+import com.semosan.api.domain.user.entity.User;
+
+public record AuthorResponse(
+        Long id,
+        String name,
+        String profileUrl
+) {
+    public static AuthorResponse from(User user) {
+        return new AuthorResponse(user.getId(), user.getName(), user.getProfileUrl());
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/dto/FreePostCreateRequest.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/FreePostCreateRequest.java
@@ -1,12 +1,13 @@
 package com.semosan.api.domain.community.post.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 public record FreePostCreateRequest(
-        @NotBlank String title,
-        @NotBlank String content,
+        @NotBlank @Size(max = 200) String title,
+        @NotBlank @Size(max = 5000) String content,
         List<String> imageUrls,
         Integer mainImageIndex
 ) {

--- a/src/main/java/com/semosan/api/domain/community/post/dto/FreePostCreateRequest.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/FreePostCreateRequest.java
@@ -1,0 +1,13 @@
+package com.semosan.api.domain.community.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record FreePostCreateRequest(
+        @NotBlank String title,
+        @NotBlank String content,
+        List<String> imageUrls,
+        Integer mainImageIndex
+) {
+}

--- a/src/main/java/com/semosan/api/domain/community/post/dto/FreePostDetailResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/FreePostDetailResponse.java
@@ -17,7 +17,7 @@ public record FreePostDetailResponse(
         Long commentCount,
         LocalDateTime createdAt
 ) {
-    public static FreePostDetailResponse from(
+    public static FreePostDetailResponse of(
             FreePost post,
             List<PostImage> images,
             long likeCount,

--- a/src/main/java/com/semosan/api/domain/community/post/dto/FreePostDetailResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/FreePostDetailResponse.java
@@ -1,0 +1,38 @@
+package com.semosan.api.domain.community.post.dto;
+
+import com.semosan.api.domain.community.post.entity.FreePost;
+import com.semosan.api.domain.community.post.entity.PostImage;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FreePostDetailResponse(
+        Long id,
+        AuthorResponse author,
+        String title,
+        String content,
+        List<PostImageResponse> images,
+        Integer viewCount,
+        Long likeCount,
+        Long commentCount,
+        LocalDateTime createdAt
+) {
+    public static FreePostDetailResponse from(
+            FreePost post,
+            List<PostImage> images,
+            long likeCount,
+            long commentCount
+    ) {
+        return new FreePostDetailResponse(
+                post.getId(),
+                AuthorResponse.from(post.getAuthor()),
+                post.getTitle(),
+                post.getContent(),
+                images.stream().map(PostImageResponse::from).toList(),
+                post.getViewCount(),
+                likeCount,
+                commentCount,
+                post.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/dto/FreePostListResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/FreePostListResponse.java
@@ -1,0 +1,45 @@
+package com.semosan.api.domain.community.post.dto;
+
+import com.semosan.api.domain.community.post.entity.FreePost;
+
+import java.time.LocalDateTime;
+
+public record FreePostListResponse(
+        Long id,
+        AuthorResponse author,
+        String title,
+        String contentPreview,
+        String representativeImageUrl,
+        Integer viewCount,
+        Long likeCount,
+        Long commentCount,
+        LocalDateTime createdAt
+) {
+    private static final int PREVIEW_LENGTH = 100;
+
+    public static FreePostListResponse from(
+            FreePost post,
+            String representativeImageUrl,
+            long likeCount,
+            long commentCount
+    ) {
+        return new FreePostListResponse(
+                post.getId(),
+                AuthorResponse.from(post.getAuthor()),
+                post.getTitle(),
+                preview(post.getContent()),
+                representativeImageUrl,
+                post.getViewCount(),
+                likeCount,
+                commentCount,
+                post.getCreatedAt()
+        );
+    }
+
+    private static String preview(String content) {
+        if (content == null) return null;
+        return content.length() > PREVIEW_LENGTH
+                ? content.substring(0, PREVIEW_LENGTH)
+                : content;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/dto/PostImageResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/PostImageResponse.java
@@ -1,0 +1,19 @@
+package com.semosan.api.domain.community.post.dto;
+
+import com.semosan.api.domain.community.post.entity.PostImage;
+
+public record PostImageResponse(
+        Long id,
+        String imageUrl,
+        Integer sortOrder,
+        boolean main
+) {
+    public static PostImageResponse from(PostImage image) {
+        return new PostImageResponse(
+                image.getId(),
+                image.getImageUrl(),
+                image.getSortOrder(),
+                image.isMain()
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/dto/RecordPostCreateRequest.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/RecordPostCreateRequest.java
@@ -1,0 +1,9 @@
+package com.semosan.api.domain.community.post.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record RecordPostCreateRequest(
+        @NotNull Long hikingRecordId,
+        String content
+) {
+}

--- a/src/main/java/com/semosan/api/domain/community/post/dto/RecordPostResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/RecordPostResponse.java
@@ -1,0 +1,26 @@
+package com.semosan.api.domain.community.post.dto;
+
+import com.semosan.api.domain.community.post.entity.RecordPost;
+import com.semosan.api.domain.hiking.dto.HikingRecordSummaryResponse;
+
+import java.time.LocalDateTime;
+
+public record RecordPostResponse(
+        Long id,
+        AuthorResponse author,
+        String content,
+        HikingRecordSummaryResponse hikingRecord,
+        Integer viewCount,
+        LocalDateTime createdAt
+) {
+    public static RecordPostResponse from(RecordPost post) {
+        return new RecordPostResponse(
+                post.getId(),
+                AuthorResponse.from(post.getAuthor()),
+                post.getContent(),
+                HikingRecordSummaryResponse.from(post.getHikingRecord()),
+                post.getViewCount(),
+                post.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/entity/FreePost.java
+++ b/src/main/java/com/semosan/api/domain/community/post/entity/FreePost.java
@@ -1,0 +1,27 @@
+package com.semosan.api.domain.community.post.entity;
+
+import com.semosan.api.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "free_posts")
+@Getter
+@Entity
+@DiscriminatorValue("FREE")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FreePost extends Post {
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    private FreePost(User author, String title, String content) {
+        super(author, content);
+        this.title = title;
+    }
+
+    public static FreePost create(User author, String title, String content) {
+        return new FreePost(author, title, content);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/entity/Post.java
+++ b/src/main/java/com/semosan/api/domain/community/post/entity/Post.java
@@ -1,0 +1,47 @@
+package com.semosan.api.domain.community.post.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "posts")
+@Getter
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "post_type", length = 20)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "view_count", nullable = false)
+    private Integer viewCount = 0;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean deleted = false;
+
+    protected Post(User author, String content) {
+        this.author = author;
+        this.content = content;
+    }
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    public void softDelete() {
+        this.deleted = true;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/entity/PostImage.java
+++ b/src/main/java/com/semosan/api/domain/community/post/entity/PostImage.java
@@ -7,8 +7,6 @@ import lombok.*;
 @Table(name = "post_images")
 @Getter
 @Entity
-@Builder(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostImage extends BaseEntity {
 
@@ -29,12 +27,14 @@ public class PostImage extends BaseEntity {
     @Column(name = "is_main", nullable = false)
     private boolean main;
 
+    private PostImage(Post post, String imageUrl, Integer sortOrder, boolean main) {
+        this.post = post;
+        this.imageUrl = imageUrl;
+        this.sortOrder = sortOrder;
+        this.main = main;
+    }
+
     public static PostImage create(Post post, String imageUrl, int sortOrder, boolean main) {
-        return PostImage.builder()
-                .post(post)
-                .imageUrl(imageUrl)
-                .sortOrder(sortOrder)
-                .main(main)
-                .build();
+        return new PostImage(post, imageUrl, sortOrder, main);
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/post/entity/PostImage.java
+++ b/src/main/java/com/semosan/api/domain/community/post/entity/PostImage.java
@@ -1,0 +1,40 @@
+package com.semosan.api.domain.community.post.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "post_images")
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Column(name = "is_main", nullable = false)
+    private boolean main;
+
+    public static PostImage create(Post post, String imageUrl, int sortOrder, boolean main) {
+        return PostImage.builder()
+                .post(post)
+                .imageUrl(imageUrl)
+                .sortOrder(sortOrder)
+                .main(main)
+                .build();
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/entity/RecordPost.java
+++ b/src/main/java/com/semosan/api/domain/community/post/entity/RecordPost.java
@@ -1,0 +1,29 @@
+package com.semosan.api.domain.community.post.entity;
+
+import com.semosan.api.domain.hiking.entity.HikingRecord;
+import com.semosan.api.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "record_posts")
+@Getter
+@Entity
+@DiscriminatorValue("RECORD")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecordPost extends Post {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hiking_record_id", nullable = false)
+    private HikingRecord hikingRecord;
+
+    private RecordPost(User author, String content, HikingRecord hikingRecord) {
+        super(author, content);
+        this.hikingRecord = hikingRecord;
+    }
+
+    public static RecordPost create(User author, String content, HikingRecord hikingRecord) {
+        return new RecordPost(author, content, hikingRecord);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/repository/FreePostRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/FreePostRepository.java
@@ -1,0 +1,14 @@
+package com.semosan.api.domain.community.post.repository;
+
+import com.semosan.api.domain.community.post.entity.FreePost;
+import com.semosan.api.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FreePostRepository extends JpaRepository<FreePost, Long> {
+
+    Page<FreePost> findAllByDeletedFalse(Pageable pageable);
+
+    Page<FreePost> findByAuthorAndDeletedFalse(User author, Pageable pageable);
+}

--- a/src/main/java/com/semosan/api/domain/community/post/repository/PostImageRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/PostImageRepository.java
@@ -1,0 +1,17 @@
+package com.semosan.api.domain.community.post.repository;
+
+import com.semosan.api.domain.community.post.entity.Post;
+import com.semosan.api.domain.community.post.entity.PostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+
+    List<PostImage> findByPostOrderBySortOrderAsc(Post post);
+
+    @Query("SELECT pi FROM PostImage pi WHERE pi.post.id IN :postIds AND pi.main = true")
+    List<PostImage> findMainImagesByPostIds(@Param("postIds") List<Long> postIds);
+}

--- a/src/main/java/com/semosan/api/domain/community/post/repository/PostRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/PostRepository.java
@@ -3,5 +3,8 @@ package com.semosan.api.domain.community.post.repository;
 import com.semosan.api.domain.community.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/com/semosan/api/domain/community/post/repository/PostRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.semosan.api.domain.community.post.repository;
+
+import com.semosan.api.domain.community.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/semosan/api/domain/community/post/repository/RecordPostRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/RecordPostRepository.java
@@ -1,0 +1,14 @@
+package com.semosan.api.domain.community.post.repository;
+
+import com.semosan.api.domain.community.post.entity.RecordPost;
+import com.semosan.api.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecordPostRepository extends JpaRepository<RecordPost, Long> {
+
+    Page<RecordPost> findAllByDeletedFalse(Pageable pageable);
+
+    Page<RecordPost> findByAuthorAndDeletedFalse(User author, Pageable pageable);
+}

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -1,0 +1,131 @@
+package com.semosan.api.domain.community.post.service;
+
+import com.semosan.api.domain.community.comment.repository.CommentRepository;
+import com.semosan.api.domain.community.like.repository.PostLikeRepository;
+import com.semosan.api.domain.community.post.dto.FreePostDetailResponse;
+import com.semosan.api.domain.community.post.dto.FreePostListResponse;
+import com.semosan.api.domain.community.post.entity.FreePost;
+import com.semosan.api.domain.community.post.entity.PostImage;
+import com.semosan.api.domain.community.post.repository.FreePostRepository;
+import com.semosan.api.domain.community.post.repository.PostImageRepository;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FreePostService {
+
+    private final FreePostRepository freePostRepository;
+    private final PostImageRepository postImageRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public FreePostDetailResponse create(
+            Long authorId,
+            String title,
+            String content,
+            List<String> imageUrls,
+            Integer mainImageIndex
+    ) {
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("자유게시판 본문은 비어있을 수 없습니다.");
+        }
+        User author = userRepository.findById(authorId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        FreePost post = FreePost.create(author, title, content);
+        freePostRepository.save(post);
+
+        List<PostImage> images = saveImages(post, imageUrls, mainImageIndex);
+
+        return FreePostDetailResponse.from(post, images, 0L, 0L);
+    }
+
+    public Page<FreePostListResponse> getList(Pageable pageable) {
+        return enrichWithCounts(freePostRepository.findAllByDeletedFalse(pageable));
+    }
+
+    public Page<FreePostListResponse> getMyList(Long authorId, Pageable pageable) {
+        User author = userRepository.findById(authorId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+        return enrichWithCounts(freePostRepository.findByAuthorAndDeletedFalse(author, pageable));
+    }
+
+    @Transactional
+    public FreePostDetailResponse getDetail(Long postId) {
+        FreePost post = findActivePostOrThrow(postId);
+        post.increaseViewCount();
+
+        List<PostImage> images = postImageRepository.findByPostOrderBySortOrderAsc(post);
+        long likeCount = postLikeRepository.countByPost(post);
+        long commentCount = commentRepository.countByPostAndDeletedFalse(post);
+
+        return FreePostDetailResponse.from(post, images, likeCount, commentCount);
+    }
+
+    @Transactional
+    public void delete(Long postId, Long requesterId) {
+        FreePost post = findActivePostOrThrow(postId);
+        if (!post.getAuthor().getId().equals(requesterId)) {
+            throw new IllegalStateException("본인의 게시글만 삭제할 수 있습니다.");
+        }
+        post.softDelete();
+    }
+
+    private List<PostImage> saveImages(FreePost post, List<String> imageUrls, Integer mainImageIndex) {
+        if (imageUrls == null || imageUrls.isEmpty()) {
+            return List.of();
+        }
+        int main = (mainImageIndex != null) ? mainImageIndex : 0;
+        if (main < 0 || main >= imageUrls.size()) {
+            throw new IllegalArgumentException("대표 이미지 인덱스가 잘못되었습니다.");
+        }
+        List<PostImage> saved = new java.util.ArrayList<>();
+        for (int i = 0; i < imageUrls.size(); i++) {
+            saved.add(postImageRepository.save(PostImage.create(post, imageUrls.get(i), i, i == main)));
+        }
+        return saved;
+    }
+
+    private Page<FreePostListResponse> enrichWithCounts(Page<FreePost> posts) {
+        if (posts.isEmpty()) {
+            return posts.map(p -> null);
+        }
+        List<Long> postIds = posts.getContent().stream().map(FreePost::getId).toList();
+
+        Map<Long, Long> likeCountMap = postLikeRepository.countByPostIdsGrouped(postIds).stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
+        Map<Long, Long> commentCountMap = commentRepository.countByPostIdsGrouped(postIds).stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
+        Map<Long, String> mainImageMap = postImageRepository.findMainImagesByPostIds(postIds).stream()
+                .collect(Collectors.toMap(img -> img.getPost().getId(), PostImage::getImageUrl));
+
+        return posts.map(post -> FreePostListResponse.from(
+                post,
+                mainImageMap.get(post.getId()),
+                likeCountMap.getOrDefault(post.getId(), 0L),
+                commentCountMap.getOrDefault(post.getId(), 0L)
+        ));
+    }
+
+    private FreePost findActivePostOrThrow(Long postId) {
+        FreePost post = freePostRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+        if (post.isDeleted()) {
+            throw new IllegalArgumentException("삭제된 게시글입니다.");
+        }
+        return post;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -52,7 +52,7 @@ public class FreePostService {
 
         List<PostImage> images = saveImages(post, imageUrls, mainImageIndex);
 
-        return FreePostDetailResponse.from(post, images, 0L, 0L);
+        return FreePostDetailResponse.of(post, images, 0L, 0L);
     }
 
     public Page<FreePostListResponse> getList(Pageable pageable) {
@@ -74,7 +74,7 @@ public class FreePostService {
         long likeCount = postLikeRepository.countByPost(post);
         long commentCount = commentRepository.countByPostAndDeletedFalse(post);
 
-        return FreePostDetailResponse.from(post, images, likeCount, commentCount);
+        return FreePostDetailResponse.of(post, images, likeCount, commentCount);
     }
 
     @Transactional

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -1,5 +1,7 @@
 package com.semosan.api.domain.community.post.service;
 
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.comment.repository.CommentRepository;
 import com.semosan.api.domain.community.like.repository.PostLikeRepository;
 import com.semosan.api.domain.community.post.dto.FreePostDetailResponse;
@@ -40,10 +42,10 @@ public class FreePostService {
             Integer mainImageIndex
     ) {
         if (content == null || content.isBlank()) {
-            throw new IllegalArgumentException("자유게시판 본문은 비어있을 수 없습니다.");
+            throw new GeneralException(ErrorStatus.POST_CONTENT_REQUIRED);
         }
         User author = userRepository.findById(authorId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         FreePost post = FreePost.create(author, title, content);
         freePostRepository.save(post);
@@ -59,7 +61,7 @@ public class FreePostService {
 
     public Page<FreePostListResponse> getMyList(Long authorId, Pageable pageable) {
         User author = userRepository.findById(authorId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         return enrichWithCounts(freePostRepository.findByAuthorAndDeletedFalse(author, pageable));
     }
 
@@ -79,7 +81,7 @@ public class FreePostService {
     public void delete(Long postId, Long requesterId) {
         FreePost post = findActivePostOrThrow(postId);
         if (!post.getAuthor().getId().equals(requesterId)) {
-            throw new IllegalStateException("본인의 게시글만 삭제할 수 있습니다.");
+            throw new GeneralException(ErrorStatus.POST_FORBIDDEN);
         }
         post.softDelete();
     }
@@ -90,7 +92,7 @@ public class FreePostService {
         }
         int main = (mainImageIndex != null) ? mainImageIndex : 0;
         if (main < 0 || main >= imageUrls.size()) {
-            throw new IllegalArgumentException("대표 이미지 인덱스가 잘못되었습니다.");
+            throw new GeneralException(ErrorStatus.POST_IMAGE_INDEX_INVALID);
         }
         List<PostImage> saved = new java.util.ArrayList<>();
         for (int i = 0; i < imageUrls.size(); i++) {
@@ -122,9 +124,9 @@ public class FreePostService {
 
     private FreePost findActivePostOrThrow(Long postId) {
         FreePost post = freePostRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
         if (post.isDeleted()) {
-            throw new IllegalArgumentException("삭제된 게시글입니다.");
+            throw new GeneralException(ErrorStatus.POST_DELETED);
         }
         return post;
     }

--- a/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
@@ -1,5 +1,7 @@
 package com.semosan.api.domain.community.post.service;
 
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.post.entity.RecordPost;
 import com.semosan.api.domain.community.post.repository.RecordPostRepository;
 import com.semosan.api.domain.hiking.entity.HikingRecord;
@@ -26,12 +28,12 @@ public class RecordPostService {
     @Transactional
     public RecordPost create(Long authorId, Long hikingRecordId, String content) {
         User author = userRepository.findById(authorId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         HikingRecord hikingRecord = hikingRecordRepository.findById(hikingRecordId)
-                .orElseThrow(() -> new IllegalArgumentException("등산 기록을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.HIKING_RECORD_NOT_FOUND));
 
         if (!hikingMemberRepository.existsByHikingRecordAndUser(hikingRecord, author)) {
-            throw new IllegalStateException("본인이 참여한 등산 기록만 공유할 수 있습니다.");
+            throw new GeneralException(ErrorStatus.HIKING_RECORD_FORBIDDEN);
         }
 
         RecordPost post = RecordPost.create(author, content, hikingRecord);
@@ -44,7 +46,7 @@ public class RecordPostService {
 
     public Page<RecordPost> getMyList(Long authorId, Pageable pageable) {
         User author = userRepository.findById(authorId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         return recordPostRepository.findByAuthorAndDeletedFalse(author, pageable);
     }
 
@@ -59,16 +61,16 @@ public class RecordPostService {
     public void delete(Long postId, Long requesterId) {
         RecordPost post = findActivePostOrThrow(postId);
         if (!post.getAuthor().getId().equals(requesterId)) {
-            throw new IllegalStateException("본인의 게시글만 삭제할 수 있습니다.");
+            throw new GeneralException(ErrorStatus.POST_FORBIDDEN);
         }
         post.softDelete();
     }
 
     private RecordPost findActivePostOrThrow(Long postId) {
         RecordPost post = recordPostRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
         if (post.isDeleted()) {
-            throw new IllegalArgumentException("삭제된 게시글입니다.");
+            throw new GeneralException(ErrorStatus.POST_DELETED);
         }
         return post;
     }

--- a/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.community.post.service;
 import com.semosan.api.domain.community.post.entity.RecordPost;
 import com.semosan.api.domain.community.post.repository.RecordPostRepository;
 import com.semosan.api.domain.hiking.entity.HikingRecord;
+import com.semosan.api.domain.hiking.repository.HikingMemberRepository;
 import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.repository.UserRepository;
@@ -19,6 +20,7 @@ public class RecordPostService {
 
     private final RecordPostRepository recordPostRepository;
     private final HikingRecordRepository hikingRecordRepository;
+    private final HikingMemberRepository hikingMemberRepository;
     private final UserRepository userRepository;
 
     @Transactional
@@ -27,6 +29,10 @@ public class RecordPostService {
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
         HikingRecord hikingRecord = hikingRecordRepository.findById(hikingRecordId)
                 .orElseThrow(() -> new IllegalArgumentException("등산 기록을 찾을 수 없습니다."));
+
+        if (!hikingMemberRepository.existsByHikingRecordAndUser(hikingRecord, author)) {
+            throw new IllegalStateException("본인이 참여한 등산 기록만 공유할 수 있습니다.");
+        }
 
         RecordPost post = RecordPost.create(author, content, hikingRecord);
         return recordPostRepository.save(post);

--- a/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
@@ -1,5 +1,7 @@
 package com.semosan.api.domain.community.post.service;
 
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.post.entity.RecordPost;
 import com.semosan.api.domain.community.post.repository.RecordPostRepository;
 import com.semosan.api.domain.hiking.entity.HikingRecord;
@@ -24,9 +26,9 @@ public class RecordPostService {
     @Transactional
     public RecordPost create(Long authorId, Long hikingRecordId, String content) {
         User author = userRepository.findById(authorId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         HikingRecord hikingRecord = hikingRecordRepository.findById(hikingRecordId)
-                .orElseThrow(() -> new IllegalArgumentException("등산 기록을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.HIKING_RECORD_NOT_FOUND));
 
         RecordPost post = RecordPost.create(author, content, hikingRecord);
         return recordPostRepository.save(post);
@@ -38,7 +40,7 @@ public class RecordPostService {
 
     public Page<RecordPost> getMyList(Long authorId, Pageable pageable) {
         User author = userRepository.findById(authorId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         return recordPostRepository.findByAuthorAndDeletedFalse(author, pageable);
     }
 
@@ -53,16 +55,16 @@ public class RecordPostService {
     public void delete(Long postId, Long requesterId) {
         RecordPost post = findActivePostOrThrow(postId);
         if (!post.getAuthor().getId().equals(requesterId)) {
-            throw new IllegalStateException("본인의 게시글만 삭제할 수 있습니다.");
+            throw new GeneralException(ErrorStatus.POST_FORBIDDEN);
         }
         post.softDelete();
     }
 
     private RecordPost findActivePostOrThrow(Long postId) {
         RecordPost post = recordPostRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
         if (post.isDeleted()) {
-            throw new IllegalArgumentException("삭제된 게시글입니다.");
+            throw new GeneralException(ErrorStatus.POST_DELETED);
         }
         return post;
     }

--- a/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
@@ -1,0 +1,69 @@
+package com.semosan.api.domain.community.post.service;
+
+import com.semosan.api.domain.community.post.entity.RecordPost;
+import com.semosan.api.domain.community.post.repository.RecordPostRepository;
+import com.semosan.api.domain.hiking.entity.HikingRecord;
+import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecordPostService {
+
+    private final RecordPostRepository recordPostRepository;
+    private final HikingRecordRepository hikingRecordRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public RecordPost create(Long authorId, Long hikingRecordId, String content) {
+        User author = userRepository.findById(authorId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+        HikingRecord hikingRecord = hikingRecordRepository.findById(hikingRecordId)
+                .orElseThrow(() -> new IllegalArgumentException("등산 기록을 찾을 수 없습니다."));
+
+        RecordPost post = RecordPost.create(author, content, hikingRecord);
+        return recordPostRepository.save(post);
+    }
+
+    public Page<RecordPost> getList(Pageable pageable) {
+        return recordPostRepository.findAllByDeletedFalse(pageable);
+    }
+
+    public Page<RecordPost> getMyList(Long authorId, Pageable pageable) {
+        User author = userRepository.findById(authorId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+        return recordPostRepository.findByAuthorAndDeletedFalse(author, pageable);
+    }
+
+    @Transactional
+    public RecordPost getDetail(Long postId) {
+        RecordPost post = findActivePostOrThrow(postId);
+        post.increaseViewCount();
+        return post;
+    }
+
+    @Transactional
+    public void delete(Long postId, Long requesterId) {
+        RecordPost post = findActivePostOrThrow(postId);
+        if (!post.getAuthor().getId().equals(requesterId)) {
+            throw new IllegalStateException("본인의 게시글만 삭제할 수 있습니다.");
+        }
+        post.softDelete();
+    }
+
+    private RecordPost findActivePostOrThrow(Long postId) {
+        RecordPost post = recordPostRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+        if (post.isDeleted()) {
+            throw new IllegalArgumentException("삭제된 게시글입니다.");
+        }
+        return post;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/hiking/dto/HikingRecordSummaryResponse.java
+++ b/src/main/java/com/semosan/api/domain/hiking/dto/HikingRecordSummaryResponse.java
@@ -1,0 +1,27 @@
+package com.semosan.api.domain.hiking.dto;
+
+import com.semosan.api.domain.hiking.entity.HikingRecord;
+
+public record HikingRecordSummaryResponse(
+        Long id,
+        String mountainName,
+        String courseName,
+        Integer duration,
+        Double altitude,
+        Integer calories,
+        String cliveImageUrl,
+        String photoReportImageUrl
+) {
+    public static HikingRecordSummaryResponse from(HikingRecord record) {
+        return new HikingRecordSummaryResponse(
+                record.getId(),
+                record.getMountain().getName(),
+                record.getCourse().getName(),
+                record.getDuration(),
+                record.getAltitude(),
+                record.getCalories(),
+                record.getCliveImageUrl(),
+                record.getPhotoReportImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/hiking/entity/HikingMember.java
+++ b/src/main/java/com/semosan/api/domain/hiking/entity/HikingMember.java
@@ -1,0 +1,42 @@
+package com.semosan.api.domain.hiking.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(
+        name = "hiking_members",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_hiking_member_record_user",
+                        columnNames = {"hiking_record_id", "user_id"}
+                )
+        }
+)
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HikingMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hiking_record_id", nullable = false)
+    private HikingRecord hikingRecord;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public static HikingMember create(HikingRecord hikingRecord, User user) {
+        return HikingMember.builder()
+                .hikingRecord(hikingRecord)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/semosan/api/domain/hiking/entity/HikingRecord.java
+++ b/src/main/java/com/semosan/api/domain/hiking/entity/HikingRecord.java
@@ -1,0 +1,66 @@
+package com.semosan.api.domain.hiking.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import com.semosan.api.domain.mountain.entity.Course;
+import com.semosan.api.domain.mountain.entity.Mountain;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "hiking_records")
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HikingRecord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mountain_id", nullable = false)
+    private Mountain mountain;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    /** 실제 소요 시간 (초) */
+    @Column(name = "duration", nullable = false)
+    private Integer duration;
+
+    /** 등산 중 도달한 최고 고도 (m) */
+    @Column(name = "max_altitude", nullable = false)
+    private Double altitude;
+
+    /** 소모 칼로리 (kcal) */
+    @Column(name = "calories", nullable = false)
+    private Integer calories;
+
+    @Column(name = "clive_image_url", length = 500)
+    private String cliveImageUrl;
+
+    @Column(name = "photo_report_image_url", length = 500)
+    private String photoReportImageUrl;
+
+    public static HikingRecord create(
+            Mountain mountain,
+            Course course,
+            Integer duration,
+            Double altitude,
+            Integer calories,
+            String cliveImageUrl,
+            String photoReportImageUrl
+    ) {
+        return HikingRecord.builder()
+                .mountain(mountain)
+                .course(course)
+                .duration(duration)
+                .altitude(altitude)
+                .calories(calories)
+                .cliveImageUrl(cliveImageUrl)
+                .photoReportImageUrl(photoReportImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/semosan/api/domain/hiking/entity/HikingRecord.java
+++ b/src/main/java/com/semosan/api/domain/hiking/entity/HikingRecord.java
@@ -30,7 +30,7 @@ public class HikingRecord extends BaseEntity {
     @Column(name = "duration", nullable = false)
     private Integer duration;
 
-    /** 등산 중 도달한 최고 고도 (m) */
+    /** TODO: 등산 중 도달한 최고 고도 (m)가 맞는지 확인 필요 */
     @Column(name = "max_altitude", nullable = false)
     private Double altitude;
 

--- a/src/main/java/com/semosan/api/domain/hiking/repository/HikingMemberRepository.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/HikingMemberRepository.java
@@ -1,0 +1,19 @@
+package com.semosan.api.domain.hiking.repository;
+
+import com.semosan.api.domain.hiking.entity.HikingMember;
+import com.semosan.api.domain.hiking.entity.HikingRecord;
+import com.semosan.api.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface HikingMemberRepository extends JpaRepository<HikingMember, Long> {
+
+    boolean existsByHikingRecordAndUser(HikingRecord hikingRecord, User user);
+
+    List<HikingMember> findByHikingRecord(HikingRecord hikingRecord);
+
+    Page<HikingMember> findByUser(User user, Pageable pageable);
+}

--- a/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
@@ -1,0 +1,7 @@
+package com.semosan.api.domain.hiking.repository;
+
+import com.semosan.api.domain.hiking.entity.HikingRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HikingRecordRepository extends JpaRepository<HikingRecord, Long> {
+}


### PR DESCRIPTION
## 🧾 요약
- 하이킹 기록 도메인 + 커뮤니티 게시글 추상화 + 기록공유 게시판 추가

## 🔗 이슈
- close #31 

## ✨ 변경 내용
  - 하이킹 기록 도메인 추가 (`HikingRecord`, `HikingMember` + Repository) — User ↔ HikingRecord M:N은 중간 엔티티 명시
  - 게시글 도메인 추상화 (`Post` 추상 부모 + `RecordPost` 자식, JOINED 상속 전략)
  - 댓글/대댓글 모델 추가 (`Comment`, 유저 태그)
  - 좋아요 모델 추가 (`PostLike`)                                                                                                     
  - 기록공유 게시글 API 추가 (CRUD + 댓글/대댓글 + 좋아요 토글)                                                                                                         
  - 댓글/좋아요는 부모 `Post` 참조 

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK