### PR TITLE
[Fix] #75 getNearbyMountain 메소드 파라미터 제약 수정

### DIFF
--- a/src/main/java/com/semosan/api/domain/tracking/controller/TrackingController.java
+++ b/src/main/java/com/semosan/api/domain/tracking/controller/TrackingController.java
@@ -5,8 +5,6 @@ import com.semosan.api.common.status.SuccessStatus;
 import com.semosan.api.domain.tracking.controller.docs.TrackingControllerDocs;
 import com.semosan.api.domain.tracking.dto.response.NearbyMountainResponse;
 import com.semosan.api.domain.tracking.service.TrackingService;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -34,8 +32,8 @@ public class TrackingController implements TrackingControllerDocs {
     @Override
     public ResponseEntity<ApiResponse<NearbyMountainResponse>> getNearbyMountain(
             @AuthenticationPrincipal Long userId,
-            @RequestParam @Min(-90) @Max(90) Double lat,
-            @RequestParam @Min(-180) @Max(180) Double lng
+            @RequestParam Double lat,
+            @RequestParam Double lng
     ) {
         NearbyMountainResponse response = trackingService.getNearbyMountain(userId, lat, lng);
         return ApiResponse.success(SuccessStatus.TRACKING_NEAREST_MOUNTAIN_SUCCESS, response);

--- a/src/main/java/com/semosan/api/domain/tracking/controller/docs/TrackingControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/tracking/controller/docs/TrackingControllerDocs.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,8 +37,8 @@ public interface TrackingControllerDocs {
             @Parameter(hidden = true)
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "현재 위치 위도", required = true)
-            @RequestParam Double lat,
+            @RequestParam @Min(-90) @Max(90) Double lat,
             @Parameter(description = "현재 위치 경도", required = true)
-            @RequestParam Double lng
+            @RequestParam @Min(-180) @Max(180) Double lng
     );
 }


### PR DESCRIPTION
## 🧾 요약
- getNearbyMountain 메소드 파라미터 제약 수정

## 🔗 이슈
- close #75 

## ✨ 변경 내용
- 오버라이딩하는 함수의 파라미터에는 제약을 넣을 수없다


## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized validation constraints for geographic coordinate parameters in the nearby mountain lookup functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->