### PR TITLE
[Fix] JwtFilter 가 WebSocket 핸드셰이크에서 토큰 검증해 401 반환하는 문제 수정

### DIFF
--- a/src/main/java/com/semosan/api/common/jwt/JwtFilter.java
+++ b/src/main/java/com/semosan/api/common/jwt/JwtFilter.java
@@ -32,9 +32,16 @@ public class JwtFilter extends OncePerRequestFilter {
     private final JwtService jwtService;
     private final ObjectMapper objectMapper;
 
-    // SecurityConfig의 permitAll 경로와 동일하게 맞춰줍니다
+    // SecurityConfig의 permitAll 경로와 동일하게 맞춰줍니다.
+    // WebSocket 핸드셰이크(/ws/tracking)는 HTTP JWT 필터 우회 — STOMP CONNECT 프레임의
+    // StompAuthChannelInterceptor 가 별도로 인증한다.
     private static final List<PathPatternRequestMatcher> EXCLUDED_PATHS =
-            Stream.of(SecurityConfig.SWAGGER_URIS, SecurityConfig.OAUTH_URIS, SecurityConfig.AUTH_URIS)
+            Stream.of(
+                            SecurityConfig.SWAGGER_URIS,
+                            SecurityConfig.OAUTH_URIS,
+                            SecurityConfig.AUTH_URIS,
+                            SecurityConfig.WEBSOCKET_URIS
+                    )
                     .flatMap(Arrays::stream)
                     .map(PathPatternRequestMatcher.withDefaults()::matcher)
                     .toList();


### PR DESCRIPTION
## 🧾 요약
- JwtFilter 가 WebSocket 핸드셰이크에서 토큰 검증해 401 반환하는 문제 수정

## 🔗 이슈
- close #82 

## ✨ 변경 내용
- JwtFilter 가 WebSocket 핸드셰이크에서 토큰 검증해 401 반환하는 문제 수

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where WebSocket connections were being incorrectly processed by the authentication filter, ensuring WebSocket handshake requests can now be properly established without authentication delays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->