### PR TITLE
[Feat] 자유게시판 키워드 검색 API 및 목록 응답 개선

### DIFF
--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -109,7 +109,8 @@ public enum SuccessStatus implements BaseStatus {
     FREE_POST_LIST_SUCCESS(HttpStatus.OK, "FPOST_200_1", "자유게시판 게시글 목록 조회에 성공했습니다."),
     FREE_POST_MY_LIST_SUCCESS(HttpStatus.OK, "FPOST_200_2", "내 자유게시판 게시글 목록 조회에 성공했습니다."),
     FREE_POST_DETAIL_SUCCESS(HttpStatus.OK, "FPOST_200_3", "자유게시판 게시글 상세 조회에 성공했습니다."),
-    FREE_POST_DELETE_SUCCESS(HttpStatus.OK, "FPOST_200_4", "자유게시판 게시글이 삭제되었습니다.");
+    FREE_POST_DELETE_SUCCESS(HttpStatus.OK, "FPOST_200_4", "자유게시판 게시글이 삭제되었습니다."),
+    FREE_POST_SEARCH_SUCCESS(HttpStatus.OK, "FPOST_200_5", "자유게시판 게시글 검색에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/semosan/api/domain/community/post/controller/FreePostController.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/FreePostController.java
@@ -49,6 +49,17 @@ public class FreePostController implements FreePostControllerDocs {
         );
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<PageResponse<FreePostListResponse>>> search(
+            @RequestParam String keyword,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ApiResponse.success(
+                SuccessStatus.FREE_POST_SEARCH_SUCCESS,
+                PageResponse.from(freePostService.search(keyword, pageable))
+        );
+    }
+
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<PageResponse<FreePostListResponse>>> getMyList(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/semosan/api/domain/community/post/controller/docs/FreePostControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/docs/FreePostControllerDocs.java
@@ -35,6 +35,15 @@ public interface FreePostControllerDocs {
     })
     ResponseEntity<ApiResponse<PageResponse<FreePostListResponse>>> getList(Pageable pageable);
 
+    @Operation(summary = "자유게시판 검색", description = "제목/내용 기반 키워드 검색. 최신순 페이징.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색 성공")
+    })
+    ResponseEntity<ApiResponse<PageResponse<FreePostListResponse>>> search(
+            String keyword,
+            Pageable pageable
+    );
+
     @Operation(summary = "내 자유게시판 목록", description = "내가 쓴 자유게시판 게시글 목록.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")

--- a/src/main/java/com/semosan/api/domain/community/post/dto/AuthorResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/AuthorResponse.java
@@ -4,20 +4,19 @@ import com.semosan.api.domain.user.entity.User;
 
 public record AuthorResponse(
         Long id,
-        String name,
+        String nickname,
         String profileUrl,
         boolean isDeleted
 ) {
 
-    //TODO: 앱 정책에 따라서 탈퇴한 회원 이름 어떻게 보내줄지 결정되면 통일하기
-    private static final String DELETED_USER_NAME = "탈퇴한 사용자";
-    private static final String UNKNOWN_USER_NAME = "이름없음";
+    private static final String DELETED_USER_NICKNAME = "탈퇴한 사용자";
+    private static final String UNKNOWN_USER_NICKNAME = "이름없음";
 
     public static AuthorResponse from(User user) {
         if (user.isDeleted()) {
-            return new AuthorResponse(user.getId(), DELETED_USER_NAME, null, true);
+            return new AuthorResponse(user.getId(), DELETED_USER_NICKNAME, null, true);
         }
-        String name = user.getName() != null ? user.getName() : UNKNOWN_USER_NAME;
-        return new AuthorResponse(user.getId(), name, user.getProfileUrl(), false);
+        String nickname = user.getNickname() != null ? user.getNickname() : UNKNOWN_USER_NICKNAME;
+        return new AuthorResponse(user.getId(), nickname, user.getProfileUrl(), false);
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/post/dto/FreePostListResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/FreePostListResponse.java
@@ -10,6 +10,7 @@ public record FreePostListResponse(
         String title,
         String contentPreview,
         String thumbnailUrl,
+        Integer extraImageCount,
         Long likeCount,
         Long commentCount,
         LocalDateTime createdAt
@@ -19,6 +20,7 @@ public record FreePostListResponse(
     public static FreePostListResponse from(
             FreePost post,
             String thumbnailUrl,
+            Integer extraImageCount,
             long likeCount,
             long commentCount
     ) {
@@ -28,6 +30,7 @@ public record FreePostListResponse(
                 post.getTitle(),
                 preview(post.getContent()),
                 thumbnailUrl,
+                extraImageCount != null && extraImageCount > 1 ? extraImageCount - 1 : null,
                 likeCount,
                 commentCount,
                 post.getCreatedAt()

--- a/src/main/java/com/semosan/api/domain/community/post/dto/FreePostListResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/FreePostListResponse.java
@@ -9,8 +9,7 @@ public record FreePostListResponse(
         AuthorResponse author,
         String title,
         String contentPreview,
-        String representativeImageUrl,
-        Integer viewCount,
+        String thumbnailUrl,
         Long likeCount,
         Long commentCount,
         LocalDateTime createdAt
@@ -19,7 +18,7 @@ public record FreePostListResponse(
 
     public static FreePostListResponse from(
             FreePost post,
-            String representativeImageUrl,
+            String thumbnailUrl,
             long likeCount,
             long commentCount
     ) {
@@ -28,8 +27,7 @@ public record FreePostListResponse(
                 AuthorResponse.from(post.getAuthor()),
                 post.getTitle(),
                 preview(post.getContent()),
-                representativeImageUrl,
-                post.getViewCount(),
+                thumbnailUrl,
                 likeCount,
                 commentCount,
                 post.getCreatedAt()

--- a/src/main/java/com/semosan/api/domain/community/post/repository/FreePostRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/FreePostRepository.java
@@ -5,10 +5,19 @@ import com.semosan.api.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FreePostRepository extends JpaRepository<FreePost, Long> {
 
     Page<FreePost> findAllByDeletedFalse(Pageable pageable);
 
     Page<FreePost> findByAuthorAndDeletedFalse(User author, Pageable pageable);
+
+    @Query("SELECT fp FROM FreePost fp " +
+            "WHERE fp.deleted = false " +
+            "AND (LOWER(fp.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(fp.content) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+            "ORDER BY fp.createdAt DESC")
+    Page<FreePost> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/semosan/api/domain/community/post/repository/PostImageRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/PostImageRepository.java
@@ -14,4 +14,7 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
     @Query("SELECT pi FROM PostImage pi WHERE pi.post.id IN :postIds AND pi.main = true")
     List<PostImage> findMainImagesByPostIds(@Param("postIds") List<Long> postIds);
+
+    @Query("SELECT pi.post.id, COUNT(pi) FROM PostImage pi WHERE pi.post.id IN :postIds GROUP BY pi.post.id")
+    List<Object[]> countByPostIdsGrouped(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -61,8 +61,11 @@ public class FreePostService {
     }
 
     public Page<FreePostListResponse> search(String keyword, Pageable pageable) {
+        if (keyword == null || keyword.isBlank()) {
+            return Page.empty(pageable);
+        }
         Pageable unsorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        return enrichWithCounts(freePostRepository.searchByKeyword(keyword, unsorted));
+        return enrichWithCounts(freePostRepository.searchByKeyword(keyword.strip(), unsorted));
     }
 
     public Page<FreePostListResponse> getMyList(Long authorId, Pageable pageable) {

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -119,10 +119,13 @@ public class FreePostService {
                 .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
         Map<Long, String> mainImageMap = postImageRepository.findMainImagesByPostIds(postIds).stream()
                 .collect(Collectors.toMap(img -> img.getPost().getId(), PostImage::getImageUrl));
+        Map<Long, Long> imageCountMap = postImageRepository.countByPostIdsGrouped(postIds).stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
 
         return posts.map(post -> FreePostListResponse.from(
                 post,
                 mainImageMap.get(post.getId()),
+                imageCountMap.getOrDefault(post.getId(), 0L).intValue(),
                 likeCountMap.getOrDefault(post.getId(), 0L),
                 commentCountMap.getOrDefault(post.getId(), 0L)
         ));

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -14,6 +14,7 @@ import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,6 +58,11 @@ public class FreePostService {
 
     public Page<FreePostListResponse> getList(Pageable pageable) {
         return enrichWithCounts(freePostRepository.findAllByDeletedFalse(pageable));
+    }
+
+    public Page<FreePostListResponse> search(String keyword, Pageable pageable) {
+        Pageable unsorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+        return enrichWithCounts(freePostRepository.searchByKeyword(keyword, unsorted));
     }
 
     public Page<FreePostListResponse> getMyList(Long authorId, Pageable pageable) {

--- a/src/main/resources/db/migration/V13__add_free_post_search_index.sql
+++ b/src/main/resources/db/migration/V13__add_free_post_search_index.sql
@@ -1,0 +1,17 @@
+-- =====================================================================
+-- V13__add_free_post_search_index.sql
+-- 목적: 자유게시판 제목/내용 검색 성능을 위한 pg_trgm GIN 인덱스
+-- =====================================================================
+
+-- 1) pg_trgm extension 활성화
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- 2) 제목 검색용 GIN 인덱스
+CREATE INDEX IF NOT EXISTS idx_free_post_title_trgm
+    ON free_posts
+    USING GIN (title gin_trgm_ops);
+
+-- 3) 본문 검색용 GIN 인덱스
+CREATE INDEX IF NOT EXISTS idx_post_content_trgm
+    ON posts
+    USING GIN (content gin_trgm_ops);


### PR DESCRIPTION
## 🧾 요약
- 자유게시판 제목/내용 키워드 검색 API 추가 및 목록 응답 DTO 개선

## 🔗 이슈
- close #84

## ✨ 변경 내용
- 자유게시판 키워드 검색 API 추가 (JPQL, pg_trgm GIN 인덱스)
- AuthorResponse: name → nickname 변경
- 목록 응답에서 viewCount 제거, representativeImageUrl → thumbnailUrl 변경
- 썸네일 제외 추가 이미지 개수(extraImageCount) 반환
- 빈 키워드 검증 추가
- V13 검색 인덱스 마이그레이션 추가

## ✅ 확인
- [x] 빌드 OK
- [x] 로컬 검색 API 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyword-based search for free posts with paginated results.
  * Post list display now shows thumbnail images and image count instead of view count.
  * Author profiles now display nicknames.

* **Chores**
  * Optimized search performance with database indexing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->