### PR TITLE
[Fix] 산림청 이미지 URL http → https 마이그레이션

### DIFF
--- a/src/main/resources/db/migration/V4__fix_mountain_image_url_https.sql
+++ b/src/main/resources/db/migration/V4__fix_mountain_image_url_https.sql
@@ -1,0 +1,12 @@
+-- =====================================================================
+-- V4__fix_mountain_image_url_https.sql
+-- 목적: V3 시드의 산림청 이미지 URL(http) 를 https 로 일괄 치환.
+--        iOS ATS / 브라우저 mixed content 차단 회피.
+-- 대상: forest.go.kr 도메인의 http URL 만 (관악·북한·도봉 9건).
+--        위키미디어(청계·수락·인왕·아차) 는 이미 https 라 무영향.
+-- 멱등: WHERE 절이 http 패턴만 잡으므로 재실행해도 noop.
+-- =====================================================================
+
+UPDATE mountains
+SET image_urls = REPLACE(image_urls::text, 'http://www.forest.go.kr', 'https://www.forest.go.kr')::jsonb
+WHERE image_urls::text LIKE '%http://www.forest.go.kr%';


### PR DESCRIPTION
## 🧾 요약
- http 로 이미지 https로 교체

## 🔗 이슈
- close #

## ✨ 변경 내용
- http 로 이미지 https로 교체

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated mountain image URLs to use secure HTTPS connections for safer and more reliable image loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->