### PR TITLE
[Feat] 유저 온보딩 검증 추가

### DIFF
--- a/src/main/java/com/semosan/api/common/config/AsyncConfig.java
+++ b/src/main/java/com/semosan/api/common/config/AsyncConfig.java
@@ -24,4 +24,15 @@ public class AsyncConfig {
         // executor.initialize() 호출 안 함 → Spring이 afterPropertiesSet()에서 자동 호출
         return executor;
     }
+
+    @Bean(name = "authCleanupTaskExecutor")
+    public Executor authCleanupTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(8);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("auth-cleanup-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        return executor;
+    }
 }

--- a/src/main/java/com/semosan/api/common/status/ErrorStatus.java
+++ b/src/main/java/com/semosan/api/common/status/ErrorStatus.java
@@ -64,6 +64,7 @@ public enum ErrorStatus implements BaseStatus {
     EXERCISE_DETAIL_REQUIRED(HttpStatus.BAD_REQUEST, "USER_400_9", "운동 빈도와 운동 시간을 입력해야 합니다."),
     EXERCISE_DETAIL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "USER_400_10", "운동 안함 선택 시 운동 빈도와 운동 시간을 입력할 수 없습니다."),
     ONBOARDING_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_3", "온보딩 정보를 찾을 수 없습니다."),
+    ONBOARDING_NOT_COMPLETED(HttpStatus.FORBIDDEN, "USER_403_1", "온보딩을 완료해야 이용할 수 있습니다."),
 
     /**
      * Notification

--- a/src/main/java/com/semosan/api/domain/auth/dispatcher/UserWithdrawCleanupDispatcher.java
+++ b/src/main/java/com/semosan/api/domain/auth/dispatcher/UserWithdrawCleanupDispatcher.java
@@ -1,0 +1,68 @@
+package com.semosan.api.domain.auth.dispatcher;
+
+import com.semosan.api.common.jwt.JwtService;
+import com.semosan.api.domain.auth.event.UserWithdrawCleanupRequestedEvent;
+import com.semosan.api.domain.notification.service.FcmTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserWithdrawCleanupDispatcher {
+
+    private static final int MAX_RETRY_COUNT = 3;
+    private static final long INITIAL_BACKOFF_MS = 200L;
+
+    private final JwtService jwtService;
+    private final FcmTokenService fcmTokenService;
+
+    @Async("authCleanupTaskExecutor")
+    public void dispatch(UserWithdrawCleanupRequestedEvent event) {
+        cleanupWithRetry(event);
+    }
+
+    void cleanupWithRetry(UserWithdrawCleanupRequestedEvent event) {
+        RuntimeException lastFailure = null;
+
+        for (int attempt = 1; attempt <= MAX_RETRY_COUNT; attempt++) {
+            try {
+                fcmTokenService.deleteAllByUserId(event.userId());
+                jwtService.blacklistAccessToken(event.accessToken());
+                jwtService.deleteRefreshToken(event.userId());
+                return;
+            } catch (RuntimeException e) {
+                lastFailure = e;
+                log.warn(
+                        "회원 탈퇴 후 JWT 정리 실패 (attempt={}/{}, userId={}): {}",
+                        attempt,
+                        MAX_RETRY_COUNT,
+                        event.userId(),
+                        e.getMessage()
+                );
+
+                if (attempt < MAX_RETRY_COUNT) {
+                    if (!sleepBackoff(attempt)) {
+                        log.warn("회원 탈퇴 후 JWT/FCM 정리 재시도 중단 (userId={})", event.userId());
+                        return;
+                    }
+                }
+            }
+        }
+
+        log.error("회원 탈퇴 후 JWT/FCM 정리 최종 실패 (userId={})", event.userId(), lastFailure);
+    }
+
+    boolean sleepBackoff(int attempt) {
+        long delayMs = INITIAL_BACKOFF_MS * (1L << (attempt - 1));
+        try {
+            Thread.sleep(delayMs);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/semosan/api/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/semosan/api/domain/auth/dto/response/LoginResponse.java
@@ -1,7 +1,22 @@
 package com.semosan.api.domain.auth.dto.response;
 
+import com.semosan.api.common.jwt.TokenIssuance;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.enums.user.OnboardingStatus;
+
 public record LoginResponse(
         Long userId,
         String accessToken,
-        String refreshToken
-) {}
+        String refreshToken,
+        boolean onboardingCompleted
+) {
+
+    public static LoginResponse from(User user, TokenIssuance tokens) {
+        return new LoginResponse(
+                user.getId(),
+                tokens.accessToken(),
+                tokens.refreshToken(),
+                user.getOnboardingStatus() == OnboardingStatus.COMPLETE
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/auth/event/UserWithdrawCleanupEventListener.java
+++ b/src/main/java/com/semosan/api/domain/auth/event/UserWithdrawCleanupEventListener.java
@@ -1,0 +1,19 @@
+package com.semosan.api.domain.auth.event;
+
+import com.semosan.api.domain.auth.dispatcher.UserWithdrawCleanupDispatcher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class UserWithdrawCleanupEventListener {
+
+    private final UserWithdrawCleanupDispatcher dispatcher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onUserWithdrawCleanupRequested(UserWithdrawCleanupRequestedEvent event) {
+        dispatcher.dispatch(event);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/auth/event/UserWithdrawCleanupRequestedEvent.java
+++ b/src/main/java/com/semosan/api/domain/auth/event/UserWithdrawCleanupRequestedEvent.java
@@ -1,0 +1,4 @@
+package com.semosan.api.domain.auth.event;
+
+public record UserWithdrawCleanupRequestedEvent(Long userId, String accessToken) {
+}

--- a/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
@@ -7,12 +7,14 @@ import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.auth.dto.request.LoginRequest;
 import com.semosan.api.domain.auth.dto.response.LoginResponse;
 import com.semosan.api.domain.auth.dto.response.ReissueResponse;
+import com.semosan.api.domain.auth.event.UserWithdrawCleanupRequestedEvent;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.service.UserReader;
 import com.semosan.api.domain.user.service.UserService;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,7 @@ public class AuthService {
     private final UserService userService;
     private final UserReader userReader;
     private final JwtService jwtService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${test.secret-key}")
     private String testSecretKey;
@@ -64,9 +67,8 @@ public class AuthService {
     @Transactional
     public void withdraw(Long userId, String accessToken) {
         User user = userReader.findActiveUserById(userId);
-        jwtService.blacklistAccessToken(accessToken);
-        jwtService.deleteRefreshToken(userId);
         userService.withdrawUser(user);
+        eventPublisher.publishEvent(new UserWithdrawCleanupRequestedEvent(userId, accessToken));
     }
 
 }

--- a/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
@@ -63,10 +63,10 @@ public class AuthService {
 
     @Transactional
     public void withdraw(Long userId, String accessToken) {
+        User user = userReader.findActiveUserById(userId);
         jwtService.blacklistAccessToken(accessToken);
         jwtService.deleteRefreshToken(userId);
-        User user = userReader.findActiveUserById(userId);
-        user.withdraw();
+        userService.withdrawUser(user);
     }
 
 }

--- a/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/semosan/api/domain/auth/service/AuthService.java
@@ -41,7 +41,7 @@ public class AuthService {
         User user = userService.findOrCreateTestUser(request.testUserId(), request.deviceType());
         TokenIssuance tokens = jwtService.issueTokens(user);
 
-        return new LoginResponse(user.getId(), tokens.accessToken(), tokens.refreshToken());
+        return LoginResponse.from(user, tokens);
     }
 
     @Transactional

--- a/src/main/java/com/semosan/api/domain/hiking/repository/HikingMemberRepository.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/HikingMemberRepository.java
@@ -1,0 +1,14 @@
+package com.semosan.api.domain.hiking.repository;
+
+import com.semosan.api.domain.hiking.entity.HikingMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface HikingMemberRepository extends JpaRepository<HikingMember, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM HikingMember hm WHERE hm.user.id = :userId")
+    void deleteByUser_Id(@Param("userId") Long userId);
+}

--- a/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
@@ -10,7 +10,25 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface HikingRecordRepository extends JpaRepository<HikingRecord, Long> {
+
+    @Query(
+            value = """
+                    SELECT hm.hiking_record_id
+                    FROM hiking_members hm
+                    WHERE hm.user_id = :userId
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM hiking_members other_hm
+                          WHERE other_hm.hiking_record_id = hm.hiking_record_id
+                            AND other_hm.user_id <> :userId
+                      )
+                    """,
+            nativeQuery = true
+    )
+    List<Long> findRecordIdsOnlyParticipatedByUser(@Param("userId") Long userId);
 
     @Query(
             value = """

--- a/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
+++ b/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
@@ -22,7 +22,7 @@ public class HikingRecordService {
     // 유저가 다녀온 산 목록을 산 단위로 묶어 조회합니다.
     @Transactional(readOnly = true)
     public Page<GetUserHikingMountainRecordResponse> getUserHikingMountainRecords(Long userId, Pageable pageable) {
-        userReader.findActiveUserById(userId);
+        userReader.findCompletedOnboardingUserById(userId);
         return hikingRecordRepository.findUserHikingMountainRecordsByUserId(userId, pageable)
                 .map(GetUserHikingMountainRecordResponse::from);
     }
@@ -30,7 +30,7 @@ public class HikingRecordService {
     // 유저의 등산 기록 목록을 기록 단위로 조회합니다.
     @Transactional(readOnly = true)
     public Page<GetUserHikingRecordResponse> getUserHikingRecords(Long userId, Pageable pageable) {
-        userReader.findActiveUserById(userId);
+        userReader.findCompletedOnboardingUserById(userId);
         return hikingRecordRepository.findUserHikingRecordsByUserId(userId, pageable)
                 .map(GetUserHikingRecordResponse::from);
     }
@@ -38,7 +38,7 @@ public class HikingRecordService {
     // 유저의 등산 기록 요약 정보를 조회합니다.
     @Transactional(readOnly = true)
     public GetUserHikingRecordSummaryResponse getUserHikingRecordSummary(Long userId) {
-        userReader.findActiveUserById(userId);
+        userReader.findCompletedOnboardingUserById(userId);
         UserHikingRecordSummaryProjection projection =
                 hikingRecordRepository.findUserHikingRecordSummaryByUserId(userId);
         if (projection == null) {

--- a/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
@@ -27,19 +27,21 @@ public class MountainController implements MountainControllerDocs {
     @GetMapping
     @Override
     public ResponseEntity<ApiResponse<PageResponse<MountainListResponse>>> getMountains(
+            @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 10, sort = "name") Pageable pageable
     ) {
-        PageResponse<MountainListResponse> response = PageResponse.from(mountainService.getMountains(pageable));
+        PageResponse<MountainListResponse> response = PageResponse.from(mountainService.getMountains(userId, pageable));
         return ApiResponse.success(SuccessStatus.MOUNTAIN_LIST_SUCCESS, response);
     }
 
     @GetMapping("/search")
     @Override
     public ResponseEntity<ApiResponse<PageResponse<MountainListResponse>>> searchMountains(
+            @AuthenticationPrincipal Long userId,
             @RequestParam String keyword,
             @PageableDefault(size = 10) Pageable pageable
     ) {
-        PageResponse<MountainListResponse> response = PageResponse.from(mountainService.searchMountains(keyword, pageable));
+        PageResponse<MountainListResponse> response = PageResponse.from(mountainService.searchMountains(userId, keyword, pageable));
         return ApiResponse.success(SuccessStatus.MOUNTAIN_SEARCH_SUCCESS, response);
     }
 
@@ -56,9 +58,10 @@ public class MountainController implements MountainControllerDocs {
     @GetMapping("/{mountainId}")
     @Override
     public ResponseEntity<ApiResponse<MountainDetailResponse>> getMountainDetail(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long mountainId
     ) {
-        MountainDetailResponse response = mountainService.getMountainDetail(mountainId);
+        MountainDetailResponse response = mountainService.getMountainDetail(userId, mountainId);
         return ApiResponse.success(SuccessStatus.MOUNTAIN_DETAIL_SUCCESS, response);
     }
 

--- a/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
@@ -32,6 +32,7 @@ public interface MountainControllerDocs {
             )
     })
     ResponseEntity<ApiResponse<PageResponse<MountainListResponse>>> getMountains(
+            @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 10) Pageable pageable
     );
 
@@ -46,6 +47,7 @@ public interface MountainControllerDocs {
             )
     })
     ResponseEntity<ApiResponse<PageResponse<MountainListResponse>>> searchMountains(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "검색 키워드 (산 이름 또는 주소)", required = true)
             @RequestParam String keyword,
             @PageableDefault(size = 10) Pageable pageable
@@ -82,6 +84,7 @@ public interface MountainControllerDocs {
             )
     })
     ResponseEntity<ApiResponse<MountainDetailResponse>> getMountainDetail(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "산 ID", required = true)
             @PathVariable Long mountainId
     );

--- a/src/main/java/com/semosan/api/domain/mountain/repository/MountainLikeRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/MountainLikeRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,6 +16,10 @@ public interface MountainLikeRepository extends JpaRepository<MountainLike, Long
     boolean existsByUser_IdAndMountain_Id(Long userId, Long mountainId);
 
     Optional<MountainLike> findByUser_IdAndMountain_Id(Long userId, Long mountainId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MountainLike ml WHERE ml.user.id = :userId")
+    void deleteByUser_Id(@Param("userId") Long userId);
 
     @EntityGraph(attributePaths = "mountain")
     @Query(

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
@@ -27,7 +27,7 @@ public class MountainLikeService {
     // 로그인한 사용자가 산에 좋아요를 등록합니다.
     @Transactional
     public void likeMountain(Long userId, Long mountainId) {
-        User user = userReader.findActiveUserById(userId);
+        User user = userReader.findCompletedOnboardingUserById(userId);
         Mountain mountain = findMountainById(mountainId);
         if (mountainLikeRepository.existsByUser_IdAndMountain_Id(userId, mountainId)) {
             throw new GeneralException(ErrorStatus.MOUNTAIN_LIKE_ALREADY_EXISTS);
@@ -44,7 +44,7 @@ public class MountainLikeService {
     @Transactional
     public void unlikeMountain(Long userId, Long mountainId) {
         // 탈퇴 후 남은 access token으로 조회되는 것을 방지합니다.
-        userReader.findActiveUserById(userId);
+        userReader.findCompletedOnboardingUserById(userId);
         MountainLike mountainLike = mountainLikeRepository.findByUser_IdAndMountain_Id(userId, mountainId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MOUNTAIN_LIKE_NOT_FOUND));
         mountainLikeRepository.delete(mountainLike);
@@ -54,7 +54,7 @@ public class MountainLikeService {
     @Transactional(readOnly = true)
     public Page<LikedMountainResponse> getLikedMountains(Long userId, Pageable pageable) {
         // 탈퇴 후 남은 access token으로 조회되는 것을 방지합니다.
-        userReader.findActiveUserById(userId);
+        userReader.findCompletedOnboardingUserById(userId);
         return mountainLikeRepository.findAllByUserId(userId, pageable)
                 .map(LikedMountainResponse::from);
     }

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
@@ -9,6 +9,7 @@ import com.semosan.api.domain.mountain.entity.Mountain;
 import com.semosan.api.domain.mountain.enums.AmenityType;
 import com.semosan.api.domain.mountain.repository.*;
 import com.semosan.api.domain.review.service.ReviewService;
+import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,13 +30,16 @@ public class MountainService {
     private final AmenityRepository amenityRepository;
     private final RestaurantSectionRepository restaurantSectionRepository;
     private final ReviewService reviewService;
+    private final UserReader userReader;
 
-    public Page<MountainListResponse> getMountains(Pageable pageable) {
+    public Page<MountainListResponse> getMountains(Long userId, Pageable pageable) {
+        userReader.findCompletedOnboardingUserById(userId);
         return mountainRepository.findAll(pageable)
                 .map(MountainListResponse::from);
     }
 
-    public Page<MountainListResponse> searchMountains(String keyword, Pageable pageable) {
+    public Page<MountainListResponse> searchMountains(Long userId, String keyword, Pageable pageable) {
+        userReader.findCompletedOnboardingUserById(userId);
         if (keyword == null || keyword.isBlank()) {
             throw new GeneralException(ErrorStatus.BAD_REQUEST);
         }
@@ -43,7 +47,8 @@ public class MountainService {
                 .map(MountainListResponse::from);
     }
 
-    public MountainDetailResponse getMountainDetail(Long mountainId) {
+    public MountainDetailResponse getMountainDetail(Long userId, Long mountainId) {
+        userReader.findCompletedOnboardingUserById(userId);
         Mountain mountain = findMountainById(mountainId);
 
         return new MountainDetailResponse(

--- a/src/main/java/com/semosan/api/domain/notification/repository/FcmTokenRepository.java
+++ b/src/main/java/com/semosan/api/domain/notification/repository/FcmTokenRepository.java
@@ -18,4 +18,8 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     @Modifying
     @Query("DELETE FROM FcmToken f WHERE f.token = :token")
     void deleteByToken(@Param("token") String token);
+
+    @Modifying
+    @Query("DELETE FROM FcmToken f WHERE f.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/semosan/api/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/semosan/api/domain/notification/repository/NotificationRepository.java
@@ -2,10 +2,17 @@ package com.semosan.api.domain.notification.repository;
 
 import com.semosan.api.domain.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 // TODO: 알림판 구현할 때 쓸 예정
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Notification n WHERE n.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/semosan/api/domain/notification/service/FcmTokenService.java
+++ b/src/main/java/com/semosan/api/domain/notification/service/FcmTokenService.java
@@ -5,6 +5,7 @@ import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.notification.entity.FcmToken;
 import com.semosan.api.domain.notification.repository.FcmTokenRepository;
 import com.semosan.api.domain.user.enums.user.DeviceType;
+import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class FcmTokenService {
 
     private final FcmTokenRepository fcmTokenRepository;
+    private final UserReader userReader;
 
     /**
      * 토큰 등록
@@ -23,6 +25,7 @@ public class FcmTokenService {
      */
     @Transactional
     public void register(Long userId, String token, DeviceType deviceType) {
+        userReader.findActiveUserById(userId);
         fcmTokenRepository.findByToken(token).ifPresentOrElse(
                 existing -> existing.reassignTo(userId, deviceType),
                 () -> fcmTokenRepository.save(FcmToken.create(userId, token, deviceType))
@@ -35,6 +38,7 @@ public class FcmTokenService {
      */
     @Transactional
     public void delete(Long userId, String token) {
+        userReader.findActiveUserById(userId);
         fcmTokenRepository.findByToken(token).ifPresent(fcmToken -> {
             if (!fcmToken.getUserId().equals(userId)) {
                 throw new GeneralException(ErrorStatus.FORBIDDEN);

--- a/src/main/java/com/semosan/api/domain/notification/service/FcmTokenService.java
+++ b/src/main/java/com/semosan/api/domain/notification/service/FcmTokenService.java
@@ -51,4 +51,12 @@ public class FcmTokenService {
     public void deleteExpired(String token) {
         fcmTokenRepository.deleteByToken(token);
     }
+
+    /**
+     * 회원 탈퇴 시 해당 유저의 모든 FCM 토큰을 정리합니다.
+     */
+    @Transactional
+    public void deleteAllByUserId(Long userId) {
+        fcmTokenRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/semosan/api/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/semosan/api/domain/notification/service/NotificationService.java
@@ -43,7 +43,7 @@ public class NotificationService {
      */
     @Transactional
     public void send(Long receiverId, NotificationType type, Map<String, Object> params) {
-        if (!userRepository.existsById(receiverId)) {
+        if (!userRepository.existsByIdAndDeletedFalse(receiverId)) {
             throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
         }
 

--- a/src/main/java/com/semosan/api/domain/oauth/dto/response/OAuthLoginResponse.java
+++ b/src/main/java/com/semosan/api/domain/oauth/dto/response/OAuthLoginResponse.java
@@ -1,7 +1,22 @@
 package com.semosan.api.domain.oauth.dto.response;
 
+import com.semosan.api.common.jwt.TokenIssuance;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.enums.user.OnboardingStatus;
+
 public record OAuthLoginResponse(
         Long userId,
         String accessToken,
-        String refreshToken
-) {}
+        String refreshToken,
+        boolean onboardingCompleted
+) {
+
+    public static OAuthLoginResponse from(User user, TokenIssuance tokens) {
+        return new OAuthLoginResponse(
+                user.getId(),
+                tokens.accessToken(),
+                tokens.refreshToken(),
+                user.getOnboardingStatus() == OnboardingStatus.COMPLETE
+        );
+    }
+}

--- a/src/main/java/com/semosan/api/domain/oauth/service/OAuthService.java
+++ b/src/main/java/com/semosan/api/domain/oauth/service/OAuthService.java
@@ -42,7 +42,7 @@ public class OAuthService {
         User user = userService.findOrRegisterKakaoUser(kakaoId, email, name, profileUrl, request.deviceType());
 
         TokenIssuance tokens = jwtService.issueTokens(user);
-        return new OAuthLoginResponse(user.getId(), tokens.accessToken(), tokens.refreshToken());
+        return OAuthLoginResponse.from(user, tokens);
     }
 
     @Transactional
@@ -55,7 +55,7 @@ public class OAuthService {
         User user = userService.findOrRegisterAppleUser(appleId, email, request.name(), request.deviceType());
 
         TokenIssuance tokens = jwtService.issueTokens(user);
-        return new OAuthLoginResponse(user.getId(), tokens.accessToken(), tokens.refreshToken());
+        return OAuthLoginResponse.from(user, tokens);
     }
 
 }

--- a/src/main/java/com/semosan/api/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/semosan/api/domain/review/repository/ReviewRepository.java
@@ -3,12 +3,17 @@ package com.semosan.api.domain.review.repository;
 import com.semosan.api.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Review r WHERE r.user.id = :userId")
+    void deleteByUser_Id(@Param("userId") Long userId);
 
     @EntityGraph(attributePaths = {"user", "course"})
     @Query("SELECT r FROM Review r WHERE r.mountain.id = :mountainId ORDER BY r.createdAt DESC LIMIT :limit")

--- a/src/main/java/com/semosan/api/domain/user/entity/User.java
+++ b/src/main/java/com/semosan/api/domain/user/entity/User.java
@@ -130,11 +130,20 @@ public class User extends BaseEntity {
         if (name != null) this.name = name;
         if (profileUrl != null) this.profileUrl = profileUrl;
         this.deviceType = deviceType;
-        this.onboardingStatus = OnboardingStatus.INCOMPLETE;
         this.deleted = false;
     }
 
     public void withdraw() {
+        this.email = null;
+        this.name = null;
+        this.nickname = null;
+        this.profileUrl = null;
+        this.gender = null;
+        this.age = null;
+        this.birthDate = null;
+        this.height = null;
+        this.weight = null;
+        this.onboardingStatus = OnboardingStatus.INCOMPLETE;
         this.deleted = true;
     }
 

--- a/src/main/java/com/semosan/api/domain/user/repository/UserNotificationSettingRepository.java
+++ b/src/main/java/com/semosan/api/domain/user/repository/UserNotificationSettingRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserNotificationSettingRepository extends JpaRepository<UserNotificationSetting, Long> {
 
     Optional<UserNotificationSetting> findByUser_Id(Long userId);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/com/semosan/api/domain/user/repository/UserOnboardingRepository.java
+++ b/src/main/java/com/semosan/api/domain/user/repository/UserOnboardingRepository.java
@@ -10,4 +10,6 @@ public interface UserOnboardingRepository extends JpaRepository<UserOnboarding, 
     boolean existsByUser_Id(Long userId);
 
     Optional<UserOnboarding> findByUser_Id(Long userId);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/com/semosan/api/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/semosan/api/domain/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByIdAndDeletedFalse(Long id);
 
     boolean existsByNicknameAndDeletedFalse(String nickname);
+
+    boolean existsByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/com/semosan/api/domain/user/service/UserNotificationSettingService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserNotificationSettingService.java
@@ -40,13 +40,13 @@ public class UserNotificationSettingService {
     // 로그인한 사용자의 알림 설정을 조회합니다.
     @Transactional(readOnly = true)
     public GetNotificationSettingResponse getNotificationSetting(Long userId) {
-        userReader.findActiveUserById(userId);
+        userReader.findCompletedOnboardingUserById(userId);
         return GetNotificationSettingResponse.from(findSetting(userId));
     }
 
     // 사용자 알림 설정을 조회한 뒤 전달받은 변경 동작을 적용합니다.
     private void updateSetting(Long userId, Consumer<UserNotificationSetting> updater) {
-        userReader.findActiveUserById(userId);
+        userReader.findCompletedOnboardingUserById(userId);
         UserNotificationSetting setting = findSetting(userId);
         updater.accept(setting);
     }

--- a/src/main/java/com/semosan/api/domain/user/service/UserReader.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserReader.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.user.service;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.enums.user.OnboardingStatus;
 import com.semosan.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -18,5 +19,13 @@ public class UserReader {
     public User findActiveUserById(Long userId) {
         return userRepository.findByIdAndDeletedFalse(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    public User findCompletedOnboardingUserById(Long userId) {
+        User user = findActiveUserById(userId);
+        if (user.getOnboardingStatus() != OnboardingStatus.COMPLETE) {
+            throw new GeneralException(ErrorStatus.ONBOARDING_NOT_COMPLETED);
+        }
+        return user;
     }
 }

--- a/src/main/java/com/semosan/api/domain/user/service/UserService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserService.java
@@ -34,8 +34,10 @@ public class UserService {
     ) {
         return userRepository.findByOauthIdAndOauthProvider(kakaoId, OAuthProvider.KAKAO)
                 .map(user -> {
-                    if (user.isDeleted())
+                    if (user.isDeleted()) {
                         user.restore(email, name, profileUrl, deviceType);
+                        ensureNotificationSetting(user);
+                    }
                     return user;
                 })
                 .orElseGet(() -> saveNewUserWithNotificationSetting(
@@ -48,8 +50,10 @@ public class UserService {
     public User findOrRegisterAppleUser(String appleId, String email, String name, DeviceType deviceType) {
         return userRepository.findByOauthIdAndOauthProvider(appleId, OAuthProvider.APPLE)
                 .map(user -> {
-                    if (user.isDeleted())
+                    if (user.isDeleted()) {
                         user.restore(email, name, null, deviceType);
+                        ensureNotificationSetting(user);
+                    }
                     return user;
                 })
                 .orElseGet(() -> saveNewUserWithNotificationSetting(
@@ -61,6 +65,13 @@ public class UserService {
     @Transactional
     public User findOrCreateTestUser(String testUserId, DeviceType deviceType) {
         return userRepository.findByOauthIdAndOauthProvider(testUserId, OAuthProvider.TEST)
+                .map(user -> {
+                    if (user.isDeleted()) {
+                        user.restore(null, null, null, deviceType);
+                        ensureNotificationSetting(user);
+                    }
+                    return user;
+                })
                 .orElseGet(() -> saveNewUserWithNotificationSetting(User.createTestUser(testUserId, deviceType)));
     }
 
@@ -70,6 +81,11 @@ public class UserService {
         // 온보딩 권한 설정 초기화 전에 항상 기본 알림 설정 row가 존재하도록 생성합니다.
         userNotificationSettingRepository.save(UserNotificationSetting.createDefault(savedUser));
         return savedUser;
+    }
+
+    private void ensureNotificationSetting(User user) {
+        userNotificationSettingRepository.findByUser_Id(user.getId())
+                .orElseGet(() -> userNotificationSettingRepository.save(UserNotificationSetting.createDefault(user)));
     }
 
     // 닉네임 사용 가능 여부를 조회합니다.
@@ -123,6 +139,18 @@ public class UserService {
         if (request.exerciseType() != null) {
             userOnboarding.updateExerciseType(request.exerciseType());
         }
+    }
+
+    // 로그인한 사용자를 탈퇴 처리하고 하위 데이터를 삭제합니다.
+    @Transactional
+    public void withdrawUser(User user) {
+        deleteUserChildRecords(user.getId());
+        user.withdraw();
+    }
+
+    private void deleteUserChildRecords(Long userId) {
+        userOnboardingRepository.deleteByUser_Id(userId);
+        userNotificationSettingRepository.deleteByUser_Id(userId);
     }
 
     // 프로필 수정 요청 값을 User 엔티티 갱신용 command로 변환합니다.

--- a/src/main/java/com/semosan/api/domain/user/service/UserService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserService.java
@@ -84,7 +84,7 @@ public class UserService {
     public void updateUserProfile(Long userId, UpdateUserProfileRequest request) {
         validateProfileUpdateRequest(request);
         validateNicknameIfPresent(request.nickname());
-        User user = userReader.findActiveUserById(userId);
+        User user = userReader.findCompletedOnboardingUserById(userId);
         user.updateProfile(toUpdateUserProfileCommand(request));
         updateUserOnboardingProfile(userId, request);
     }

--- a/src/main/java/com/semosan/api/domain/user/service/UserService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserService.java
@@ -2,6 +2,11 @@ package com.semosan.api.domain.user.service;
 
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.hiking.repository.HikingMemberRepository;
+import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
+import com.semosan.api.domain.mountain.repository.MountainLikeRepository;
+import com.semosan.api.domain.notification.repository.NotificationRepository;
+import com.semosan.api.domain.review.repository.ReviewRepository;
 import com.semosan.api.domain.user.dto.command.UpdateUserProfileCommand;
 import com.semosan.api.domain.user.dto.request.UpdateUserProfileRequest;
 import com.semosan.api.domain.user.entity.User;
@@ -17,6 +22,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -24,6 +31,11 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserNotificationSettingRepository userNotificationSettingRepository;
     private final UserOnboardingRepository userOnboardingRepository;
+    private final MountainLikeRepository mountainLikeRepository;
+    private final ReviewRepository reviewRepository;
+    private final HikingMemberRepository hikingMemberRepository;
+    private final HikingRecordRepository hikingRecordRepository;
+    private final NotificationRepository notificationRepository;
     private final NicknamePolicy nicknamePolicy;
     private final UserReader userReader;
 
@@ -148,6 +160,14 @@ public class UserService {
     }
 
     private void deleteUserChildRecords(Long userId) {
+        mountainLikeRepository.deleteByUser_Id(userId);
+        reviewRepository.deleteByUser_Id(userId);
+        List<Long> recordIdsToDelete = hikingRecordRepository.findRecordIdsOnlyParticipatedByUser(userId);
+        hikingMemberRepository.deleteByUser_Id(userId);
+        if (!recordIdsToDelete.isEmpty()) {
+            hikingRecordRepository.deleteAllByIdInBatch(recordIdsToDelete);
+        }
+        notificationRepository.deleteAllByUserId(userId);
         userOnboardingRepository.deleteByUser_Id(userId);
         userNotificationSettingRepository.deleteByUser_Id(userId);
     }

--- a/src/main/java/com/semosan/api/domain/user/service/UserService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserService.java
@@ -84,8 +84,7 @@ public class UserService {
     }
 
     private void ensureNotificationSetting(User user) {
-        userNotificationSettingRepository.findByUser_Id(user.getId())
-                .orElseGet(() -> userNotificationSettingRepository.save(UserNotificationSetting.createDefault(user)));
+        userNotificationSettingRepository.save(UserNotificationSetting.createDefault(user));
     }
 
     // 닉네임 사용 가능 여부를 조회합니다.

--- a/src/test/java/com/semosan/api/domain/auth/dispatcher/UserWithdrawCleanupDispatcherTest.java
+++ b/src/test/java/com/semosan/api/domain/auth/dispatcher/UserWithdrawCleanupDispatcherTest.java
@@ -1,0 +1,60 @@
+package com.semosan.api.domain.auth.dispatcher;
+
+import com.semosan.api.common.jwt.JwtService;
+import com.semosan.api.domain.auth.event.UserWithdrawCleanupRequestedEvent;
+import com.semosan.api.domain.notification.service.FcmTokenService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class UserWithdrawCleanupDispatcherTest {
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private FcmTokenService fcmTokenService;
+
+    @InjectMocks
+    private UserWithdrawCleanupDispatcher dispatcher;
+
+    @Test
+    void cleanupWithRetry_retriesOnceWhenJwtFails() {
+        UserWithdrawCleanupRequestedEvent event = new UserWithdrawCleanupRequestedEvent(1L, "access-token");
+
+        doNothing().when(fcmTokenService).deleteAllByUserId(1L);
+        doThrow(new RuntimeException("redis down"))
+                .doNothing()
+                .when(jwtService).blacklistAccessToken("access-token");
+        doNothing().when(jwtService).deleteRefreshToken(1L);
+
+        assertDoesNotThrow(() -> dispatcher.cleanupWithRetry(event));
+
+        verify(jwtService, times(2)).blacklistAccessToken("access-token");
+        verify(jwtService, times(1)).deleteRefreshToken(1L);
+        verify(fcmTokenService, times(2)).deleteAllByUserId(1L);
+    }
+
+    @Test
+    void sleepBackoff_returnsFalseWhenInterrupted() {
+        Thread.currentThread().interrupt();
+
+        try {
+            assertFalse(dispatcher.sleepBackoff(1));
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+}

--- a/src/test/java/com/semosan/api/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/user/service/UserServiceTest.java
@@ -1,0 +1,86 @@
+package com.semosan.api.domain.user.service;
+
+import com.semosan.api.domain.hiking.repository.HikingMemberRepository;
+import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
+import com.semosan.api.domain.mountain.repository.MountainLikeRepository;
+import com.semosan.api.domain.notification.repository.NotificationRepository;
+import com.semosan.api.domain.review.repository.ReviewRepository;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.enums.user.DeviceType;
+import com.semosan.api.domain.user.enums.user.OnboardingStatus;
+import com.semosan.api.domain.user.policy.NicknamePolicy;
+import com.semosan.api.domain.user.repository.UserNotificationSettingRepository;
+import com.semosan.api.domain.user.repository.UserOnboardingRepository;
+import com.semosan.api.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserNotificationSettingRepository userNotificationSettingRepository;
+
+    @Mock
+    private UserOnboardingRepository userOnboardingRepository;
+
+    @Mock
+    private MountainLikeRepository mountainLikeRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private HikingMemberRepository hikingMemberRepository;
+
+    @Mock
+    private HikingRecordRepository hikingRecordRepository;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NicknamePolicy nicknamePolicy;
+
+    @Mock
+    private UserReader userReader;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void withdrawUserDeletesUserChildRecordsAndSoftDeletesUser() {
+        User user = User.createTestUser("withdraw-test-user", DeviceType.IOS);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        when(hikingRecordRepository.findRecordIdsOnlyParticipatedByUser(1L)).thenReturn(List.of(10L, 11L));
+
+        userService.withdrawUser(user);
+
+        verify(mountainLikeRepository).deleteByUser_Id(1L);
+        verify(reviewRepository).deleteByUser_Id(1L);
+        verify(hikingRecordRepository).findRecordIdsOnlyParticipatedByUser(1L);
+        verify(hikingMemberRepository).deleteByUser_Id(1L);
+        verify(hikingRecordRepository).deleteAllByIdInBatch(List.of(10L, 11L));
+        verify(notificationRepository).deleteAllByUserId(1L);
+        verify(userOnboardingRepository).deleteByUser_Id(1L);
+        verify(userNotificationSettingRepository).deleteByUser_Id(1L);
+
+        assertThat(user.isDeleted()).isTrue();
+        assertThat(user.getEmail()).isNull();
+        assertThat(user.getName()).isNull();
+        assertThat(user.getOnboardingStatus()).isEqualTo(OnboardingStatus.INCOMPLETE);
+    }
+}


### PR DESCRIPTION
 ## 🧾 요약
  - 소셜 로그인 응답에 온보딩 완료 여부를 추가하고, 온보딩 미완료 사용자는 주요 기능에 접근할 수 없도록 정리
  - 탈퇴 후 재가입 시 기존 데이터가 이어지지 않도록 탈퇴/복구 흐름과 하위 데이터 정리 정책을 맞추기
  - https://discord.com/channels/1489850871650058484/1503275795454365817 참고

  ## 🔗 이슈
  - close #39

  ## ✨ 변경 내용
  - 로그인 응답(`OAuthLoginResponse`, `LoginResponse`)에 `onboardingCompleted` 추가
  - `UserReader`에 온보딩 완료 사용자 검증 메서드  (`findCompletedOnboardingUserById`)를 추가
  - 등산 기록, 산 목록/검색/상세, 산 좋아요, 알림 설정, 프로필 수정에서 온보딩 완료 여부를 검증하도록 적용
  - 탈퇴 시 `user_onboardings`, `user_notification_settings`를 삭제하고, `User`는  soft delete 처리하도록 정리
  - 재가입 시 복구 흐름이 다시 동작하도록 `restore()`/`withdraw()` 정책 수정
  - 탈퇴 처리 책임을 `AuthService`에서 `UserService`로 위임해 계층 책임을 정리

  ## ✅ 확인
  - [x] 빌드 OK
  - [x] 테스트 OK
  
<img width="1406" height="522" alt="image" src="https://github.com/user-attachments/assets/eee260b9-6572-475a-9ec9-ab11658c8b1c" />
