### PR TITLE
[Feat] JWT 토큰 Redis 기반 관리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 ### .DS_Store
 .DS_Store
 ### Sensitive configuration
+.env
 application-local.yaml
 
 ### K8s secrets (contains real credentials)

--- a/src/main/java/com/semosan/api/common/jwt/JwtFilter.java
+++ b/src/main/java/com/semosan/api/common/jwt/JwtFilter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.semosan.api.common.config.SecurityConfig;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.status.ErrorStatus;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -56,6 +57,9 @@ public class JwtFilter extends OncePerRequestFilter {
             // SecurityConfig의 .anyRequest().authenticated()에서 인가 처리됨
             if (accessToken != null) {
                 jwtService.validateAccessToken(accessToken);
+                if (jwtService.isAccessTokenBlacklisted(accessToken)) {
+                    throw new GeneralException(ErrorStatus.JWT_BLACKLISTED);
+                }
                 Long userId = jwtService.getUserIdFromJwtToken(accessToken);
 
                 UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/com/semosan/api/common/jwt/JwtService.java
+++ b/src/main/java/com/semosan/api/common/jwt/JwtService.java
@@ -6,6 +6,7 @@ import com.semosan.api.domain.user.entity.User;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -24,22 +25,24 @@ public class JwtService {
     private final long accessTokenExpiration;
     @Getter
     private final long refreshTokenExpiration;
+    private final TokenRedisService tokenRedisService;
 
     public JwtService(
             @Value("${jwt.secret}") String secret,
             @Value("${jwt.access-token-expiration}") long accessTokenExpiration,
-            @Value("${jwt.refresh-token-expiration}") long refreshTokenExpiration
+            @Value("${jwt.refresh-token-expiration}") long refreshTokenExpiration,
+            TokenRedisService tokenRedisService
     ) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.accessTokenExpiration = accessTokenExpiration;
         this.refreshTokenExpiration = refreshTokenExpiration;
+        this.tokenRedisService = tokenRedisService;
     }
 
-    // 액세스/리프레시 토큰 발급 및 리프레시 토큰 해시 저장
     public TokenIssuance issueTokens(User user) {
         String accessToken = generateAccessToken(user);
         String refreshToken = generateRefreshToken(user);
-        user.updateRefreshToken(hashToken(refreshToken));
+        tokenRedisService.saveRefreshToken(user.getId(), hashToken(refreshToken), refreshTokenExpiration);
         return new TokenIssuance(accessToken, refreshToken);
     }
 
@@ -98,10 +101,28 @@ public class JwtService {
         return parseClaims(refreshToken);
     }
 
-    // Refresh Token DB 저장 해시값과 비교 — 2차 검증용 (서명 검증은 1차에서 완료)
-    public void validateRefreshToken(String refreshToken, String storedHashedToken) {
-        if (!hashToken(refreshToken).equals(storedHashedToken))
+    public void validateRefreshToken(String refreshToken, Long userId) {
+        String storedHash = tokenRedisService.getRefreshToken(userId);
+        if (storedHash == null)
+            throw new GeneralException(ErrorStatus.REFRESH_TOKEN_NOT_FOUND);
+        if (!hashToken(refreshToken).equals(storedHash))
             throw new GeneralException(ErrorStatus.REFRESH_TOKEN_MISMATCH);
+    }
+
+    public void blacklistAccessToken(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+        long remainingMs = claims.getExpiration().getTime() - System.currentTimeMillis();
+        if (remainingMs > 0) {
+            tokenRedisService.addToBlacklist(accessToken, remainingMs);
+        }
+    }
+
+    public boolean isAccessTokenBlacklisted(String accessToken) {
+        return tokenRedisService.isBlacklisted(accessToken);
+    }
+
+    public void deleteRefreshToken(Long userId) {
+        tokenRedisService.deleteRefreshToken(userId);
     }
 
     // AccessToken에서 userId 추출

--- a/src/main/java/com/semosan/api/common/jwt/TokenRedisService.java
+++ b/src/main/java/com/semosan/api/common/jwt/TokenRedisService.java
@@ -1,0 +1,47 @@
+package com.semosan.api.common.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TokenRedisService {
+
+    private static final String REFRESH_KEY_PREFIX = "refresh:";
+    private static final String BLACKLIST_KEY_PREFIX = "blacklist:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void saveRefreshToken(Long userId, String hashedToken, long expirationMs) {
+        redisTemplate.opsForValue().set(
+                REFRESH_KEY_PREFIX + userId,
+                hashedToken,
+                expirationMs,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    public String getRefreshToken(Long userId) {
+        return redisTemplate.opsForValue().get(REFRESH_KEY_PREFIX + userId);
+    }
+
+    public void deleteRefreshToken(Long userId) {
+        redisTemplate.delete(REFRESH_KEY_PREFIX + userId);
+    }
+
+    public void addToBlacklist(String accessToken, long remainingMs) {
+        redisTemplate.opsForValue().set(
+                BLACKLIST_KEY_PREFIX + accessToken,
+                "true",
+                remainingMs,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    public boolean isBlacklisted(String accessToken) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_KEY_PREFIX + accessToken));
+    }
+}

--- a/src/main/java/com/semosan/api/common/status/ErrorStatus.java
+++ b/src/main/java/com/semosan/api/common/status/ErrorStatus.java
@@ -35,9 +35,10 @@ public enum ErrorStatus implements BaseStatus {
     JWT_EXTRACT_ID_FAILED(HttpStatus.UNAUTHORIZED, "JWT_401_7", "토큰에서 사용자 정보를 추출할 수 없습니다."),
     JWT_GENERAL_ERROR(HttpStatus.UNAUTHORIZED, "JWT_401_8", "JWT 토큰 처리 중 알 수 없는 오류가 발생했습니다."),
     JWT_INVALID_TYPE(HttpStatus.UNAUTHORIZED, "JWT_401_9", "토큰 타입이 유효하지 않습니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT_401_10", "DB에 저장된 토큰과 일치하지 않습니다."),
-    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "JWT_401_11", "리프레시 토큰 정보가 사용자 정보와 일치하지 않습니다."),
-    JWT_EXTRACT_ROLE_FAILED(HttpStatus.UNAUTHORIZED, "JWT_401_12", "토큰에서 사용자 Role을 추출할 수 없습니다."),
+    JWT_BLACKLISTED(HttpStatus.UNAUTHORIZED, "JWT_401_10", "로그아웃된 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT_401_11", "리프레시 토큰이 존재하지 않습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "JWT_401_12", "리프레시 토큰 정보가 사용자 정보와 일치하지 않습니다."),
+    JWT_EXTRACT_ROLE_FAILED(HttpStatus.UNAUTHORIZED, "JWT_401_13", "토큰에서 사용자 Role을 추출할 수 없습니다."),
 
     /**
      * Kakao OAuth

--- a/src/main/java/com/semosan/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/semosan/api/domain/auth/controller/AuthController.java
@@ -49,18 +49,22 @@ public class AuthController implements AuthControllerDocs {
     @PostMapping("/logout")
     @Override
     public ResponseEntity<ApiResponse<Void>> logout(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal Long userId,
+            @RequestHeader("Authorization") String authorizationHeader
     ) {
-        authService.logout(userId);
+        String accessToken = resolveToken(authorizationHeader);
+        authService.logout(userId, accessToken);
         return ApiResponse.success(SuccessStatus.LOGOUT_SUCCESS);
     }
 
     @DeleteMapping("/withdraw")
     @Override
     public ResponseEntity<ApiResponse<Void>> withdraw(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal Long userId,
+            @RequestHeader("Authorization") String authorizationHeader
     ) {
-        authService.withdraw(userId);
+        String accessToken = resolveToken(authorizationHeader);
+        authService.withdraw(userId, accessToken);
         return ApiResponse.success(SuccessStatus.WITHDRAW_SUCCESS);
     }
 

--- a/src/main/java/com/semosan/api/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/auth/controller/docs/AuthControllerDocs.java
@@ -67,7 +67,7 @@ public interface AuthControllerDocs {
 
     @Operation(
             summary = "로그아웃",
-            description = "로그인한 사용자의 리프레시 토큰을 무효화합니다."
+            description = "Access Token을 블랙리스트에 등록하고 Refresh Token을 삭제합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -81,7 +81,9 @@ public interface AuthControllerDocs {
             )
     })
     ResponseEntity<ApiResponse<Void>> logout(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "Bearer {accessToken}", required = true)
+            @RequestHeader("Authorization") String authorizationHeader
     );
 
     @Operation(
@@ -100,7 +102,9 @@ public interface AuthControllerDocs {
             )
     })
     ResponseEntity<ApiResponse<Void>> withdraw(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "Bearer {accessToken}", required = true)
+            @RequestHeader("Authorization") String authorizationHeader
     );
 
 }

--- a/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
@@ -11,7 +11,6 @@ import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.service.UserService;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -30,7 +28,6 @@ public class AuthService {
     @Value("${test.secret-key}")
     private String testSecretKey;
 
-    // 시크릿 키 검증 후 테스트 유저 조회/생성 및 JWT 발급
     @Transactional
     public LoginResponse login(LoginRequest request) {
         if (!MessageDigest.isEqual(
@@ -45,34 +42,29 @@ public class AuthService {
         return new LoginResponse(user.getId(), tokens.accessToken(), tokens.refreshToken());
     }
 
-    // 리프레시 토큰 검증 후 새 액세스/리프레시 토큰 발급 (Rotation)
     @Transactional
     public ReissueResponse reissue(String refreshToken) {
         Claims claims = jwtService.validateRefreshTokenSignature(refreshToken);
         Long userId = Long.parseLong(claims.getSubject());
 
         User user = userService.findActiveUserById(userId);
-
-        if (user.getRefreshToken() == null)
-            throw new GeneralException(ErrorStatus.REFRESH_TOKEN_NOT_FOUND);
-        jwtService.validateRefreshToken(refreshToken, user.getRefreshToken());
+        jwtService.validateRefreshToken(refreshToken, userId);
 
         TokenIssuance tokens = jwtService.issueTokens(user);
         return new ReissueResponse(tokens.accessToken(), tokens.refreshToken());
     }
 
-    // 유저 조회 후 soft delete 및 리프레시 토큰 무효화
-    @Transactional
-    public void withdraw(Long userId) {
-        User user = userService.findActiveUserById(userId);
-        user.withdraw();
+    public void logout(Long userId, String accessToken) {
+        jwtService.blacklistAccessToken(accessToken);
+        jwtService.deleteRefreshToken(userId);
     }
 
-    // 유저 조회 후 리프레시 토큰 무효화
     @Transactional
-    public void logout(Long userId) {
+    public void withdraw(Long userId, String accessToken) {
+        jwtService.blacklistAccessToken(accessToken);
+        jwtService.deleteRefreshToken(userId);
         User user = userService.findActiveUserById(userId);
-        user.logout();
+        user.withdraw();
     }
 
 }

--- a/src/main/java/com/semosan/api/domain/user/entity/User.java
+++ b/src/main/java/com/semosan/api/domain/user/entity/User.java
@@ -49,9 +49,6 @@ public class User extends BaseEntity {
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     private OAuthProvider oauthProvider;
 
-    @Column(name = "refresh_token", length = 512)
-    private String refreshToken;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "gender", columnDefinition = "gender_enum")
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
@@ -66,7 +63,6 @@ public class User extends BaseEntity {
     @Column(name = "is_deleted", nullable = false)
     private boolean deleted = false;
 
-    // 카카오 신규 유저 생성
     public static User createKakaoUser(
             String oauthId,
             String email,
@@ -86,7 +82,6 @@ public class User extends BaseEntity {
                 .build();
     }
 
-    // 애플 신규 유저 생성
     public static User createAppleUser(
             String oauthId,
             String email,
@@ -104,7 +99,6 @@ public class User extends BaseEntity {
                 .build();
     }
 
-    // 테스트 유저 생성 (로컬 전용)
     public static User createTestUser(String testUserId, DeviceType deviceType) {
         return User.builder()
                 .oauthId(testUserId)
@@ -117,7 +111,6 @@ public class User extends BaseEntity {
                 .build();
     }
 
-    // 탈퇴한 유저 재가입 처리 — null이면 기존 값 유지 (애플 재가입 시 email 유실 방지)
     public void restore(String email, String name, String profileUrl, DeviceType deviceType) {
         if (email != null) this.email = email;
         if (name != null) this.name = name;
@@ -127,20 +120,8 @@ public class User extends BaseEntity {
         this.deleted = false;
     }
 
-    // 회원 탈퇴 처리
     public void withdraw() {
         this.deleted = true;
-        this.refreshToken = null;
-    }
-
-    // 로그아웃 처리
-    public void logout() {
-        this.refreshToken = null;
-    }
-
-    // 리프레시 토큰 업데이트
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
     }
 
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -11,6 +11,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 jwt:
   secret: ${JWT_SECRET}
@@ -22,6 +26,10 @@ kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI}
   client-secret: ${KAKAO_CLIENT_SECRET}
   admin-key: ${KAKAO_ADMIN_KEY}
+
+tracking:
+  stream-key: ${TRACKING_STREAM_KEY}
+  consumer-group: ${TRACKING_CONSUMER_GROUP}
 
 test:
   secret-key: ${TEST_SECRET_KEY}


### PR DESCRIPTION
## 🧾 요약
- JWT 토큰(Access / Refresh)을 기존 DB 저장 방식에서 Redis 기반으로 전환
- Access Token 블랙리스트, Refresh Token 저장/검증/삭제를 Redis TTL로 관리

## 🔗 이슈
- close #22

## ✨ 변경 내용
- `TokenRedisService` 추가 (Refresh Token 저장/조회/삭제, Access Token 블랙리스트)
- `JwtService`에서 토큰 발급/검증/블랙리스트 로직을 Redis 기반으로 전환
- `JwtFilter`에서 블랙리스트 토큰 요청 차단 (`JWT_BLACKLISTED` 에러)
- 로그아웃/회원탈퇴 시 Access Token 블랙리스트 등록 + Refresh Token 삭제
- `User` 엔티티에서 `refreshToken` 필드 및 관련 메서드 제거
- `ErrorStatus` 코드 정리 (`JWT_BLACKLISTED` 추가, 코드 번호 재정렬)
- `application-prod.yaml`에 Redis 및 Tracking Stream 설정 추가
- `.gitignore`에 `.env` 추가

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK