### PR TITLE
[Hotfix]#56 Presigned URL PUT 403 수정

### DIFF
--- a/src/main/java/com/semosan/api/domain/image/service/ImageService.java
+++ b/src/main/java/com/semosan/api/domain/image/service/ImageService.java
@@ -11,7 +11,6 @@ import io.minio.http.Method;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -30,14 +29,12 @@ public class ImageService {
         String key = UUID.randomUUID() + extension;
 
         try {
-            String contentType = ImageConstants.CONTENT_TYPE_MAP.get(extension.toLowerCase());
             String uploadUrl = minioClient.getPresignedObjectUrl(
                     GetPresignedObjectUrlArgs.builder()
                             .method(Method.PUT)
                             .bucket(bucket)
                             .object(key)
                             .expiry(10, TimeUnit.MINUTES)
-                            .extraHeaders(Map.of("Content-Type", contentType))
                             .build()
             );
 


### PR DESCRIPTION
## 🧾 요약
- Presigned URL PUT 업로드 시 403 Forbidden 오류 수정 — extraHeaders Content-Type 서명 제거

## 🔗 이슈
- close #56

## ✨ 변경 내용
- `ImageService.generatePresignedUrl()`에서 `extraHeaders(Content-Type)` 서명 제거
- 클라이언트가 PUT 요청 시 Content-Type 불일치로 인한 SignatureDoesNotMatch 해결

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image upload URL generation for enhanced compatibility with storage service configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->