### PR TITLE
[Fix] 코스 마일스톤 거리 계산 단위 오류 (km  → m 통일)

### DIFF
--- a/src/main/java/com/semosan/api/domain/mountain/entity/Course.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/Course.java
@@ -29,9 +29,11 @@ public class Course extends BaseEntity {
     @Column(name = "difficulty", nullable = false, length = 20)
     private Difficulty difficulty;
 
+    /** 코스 총 거리. 단위: 미터(m). 시드/응답/마일스톤 계산 모두 m 기준 일관. */
     @Column(name = "distance", nullable = false)
     private Double distance;
 
+    /** 코스 소요 시간. 단위: 분. */
     @Column(name = "duration", nullable = false)
     private Integer duration;
 

--- a/src/main/java/com/semosan/api/domain/tracking/service/TrackingMilestoneCalculator.java
+++ b/src/main/java/com/semosan/api/domain/tracking/service/TrackingMilestoneCalculator.java
@@ -9,10 +9,11 @@ import java.util.List;
 
 /**
  * 트래킹 세션의 사진 촬영 마일스톤 거리 리스트를 계산한다.
- *  - 코스 따라가기: course.distance(km) → m 변환 후 1/4, 2/4, 3/4, 4/4 (총 4컷)
+ *  - 코스 따라가기: course.distance(미터) 의 1/4, 2/4, 3/4, 4/4 지점 (총 4컷)
  *  - 자유 기록: 500m 간격, 정책상 최대 6컷 (500/1000/1500/2000/2500/3000m)
  *
- * 모든 반환 단위는 미터(m). distanceTotal(Haversine) 과 단위 일치.
+ * 단위 정책: 입력/출력 모두 미터(m). distanceTotal(Haversine 누적, m) 과 비교될 값이라 단위 일치 필수.
+ * 과거: course.distance 를 km 로 가정하고 × 1000 했으나, DB/시드/응답이 모두 m 단위라 마일스톤이 1000배로 박혀 OPEN 이 영영 안 오는 버그가 있었음.
  */
 @Component
 public class TrackingMilestoneCalculator {
@@ -20,7 +21,6 @@ public class TrackingMilestoneCalculator {
     private static final int COURSE_MILESTONE_COUNT = 4;
     private static final double FREE_RECORDING_INTERVAL_METERS = 500.0;
     private static final int FREE_RECORDING_MAX_COUNT = 6;
-    private static final double KM_TO_M = 1000.0;
 
     public List<Double> calculate(TrackingSession session) {
         if (Boolean.TRUE.equals(session.getIsFreeRecording()) || session.getCourse() == null) {
@@ -30,7 +30,7 @@ public class TrackingMilestoneCalculator {
     }
 
     private List<Double> courseMilestones(Course course) {
-        double totalMeters = (course.getDistance() == null ? 0.0 : course.getDistance()) * KM_TO_M;
+        double totalMeters = course.getDistance() == null ? 0.0 : course.getDistance();
         List<Double> result = new ArrayList<>(COURSE_MILESTONE_COUNT);
         for (int i = 1; i <= COURSE_MILESTONE_COUNT; i++) {
             result.add(totalMeters * i / COURSE_MILESTONE_COUNT);


### PR DESCRIPTION
## 🧾 요약
- 코스 마일스톤 거리 계산 단위 오류 (km  → m 통일)

## 🔗 이슈
- close #103 

## ✨ 변경 내용
- 코스 마일스톤 거리 계산 단위 오류 (km  → m 통일)
- km로 가정하고 1000을 곱해서 사용하는 계산 로직 제거 


## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected distance unit handling in milestone calculations to properly process measurements in meters.

* **Documentation**
  * Added clarifications documenting field units: distance in meters, duration in minutes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->