### PR TITLE
[Feat] MinIO 이미지 Presigned URL API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ application-local.yaml
 ### K8s secrets (contains real credentials)
 k8s/app/secret.yaml
 k8s/postgres/secret.yaml
+k8s/minio/secret.yaml
 
 # OMC
 .omc

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	// Swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
 
+	// MinIO
+	implementation 'io.minio:minio:8.5.17'
+
 	// JWT 라이브러리 (jjwt)
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
   - redis/deployment.yaml
   - redis/service.yaml
   - redis/pvc.yaml
+  - minio/deployment.yaml
+  - minio/service.yaml
 images:
   - name: ghcr.io/semosan/semosan_be
     newTag: d478edb1ff6f35bd62da2ca5902af0b38a4914fe

--- a/k8s/minio/deployment.yaml
+++ b/k8s/minio/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: semosan
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          args:
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+          ports:
+            - containerPort: 9000
+            - containerPort: 9001
+          envFrom:
+            - secretRef:
+                name: minio-secret
+          volumeMounts:
+            - name: minio-data
+              mountPath: /data
+      nodeSelector:
+        kubernetes.io/hostname: k8s-master
+      volumes:
+        - name: minio-data
+          hostPath:
+            path: /data/minio
+            type: DirectoryOrCreate

--- a/k8s/minio/service.yaml
+++ b/k8s/minio/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: semosan
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001

--- a/src/main/java/com/semosan/api/common/config/MinioConfig.java
+++ b/src/main/java/com/semosan/api/common/config/MinioConfig.java
@@ -1,0 +1,51 @@
+package com.semosan.api.common.config;
+
+import io.minio.BucketExistsArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Slf4j
+@Configuration
+public class MinioConfig {
+
+    private static final List<String> REQUIRED_BUCKETS = List.of("reviews", "mountains", "restaurants");
+
+    @Value("${minio.endpoint}")
+    private String endpoint;
+
+    @Value("${minio.access-key}")
+    private String accessKey;
+
+    @Value("${minio.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public MinioClient minioClient() {
+        return MinioClient.builder()
+                .endpoint(endpoint)
+                .credentials(accessKey, secretKey)
+                .build();
+    }
+
+    @PostConstruct
+    public void initBuckets() {
+        MinioClient client = minioClient();
+        for (String bucket : REQUIRED_BUCKETS) {
+            try {
+                if (!client.bucketExists(BucketExistsArgs.builder().bucket(bucket).build())) {
+                    client.makeBucket(MakeBucketArgs.builder().bucket(bucket).build());
+                    log.info("MinIO 버킷 생성: {}", bucket);
+                }
+            } catch (Exception e) {
+                log.warn("MinIO 버킷 초기화 실패: {} - {}", bucket, e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/semosan/api/common/config/MinioConfig.java
+++ b/src/main/java/com/semosan/api/common/config/MinioConfig.java
@@ -1,6 +1,6 @@
 package com.semosan.api.common.config;
 
-import com.semosan.api.domain.image.service.ImageService;
+import com.semosan.api.domain.image.constant.ImageConstants;
 import io.minio.BucketExistsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
@@ -30,7 +30,7 @@ public class MinioConfig {
     @PostConstruct
     public void initBuckets() {
         MinioClient client = minioClient();
-        for (String bucket : ImageService.ALLOWED_BUCKETS) {
+        for (String bucket : ImageConstants.ALLOWED_BUCKETS) {
             try {
                 if (!client.bucketExists(BucketExistsArgs.builder().bucket(bucket).build())) {
                     client.makeBucket(MakeBucketArgs.builder().bucket(bucket).build());

--- a/src/main/java/com/semosan/api/common/config/MinioConfig.java
+++ b/src/main/java/com/semosan/api/common/config/MinioConfig.java
@@ -1,5 +1,6 @@
 package com.semosan.api.common.config;
 
+import com.semosan.api.domain.image.service.ImageService;
 import io.minio.BucketExistsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
@@ -9,13 +10,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
-
 @Slf4j
 @Configuration
 public class MinioConfig {
-
-    private static final List<String> REQUIRED_BUCKETS = List.of("reviews", "mountains", "restaurants");
 
     @Value("${minio.endpoint}")
     private String endpoint;
@@ -37,7 +34,7 @@ public class MinioConfig {
     @PostConstruct
     public void initBuckets() {
         MinioClient client = minioClient();
-        for (String bucket : REQUIRED_BUCKETS) {
+        for (String bucket : ImageService.ALLOWED_BUCKETS) {
             try {
                 if (!client.bucketExists(BucketExistsArgs.builder().bucket(bucket).build())) {
                     client.makeBucket(MakeBucketArgs.builder().bucket(bucket).build());

--- a/src/main/java/com/semosan/api/common/config/MinioConfig.java
+++ b/src/main/java/com/semosan/api/common/config/MinioConfig.java
@@ -5,29 +5,25 @@ import io.minio.BucketExistsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Slf4j
 @Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(MinioProperties.class)
 public class MinioConfig {
 
-    @Value("${minio.endpoint}")
-    private String endpoint;
-
-    @Value("${minio.access-key}")
-    private String accessKey;
-
-    @Value("${minio.secret-key}")
-    private String secretKey;
+    private final MinioProperties properties;
 
     @Bean
     public MinioClient minioClient() {
         return MinioClient.builder()
-                .endpoint(endpoint)
-                .credentials(accessKey, secretKey)
+                .endpoint(properties.endpoint())
+                .credentials(properties.accessKey(), properties.secretKey())
                 .build();
     }
 

--- a/src/main/java/com/semosan/api/common/config/MinioProperties.java
+++ b/src/main/java/com/semosan/api/common/config/MinioProperties.java
@@ -1,0 +1,11 @@
+package com.semosan.api.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "minio")
+public record MinioProperties(
+        String endpoint,
+        String accessKey,
+        String secretKey,
+        String publicUrl
+) {}

--- a/src/main/java/com/semosan/api/common/config/SecurityConfig.java
+++ b/src/main/java/com/semosan/api/common/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3000", "https://lgenius.site"));
+        config.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:8081", "https://lgenius.site"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/src/main/java/com/semosan/api/common/status/ErrorStatus.java
+++ b/src/main/java/com/semosan/api/common/status/ErrorStatus.java
@@ -70,6 +70,8 @@ public enum ErrorStatus implements BaseStatus {
     /**
      * Image
      */
+    INVALID_IMAGE_BUCKET(HttpStatus.BAD_REQUEST, "IMG_400_1", "허용되지 않은 버킷입니다."),
+    INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "IMG_400_2", "허용되지 않은 이미지 확장자입니다. (jpg, jpeg, png, webp)"),
     IMAGE_UPLOAD_FAILED(HttpStatus.BAD_GATEWAY, "IMG_502_1", "이미지 업로드 URL 생성에 실패했습니다."),
 
     /**

--- a/src/main/java/com/semosan/api/domain/image/constant/ImageConstants.java
+++ b/src/main/java/com/semosan/api/domain/image/constant/ImageConstants.java
@@ -1,0 +1,18 @@
+package com.semosan.api.domain.image.constant;
+
+import java.util.Map;
+import java.util.Set;
+
+public final class ImageConstants {
+
+    private ImageConstants() {}
+
+    public static final Set<String> ALLOWED_BUCKETS = Set.of("reviews", "mountains", "restaurants", "posts", "semofeed");
+    public static final Set<String> ALLOWED_EXTENSIONS = Set.of(".jpg", ".jpeg", ".png", ".webp");
+    public static final Map<String, String> CONTENT_TYPE_MAP = Map.of(
+            ".jpg", "image/jpeg",
+            ".jpeg", "image/jpeg",
+            ".png", "image/png",
+            ".webp", "image/webp"
+    );
+}

--- a/src/main/java/com/semosan/api/domain/image/controller/ImageController.java
+++ b/src/main/java/com/semosan/api/domain/image/controller/ImageController.java
@@ -1,0 +1,31 @@
+package com.semosan.api.domain.image.controller;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.image.controller.docs.ImageControllerDocs;
+import com.semosan.api.domain.image.dto.response.PresignedUrlResponse;
+import com.semosan.api.domain.image.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class ImageController implements ImageControllerDocs {
+
+    private final ImageService imageService;
+
+    @GetMapping("/presigned-url")
+    @Override
+    public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+            @RequestParam String bucket,
+            @RequestParam String filename
+    ) {
+        PresignedUrlResponse response = imageService.generatePresignedUrl(bucket, filename);
+        return ApiResponse.success(SuccessStatus.PRESIGNED_URL_SUCCESS, response);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/image/controller/docs/ImageControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/image/controller/docs/ImageControllerDocs.java
@@ -1,0 +1,38 @@
+package com.semosan.api.domain.image.controller.docs;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.domain.image.dto.response.PresignedUrlResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Image", description = "이미지 업로드 관련 API")
+public interface ImageControllerDocs {
+
+    @Operation(
+            summary = "Presigned URL 발급",
+            description = "이미지 업로드를 위한 Presigned URL을 발급합니다. 발급된 URL로 PUT 요청하여 직접 업로드합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "Presigned URL 발급 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "502",
+                    description = "이미지 업로드 URL 생성 실패",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+            @Parameter(description = "버킷명 (reviews, mountains, restaurants)", required = true)
+            @RequestParam String bucket,
+            @Parameter(description = "원본 파일명 (확장자 추출용)", required = true)
+            @RequestParam String filename
+    );
+}

--- a/src/main/java/com/semosan/api/domain/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/semosan/api/domain/image/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,7 @@
+package com.semosan.api.domain.image.dto.response;
+
+public record PresignedUrlResponse(
+        String uploadUrl,
+        String imageUrl
+) {
+}

--- a/src/main/java/com/semosan/api/domain/image/service/ImageService.java
+++ b/src/main/java/com/semosan/api/domain/image/service/ImageService.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class ImageService {
 
-    private static final Set<String> ALLOWED_BUCKETS = Set.of("reviews", "mountains", "restaurants");
+    public static final Set<String> ALLOWED_BUCKETS = Set.of("reviews", "mountains", "restaurants", "posts", "semofeed");
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of(".jpg", ".jpeg", ".png", ".webp");
 
     private final MinioClient minioClient;
@@ -57,13 +57,13 @@ public class ImageService {
 
     private void validateBucket(String bucket) {
         if (bucket == null || !ALLOWED_BUCKETS.contains(bucket)) {
-            throw new GeneralException(ErrorStatus.BAD_REQUEST);
+            throw new GeneralException(ErrorStatus.INVALID_IMAGE_BUCKET);
         }
     }
 
     private void validateExtension(String extension) {
         if (extension.isEmpty() || !ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
-            throw new GeneralException(ErrorStatus.BAD_REQUEST);
+            throw new GeneralException(ErrorStatus.INVALID_IMAGE_EXTENSION);
         }
     }
 

--- a/src/main/java/com/semosan/api/domain/image/service/ImageService.java
+++ b/src/main/java/com/semosan/api/domain/image/service/ImageService.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.image.service;
 import com.semosan.api.common.config.MinioProperties;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.image.constant.ImageConstants;
 import com.semosan.api.domain.image.dto.response.PresignedUrlResponse;
 import io.minio.GetPresignedObjectUrlArgs;
 import io.minio.MinioClient;
@@ -11,22 +12,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 public class ImageService {
-
-    public static final Set<String> ALLOWED_BUCKETS = Set.of("reviews", "mountains", "restaurants", "posts", "semofeed");
-    private static final Set<String> ALLOWED_EXTENSIONS = Set.of(".jpg", ".jpeg", ".png", ".webp");
-    private static final Map<String, String> CONTENT_TYPE_MAP = Map.of(
-            ".jpg", "image/jpeg",
-            ".jpeg", "image/jpeg",
-            ".png", "image/png",
-            ".webp", "image/webp"
-    );
 
     private final MinioClient minioClient;
     private final MinioProperties minioProperties;
@@ -39,7 +30,7 @@ public class ImageService {
         String key = UUID.randomUUID() + extension;
 
         try {
-            String contentType = CONTENT_TYPE_MAP.get(extension.toLowerCase());
+            String contentType = ImageConstants.CONTENT_TYPE_MAP.get(extension.toLowerCase());
             String uploadUrl = minioClient.getPresignedObjectUrl(
                     GetPresignedObjectUrlArgs.builder()
                             .method(Method.PUT)
@@ -60,13 +51,13 @@ public class ImageService {
     }
 
     private void validateBucket(String bucket) {
-        if (bucket == null || !ALLOWED_BUCKETS.contains(bucket)) {
+        if (bucket == null || !ImageConstants.ALLOWED_BUCKETS.contains(bucket)) {
             throw new GeneralException(ErrorStatus.INVALID_IMAGE_BUCKET);
         }
     }
 
     private void validateExtension(String extension) {
-        if (extension.isEmpty() || !ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
+        if (extension.isEmpty() || !ImageConstants.ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
             throw new GeneralException(ErrorStatus.INVALID_IMAGE_EXTENSION);
         }
     }

--- a/src/main/java/com/semosan/api/domain/image/service/ImageService.java
+++ b/src/main/java/com/semosan/api/domain/image/service/ImageService.java
@@ -1,5 +1,6 @@
 package com.semosan.api.domain.image.service;
 
+import com.semosan.api.common.config.MinioProperties;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.image.dto.response.PresignedUrlResponse;
@@ -7,9 +8,9 @@ import io.minio.GetPresignedObjectUrlArgs;
 import io.minio.MinioClient;
 import io.minio.http.Method;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -20,14 +21,15 @@ public class ImageService {
 
     public static final Set<String> ALLOWED_BUCKETS = Set.of("reviews", "mountains", "restaurants", "posts", "semofeed");
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of(".jpg", ".jpeg", ".png", ".webp");
+    private static final Map<String, String> CONTENT_TYPE_MAP = Map.of(
+            ".jpg", "image/jpeg",
+            ".jpeg", "image/jpeg",
+            ".png", "image/png",
+            ".webp", "image/webp"
+    );
 
     private final MinioClient minioClient;
-
-    @Value("${minio.endpoint}")
-    private String endpoint;
-
-    @Value("${minio.public-url}")
-    private String publicUrl;
+    private final MinioProperties minioProperties;
 
     public PresignedUrlResponse generatePresignedUrl(String bucket, String filename) {
         validateBucket(bucket);
@@ -37,17 +39,19 @@ public class ImageService {
         String key = UUID.randomUUID() + extension;
 
         try {
+            String contentType = CONTENT_TYPE_MAP.get(extension.toLowerCase());
             String uploadUrl = minioClient.getPresignedObjectUrl(
                     GetPresignedObjectUrlArgs.builder()
                             .method(Method.PUT)
                             .bucket(bucket)
                             .object(key)
                             .expiry(10, TimeUnit.MINUTES)
+                            .extraHeaders(Map.of("Content-Type", contentType))
                             .build()
             );
 
-            uploadUrl = uploadUrl.replace(endpoint, publicUrl);
-            String imageUrl = publicUrl + "/" + bucket + "/" + key;
+            uploadUrl = uploadUrl.replace(minioProperties.endpoint(), minioProperties.publicUrl());
+            String imageUrl = minioProperties.publicUrl() + "/" + bucket + "/" + key;
 
             return new PresignedUrlResponse(uploadUrl, imageUrl);
         } catch (Exception e) {

--- a/src/main/java/com/semosan/api/domain/image/service/ImageService.java
+++ b/src/main/java/com/semosan/api/domain/image/service/ImageService.java
@@ -1,0 +1,76 @@
+package com.semosan.api.domain.image.service;
+
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.image.dto.response.PresignedUrlResponse;
+import io.minio.GetPresignedObjectUrlArgs;
+import io.minio.MinioClient;
+import io.minio.http.Method;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private static final Set<String> ALLOWED_BUCKETS = Set.of("reviews", "mountains", "restaurants");
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of(".jpg", ".jpeg", ".png", ".webp");
+
+    private final MinioClient minioClient;
+
+    @Value("${minio.endpoint}")
+    private String endpoint;
+
+    @Value("${minio.public-url}")
+    private String publicUrl;
+
+    public PresignedUrlResponse generatePresignedUrl(String bucket, String filename) {
+        validateBucket(bucket);
+        String extension = extractExtension(filename);
+        validateExtension(extension);
+
+        String key = UUID.randomUUID() + extension;
+
+        try {
+            String uploadUrl = minioClient.getPresignedObjectUrl(
+                    GetPresignedObjectUrlArgs.builder()
+                            .method(Method.PUT)
+                            .bucket(bucket)
+                            .object(key)
+                            .expiry(10, TimeUnit.MINUTES)
+                            .build()
+            );
+
+            uploadUrl = uploadUrl.replace(endpoint, publicUrl);
+            String imageUrl = publicUrl + "/" + bucket + "/" + key;
+
+            return new PresignedUrlResponse(uploadUrl, imageUrl);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+    private void validateBucket(String bucket) {
+        if (bucket == null || !ALLOWED_BUCKETS.contains(bucket)) {
+            throw new GeneralException(ErrorStatus.BAD_REQUEST);
+        }
+    }
+
+    private void validateExtension(String extension) {
+        if (extension.isEmpty() || !ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
+            throw new GeneralException(ErrorStatus.BAD_REQUEST);
+        }
+    }
+
+    private String extractExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return "";
+        }
+        return filename.substring(filename.lastIndexOf("."));
+    }
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -12,6 +12,12 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+minio:
+  endpoint: ${MINIO_ENDPOINT}
+  access-key: ${MINIO_ACCESS_KEY}
+  secret-key: ${MINIO_SECRET_KEY}
+  public-url: ${MINIO_PUBLIC_URL}
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,10 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
   jpa:
     hibernate:
       ddl-auto: update
@@ -30,11 +34,6 @@ kakao:
   client-secret: ${KAKAO_CLIENT_SECRET}
   admin-key: ${KAKAO_ADMIN_KEY}
 
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-
 tracking:
   stream-key: ${TRACKING_STREAM_KEY}
   consumer-group: ${TRACKING_CONSUMER_GROUP}
@@ -48,3 +47,9 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
   default-flat-param-object: true
+
+minio:
+  endpoint: ${MINIO_ENDPOINT}
+  access-key: ${MINIO_ACCESS_KEY}
+  secret-key: ${MINIO_SECRET_KEY}
+  public-url: ${MINIO_PUBLIC_URL}


### PR DESCRIPTION
## 🧾 요약
- MinIO 연동을 통한 이미지 업로드(Presigned URL) API 구현 및 도메인별 버킷 분리

## 🔗 이슈
- close #38

## ✨ 변경 내용
- `MinioConfig` 추가 (MinioClient 빈 생성 + 앱 시작 시 버킷 자동 생성)
- 도메인별 버킷 분리 (`reviews`, `mountains`, `restaurants`)
- `ImageService` — bucket 파라미터로 대상 버킷 선택, Presigned PUT URL 발급
- `ImageController` — `GET /api/images/presigned-url?bucket=&filename=`
- 파일 확장자 검증 (jpg, jpeg, png, webp)
- `application.yaml`, `application-prod.yaml`에 MinIO 설정 추가
- K8s MinIO deployment/service 매니페스트 추가
- `.gitignore`에 `k8s/minio/secret.yaml` 추가

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK