### PR TITLE
[Hotfix]#77 Swagger MountainInfo 스키마 충돌 해소

### DIFF
--- a/src/main/java/com/semosan/api/domain/tracking/dto/response/NearbyMountainResponse.java
+++ b/src/main/java/com/semosan/api/domain/tracking/dto/response/NearbyMountainResponse.java
@@ -7,18 +7,18 @@ import com.semosan.api.domain.mountain.enums.Difficulty;
 import java.util.List;
 
 public record NearbyMountainResponse(
-        MountainInfo mountain,
+        NearbyMountainInfo mountain,
         List<CourseInfo> courses
 ) {
 
     public static NearbyMountainResponse of(Mountain mountain, List<Course> courses) {
         return new NearbyMountainResponse(
-                MountainInfo.from(mountain),
+                NearbyMountainInfo.from(mountain),
                 courses.stream().map(CourseInfo::from).toList()
         );
     }
 
-    public record MountainInfo(
+    public record NearbyMountainInfo(
             Long mountainId,
             String name,
             String address,
@@ -27,8 +27,8 @@ public record NearbyMountainResponse(
             Double longitude,
             List<String> imageUrls
     ) {
-        public static MountainInfo from(Mountain mountain) {
-            return new MountainInfo(
+        public static NearbyMountainInfo from(Mountain mountain) {
+            return new NearbyMountainInfo(
                     mountain.getId(),
                     mountain.getName(),
                     mountain.getAddress(),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,6 +52,7 @@ springdoc:
     tags-sorter: alpha
     operations-sorter: alpha
   default-flat-param-object: true
+  use-enum-ref: true
 
 minio:
   endpoint: ${MINIO_ENDPOINT}


### PR DESCRIPTION
## 🧾 요약
- Swagger 스키마에서 MountainInfo 이름 충돌로 difficulty, duration 필드 누락 수정

## 🔗 이슈
- close #77

## ✨ 변경 내용
- `NearbyMountainResponse.MountainInfo` → `NearbyMountainInfo`로 이름 변경하여 스키마 충돌 해소
- `application.yaml`에 `springdoc.use-enum-ref: true` 추가하여 enum 타입 Swagger에 노출

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation generation for enum types in Swagger/OpenAPI specifications

* **Refactor**
  * Internal code structure improvements to response data handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->