### PR TITLE
[Refactor] 산 이미지 URL 리스트 형식으로 변경

### DIFF
--- a/src/main/java/com/semosan/api/domain/mountain/dto/response/LikedMountainResponse.java
+++ b/src/main/java/com/semosan/api/domain/mountain/dto/response/LikedMountainResponse.java
@@ -4,15 +4,16 @@ import com.semosan.api.domain.mountain.entity.Mountain;
 import com.semosan.api.domain.mountain.entity.MountainLike;
 import com.semosan.api.domain.mountain.enums.Difficulty;
 
+import java.util.List;
+
 public record LikedMountainResponse(
         Long mountainId,
         String name,
         String address,
         Double altitude,
         Difficulty difficulty,
-        String imageUrl
+        List<String> imageUrls
 ) {
-    // 좋아요한 산 정보로 응답 DTO를 생성합니다.
     public static LikedMountainResponse from(MountainLike mountainLike) {
         Mountain mountain = mountainLike.getMountain();
         return new LikedMountainResponse(
@@ -21,7 +22,7 @@ public record LikedMountainResponse(
                 mountain.getAddress(),
                 mountain.getAltitude(),
                 mountain.getDifficulty(),
-                mountain.getImageUrl()
+                mountain.getImageUrls()
         );
     }
 }

--- a/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainDetailResponse.java
+++ b/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainDetailResponse.java
@@ -26,7 +26,7 @@ public record MountainDetailResponse(
             Double altitude,
             Difficulty difficulty,
             Integer duration,
-            String imageUrl
+            List<String> imageUrls
     ) {
         public static MountainInfo from(Mountain mountain) {
             return new MountainInfo(
@@ -36,7 +36,7 @@ public record MountainDetailResponse(
                     mountain.getAltitude(),
                     mountain.getDifficulty(),
                     mountain.getDuration(),
-                    mountain.getImageUrl()
+                    mountain.getImageUrls()
             );
         }
     }

--- a/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainListResponse.java
+++ b/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainListResponse.java
@@ -3,6 +3,8 @@ package com.semosan.api.domain.mountain.dto.response;
 import com.semosan.api.domain.mountain.entity.Mountain;
 import com.semosan.api.domain.mountain.enums.Difficulty;
 
+import java.util.List;
+
 public record MountainListResponse(
         Long mountainId,
         String name,
@@ -10,7 +12,7 @@ public record MountainListResponse(
         Double altitude,
         Difficulty difficulty,
         Integer duration,
-        String imageUrl,
+        List<String> imageUrls,
         Double latitude,
         Double longitude
 ) {
@@ -23,7 +25,7 @@ public record MountainListResponse(
                 mountain.getAltitude(),
                 mountain.getDifficulty(),
                 mountain.getDuration(),
-                mountain.getImageUrl(),
+                mountain.getImageUrls(),
                 mountain.getLatitude(),
                 mountain.getLongitude()
         );

--- a/src/main/java/com/semosan/api/domain/mountain/entity/Mountain.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/Mountain.java
@@ -4,6 +4,10 @@ import com.semosan.api.common.base.BaseEntity;
 import com.semosan.api.domain.mountain.enums.Difficulty;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.List;
 
 @Table(name = "mountains")
 @Getter
@@ -33,8 +37,9 @@ public class Mountain extends BaseEntity {
     @Column(name = "duration")
     private Integer duration;
 
-    @Column(name = "image_url", length = 500)
-    private String imageUrl;
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "image_urls", columnDefinition = "jsonb")
+    private List<String> imageUrls;
 
     @Column(name = "latitude")
     private Double latitude;


### PR DESCRIPTION
## 🧾 요약
- 산 목록/상세/좋아요 조회 시 이미지를 단일 URL이 아닌 리스트(`List<String>`) 형식으로 변경
- 썸네일은 `imageUrls[0]` 사용

## 🔗 이슈
- close #42

## ✨ 변경 내용
- `Mountain` 엔티티의 `imageUrl` (varchar) → `imageUrls` (jsonb, `List<String>`) 변경
- `MountainListResponse` 응답 필드 `imageUrl` → `imageUrls` 변경
- `MountainDetailResponse.MountainInfo` 응답 필드 `imageUrl` → `imageUrls` 변경
- `LikedMountainResponse` 응답 필드 `imageUrl` → `imageUrls` 변경

## ⚠️ 참고
- DB 컬럼 타입 변경(`image_url` varchar → `image_urls` jsonb)에 따른 기존 데이터 마이그레이션 필요
- `ddl-auto: update`로 컬럼은 자동 생성되지만, 기존 데이터 변환은 수동 SQL 필요

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK