### PR TITLE
[Refactor] 유저 레벨에 맞는 산 추천 로직 수정

### DIFF
--- a/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/MountainController.java
@@ -18,6 +18,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/mountains")
 @RequiredArgsConstructor
@@ -69,21 +71,17 @@ public class MountainController implements MountainControllerDocs {
     }
 
     /**
-     * 사용자의 현재 위치(lat, lng)에서 가까운 순으로 레벨 맞춤 산을 추천한다.
+     * 사용자의 온보딩 정보를 기준으로 레벨 맞춤 산 3개를 추천한다.
      * lat, lng 는 필수임. 누락 시 400 BAD_REQUEST.
-     * Pageable.sort 는 무시됨 (서버 정책상 "거리 가까운 순" 고정).
      */
     @GetMapping("/recommendations")
     @Override
-    public ResponseEntity<ApiResponse<PageResponse<MountainRecommendationResponse>>> getRecommendedMountains(
+    public ResponseEntity<ApiResponse<List<MountainRecommendationResponse>>> getRecommendedMountains(
             @AuthenticationPrincipal Long userId,
             @RequestParam Double lat,
-            @RequestParam Double lng,
-            @PageableDefault(size = 10) Pageable pageable
+            @RequestParam Double lng
     ) {
-        PageResponse<MountainRecommendationResponse> response = PageResponse.from(
-                mountainService.getRecommendedMountains(userId, lat, lng, pageable)
-        );
+        List<MountainRecommendationResponse> response = mountainService.getRecommendedMountains(userId, lat, lng);
         return ApiResponse.success(SuccessStatus.MOUNTAIN_RECOMMENDATION_SUCCESS, response);
     }
 

--- a/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/mountain/controller/docs/MountainControllerDocs.java
@@ -20,6 +20,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
+
 @Tag(name = "Mountain", description = "산 관련 API")
 public interface MountainControllerDocs {
 
@@ -86,10 +88,8 @@ public interface MountainControllerDocs {
 
     @Operation(
             summary = "레벨 맞춤 산 추천 (홈 화면)",
-            description = "로그인 사용자의 등산 레벨(HikingLevel) → 산 난이도(Difficulty) 매핑으로 후보를 추리고, "
-                    + "사용자 위치(lat, lng)에서 가까운 순으로 정렬해 페이지 단위로 반환합니다. "
-                    + "온보딩이 완료되지 않은 사용자는 모든 난이도가 fallback으로 사용됩니다. "
-                    + "Pageable.sort 는 무시됩니다 (서버 정책상 '거리 가까운 순' 고정)."
+            description = "로그인 사용자의 온보딩/신체 정보로 체력 레벨을 산정하고, "
+                    + "KOMOUNT 코스 점수 기준으로 산 3개를 추천합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -102,13 +102,12 @@ public interface MountainControllerDocs {
                     content = @Content(schema = @Schema(implementation = ApiResponse.class))
             )
     })
-    ResponseEntity<ApiResponse<PageResponse<MountainRecommendationResponse>>> getRecommendedMountains(
+    ResponseEntity<ApiResponse<List<MountainRecommendationResponse>>> getRecommendedMountains(
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "사용자 현재 위치 위도 (필수)", required = true, example = "37.4533700")
             @RequestParam Double lat,
             @Parameter(description = "사용자 현재 위치 경도 (필수)", required = true, example = "126.9571678")
-            @RequestParam Double lng,
-            @PageableDefault(size = 10) Pageable pageable
+            @RequestParam Double lng
     );
 
     @Operation(

--- a/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainRecommendationResponse.java
+++ b/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainRecommendationResponse.java
@@ -2,7 +2,6 @@ package com.semosan.api.domain.mountain.dto.response;
 
 import com.semosan.api.domain.mountain.entity.Mountain;
 import com.semosan.api.domain.mountain.enums.Difficulty;
-import com.semosan.api.domain.mountain.enums.FitnessLevel;
 import com.semosan.api.domain.mountain.service.recommendation.TrackScorer.TrackMetrics;
 
 public record MountainRecommendationResponse(
@@ -16,23 +15,19 @@ public record MountainRecommendationResponse(
 
     public static MountainRecommendationResponse from(
             Mountain mountain,
-            TrackMetrics metrics,
-            FitnessLevel fitnessLevel
+            TrackMetrics metrics
     ) {
         return new MountainRecommendationResponse(
                 mountain.getId(),
                 mountain.getName(),
                 firstImageUrl(mountain),
-                difficultyLabel(mountain.getDifficulty(), fitnessLevel),
+                difficultyLabel(mountain.getDifficulty()),
                 metrics.mountainHeightM(),
                 mountain.getAddress()
         );
     }
 
-    private static String difficultyLabel(Difficulty difficulty, FitnessLevel fitnessLevel) {
-        if (difficulty == null) {
-            return fitnessLevel.getLabel();
-        }
+    private static String difficultyLabel(Difficulty difficulty) {
         return switch (difficulty) {
             case EASY -> "초";
             case NORMAL -> "중";

--- a/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainRecommendationResponse.java
+++ b/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainRecommendationResponse.java
@@ -2,25 +2,42 @@ package com.semosan.api.domain.mountain.dto.response;
 
 import com.semosan.api.domain.mountain.entity.Mountain;
 import com.semosan.api.domain.mountain.enums.Difficulty;
+import com.semosan.api.domain.mountain.enums.FitnessLevel;
+import com.semosan.api.domain.mountain.service.recommendation.TrackScorer.TrackMetrics;
 
 public record MountainRecommendationResponse(
         Long mountainId,
         String name,
         String imageUrl,
-        Difficulty difficulty,
-        Double altitude,
+        String difficultyLabel,
+        Integer mountainHeightM,
         String address
 ) {
 
-    public static MountainRecommendationResponse from(Mountain mountain) {
+    public static MountainRecommendationResponse from(
+            Mountain mountain,
+            TrackMetrics metrics,
+            FitnessLevel fitnessLevel
+    ) {
         return new MountainRecommendationResponse(
                 mountain.getId(),
                 mountain.getName(),
                 firstImageUrl(mountain),
-                mountain.getDifficulty(),
-                mountain.getAltitude(),
+                difficultyLabel(mountain.getDifficulty(), fitnessLevel),
+                metrics.mountainHeightM(),
                 mountain.getAddress()
         );
+    }
+
+    private static String difficultyLabel(Difficulty difficulty, FitnessLevel fitnessLevel) {
+        if (difficulty == null) {
+            return fitnessLevel.getLabel();
+        }
+        return switch (difficulty) {
+            case EASY -> "초";
+            case NORMAL -> "중";
+            case HARD -> "상";
+        };
     }
 
     private static String firstImageUrl(Mountain mountain) {

--- a/src/main/java/com/semosan/api/domain/mountain/entity/Course.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/Course.java
@@ -43,6 +43,10 @@ public class Course extends BaseEntity {
     private LineString polyline;
 
     @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "altitudes", columnDefinition = "jsonb")
+    private List<Double> altitudes;
+
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "waypoints", columnDefinition = "jsonb")
     private List<CourseWaypoint> waypoints;
 

--- a/src/main/java/com/semosan/api/domain/mountain/entity/Course.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/Course.java
@@ -4,7 +4,11 @@ import com.semosan.api.common.base.BaseEntity;
 import com.semosan.api.domain.mountain.enums.Difficulty;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import org.locationtech.jts.geom.LineString;
+
+import java.util.List;
 
 @Table(name = "courses")
 @Getter
@@ -37,4 +41,17 @@ public class Course extends BaseEntity {
 
     @Column(name = "polyline", columnDefinition = "geography(LineString, 4326)")
     private LineString polyline;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "waypoints", columnDefinition = "jsonb")
+    private List<CourseWaypoint> waypoints;
+
+    public record CourseWaypoint(
+            Double lat,
+            Double lng,
+            Double ele,
+            String name,
+            String category
+    ) {
+    }
 }

--- a/src/main/java/com/semosan/api/domain/mountain/enums/FitnessLevel.java
+++ b/src/main/java/com/semosan/api/domain/mountain/enums/FitnessLevel.java
@@ -1,0 +1,18 @@
+package com.semosan.api.domain.mountain.enums;
+
+public enum FitnessLevel {
+    ENTRY("입문"),
+    BEGINNER("초"),
+    INTERMEDIATE("중"),
+    ADVANCED("상");
+
+    private final String label;
+
+    FitnessLevel(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/mountain/repository/CourseRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/CourseRepository.java
@@ -13,6 +13,14 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     List<Course> findByMountainId(Long mountainId);
 
+    @Query("""
+            SELECT c
+            FROM Course c
+            JOIN FETCH c.mountain
+            ORDER BY c.mountain.id ASC, c.id ASC
+            """)
+    List<Course> findAllWithMountainForRecommendation();
+
     /**
      * 코스 상세 — polyline 은 PostGIS LineString 을 GeoJSON 으로 변환,
      * altitudes 는 jsonb 를 그대로 문자열로 반환. 클라이언트 응답 시 raw JSON 으로 직렬화한다.

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
@@ -115,8 +115,7 @@ public class MountainService {
                 .limit(3)
                 .map(candidate -> MountainRecommendationResponse.from(
                         candidate.mountain(),
-                        candidate.evaluation().metrics(),
-                        fitnessLevel
+                        candidate.evaluation().metrics()
                 ))
                 .toList();
     }

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
@@ -24,8 +24,6 @@ import com.semosan.api.domain.user.repository.UserOnboardingRepository;
 import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -92,11 +90,10 @@ public class MountainService {
         return MountainMapListResponse.of(hasHikingRecord, mountains);
     }
 
-    public Page<MountainRecommendationResponse> getRecommendedMountains(
+    public List<MountainRecommendationResponse> getRecommendedMountains(
             Long userId,
             Double lat,
-            Double lng,
-            Pageable pageable
+            Double lng
     ) {
         User user = userReader.findCompletedOnboardingUserById(userId);
         UserOnboarding onboarding = userOnboardingRepository.findByUser_Id(userId)
@@ -113,13 +110,11 @@ public class MountainService {
             );
         }
 
-        List<MountainRecommendationResponse> content = candidateByMountainId.values().stream()
+        return candidateByMountainId.values().stream()
                 .sorted(RecommendationCandidate.recommendationOrder())
                 .limit(3)
                 .map(candidate -> MountainRecommendationResponse.from(candidate.mountain()))
                 .toList();
-
-        return new PageImpl<>(content, PageRequest.of(0, 3), content.size());
     }
 
     private static RecommendationCandidate selectBetterCandidate(

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
@@ -8,26 +8,32 @@ import com.semosan.api.domain.mountain.dto.response.MountainListResponse;
 import com.semosan.api.domain.mountain.dto.response.MountainMapListResponse;
 import com.semosan.api.domain.mountain.dto.response.MountainMapResponse;
 import com.semosan.api.domain.mountain.dto.response.MountainRecommendationResponse;
+import com.semosan.api.domain.mountain.entity.Course;
 import com.semosan.api.domain.mountain.entity.Mountain;
 import com.semosan.api.domain.mountain.enums.AmenityType;
-import com.semosan.api.domain.mountain.enums.Difficulty;
+import com.semosan.api.domain.mountain.enums.FitnessLevel;
 import com.semosan.api.domain.mountain.repository.*;
 import com.semosan.api.domain.hiking.repository.HikingMemberRepository;
 import com.semosan.api.domain.review.service.ReviewService;
+import com.semosan.api.domain.mountain.service.recommendation.FitnessLevelCalculator;
+import com.semosan.api.domain.mountain.service.recommendation.TrackScorer;
+import com.semosan.api.domain.mountain.service.recommendation.TrackScorer.TrackEvaluation;
+import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.entity.UserOnboarding;
-import com.semosan.api.domain.user.enums.onboarding.HikingLevel;
 import com.semosan.api.domain.user.repository.UserOnboardingRepository;
 import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.EnumSet;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -49,6 +55,8 @@ public class MountainService {
     private final UserOnboardingRepository userOnboardingRepository;
     private final HikingMemberRepository hikingMemberRepository;
     private final UserReader userReader;
+    private final FitnessLevelCalculator fitnessLevelCalculator;
+    private final TrackScorer trackScorer;
 
     public Page<MountainListResponse> getMountains(Long userId, Pageable pageable) {
         userReader.findCompletedOnboardingUserById(userId);
@@ -84,43 +92,58 @@ public class MountainService {
         return MountainMapListResponse.of(hasHikingRecord, mountains);
     }
 
-    /**
-     * 로그인 사용자의 등산 레벨에 맞는 산을 "사용자 위치에서 가까운 순"으로 추천한다.
-     *  - 온보딩이 완료된 사용자: HikingLevel → Difficulty 집합 매핑 (임의로 해둠) TODO: 필터링 로직 확정되어야함
-     *  - 온보딩 미완료(UserOnboarding 없음): 모든 난이도 fallback
-     *  - 정렬: squared distance ASC (사용자 lat/lng 기준 가까운 순). 자세한 정렬 원리는 Repository 주석 참고.
-     *  - 다녀온 산 제외 여부: 현재는 포함. 기획에 따라 추후 조정
-     */
     public Page<MountainRecommendationResponse> getRecommendedMountains(
             Long userId,
             Double lat,
             Double lng,
             Pageable pageable
     ) {
-        Set<Difficulty> difficulties = userOnboardingRepository.findByUser_Id(userId)
-                .map(UserOnboarding::getHikingLevel)
-                .map(MountainService::mapHikingLevelToDifficulties)
-                .orElseGet(() -> EnumSet.allOf(Difficulty.class));
+        User user = userReader.findCompletedOnboardingUserById(userId);
+        UserOnboarding onboarding = userOnboardingRepository.findByUser_Id(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ONBOARDING_NOT_FOUND));
+        FitnessLevel fitnessLevel = fitnessLevelCalculator.calculate(user, onboarding);
 
-        List<String> difficultyNames = difficulties.stream()
-                .map(Enum::name)
+        Map<Long, RecommendationCandidate> candidateByMountainId = new LinkedHashMap<>();
+        for (Course course : courseRepository.findAllWithMountainForRecommendation()) {
+            TrackEvaluation evaluation = trackScorer.evaluate(course, fitnessLevel);
+            candidateByMountainId.merge(
+                    course.getMountain().getId(),
+                    new RecommendationCandidate(course.getMountain(), evaluation),
+                    MountainService::selectBetterCandidate
+            );
+        }
+
+        List<MountainRecommendationResponse> content = candidateByMountainId.values().stream()
+                .sorted(RecommendationCandidate.recommendationOrder())
+                .limit(3)
+                .map(candidate -> MountainRecommendationResponse.from(candidate.mountain()))
                 .toList();
 
-        return mountainRepository.findRecommendationsByDifficulties(difficultyNames, lat, lng, pageable)
-                .map(MountainRecommendationResponse::from);
+        return new PageImpl<>(content, PageRequest.of(0, 3), content.size());
     }
 
-    /**
-     * HikingLevel → Difficulty 매핑 (임의 정의).
-     * TODO: 추천 정책이 확정되면 정식 로직으로 교체 예정이오
-     */
-    private static Set<Difficulty> mapHikingLevelToDifficulties(HikingLevel level) {
-        return switch (level) {
-            case BEGINNER -> EnumSet.of(Difficulty.EASY);
-            case HOBBY -> EnumSet.of(Difficulty.EASY, Difficulty.NORMAL);
-            case EXPERIENCED -> EnumSet.of(Difficulty.NORMAL);
-            case EXPERT -> EnumSet.of(Difficulty.NORMAL, Difficulty.HARD);
-        };
+    private static RecommendationCandidate selectBetterCandidate(
+            RecommendationCandidate current,
+            RecommendationCandidate next
+    ) {
+        if (current.evaluation().eligible() != next.evaluation().eligible()) {
+            return next.evaluation().eligible() ? next : current;
+        }
+        return next.rankingScore() > current.rankingScore() ? next : current;
+    }
+
+    private record RecommendationCandidate(Mountain mountain, TrackEvaluation evaluation) {
+
+        private double rankingScore() {
+            return evaluation.eligible() ? evaluation.score() : evaluation.fallbackScore();
+        }
+
+        private static Comparator<RecommendationCandidate> recommendationOrder() {
+            return Comparator
+                    .comparing((RecommendationCandidate candidate) -> candidate.evaluation().eligible()).reversed()
+                    .thenComparing(RecommendationCandidate::rankingScore, Comparator.reverseOrder())
+                    .thenComparing(candidate -> candidate.mountain().getId());
+        }
     }
 
     public Page<MountainListResponse> searchMountains(Long userId, String keyword, Pageable pageable) {

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
@@ -18,9 +18,7 @@ import com.semosan.api.domain.review.service.ReviewService;
 import com.semosan.api.domain.mountain.service.recommendation.FitnessLevelCalculator;
 import com.semosan.api.domain.mountain.service.recommendation.TrackScorer;
 import com.semosan.api.domain.mountain.service.recommendation.TrackScorer.TrackEvaluation;
-import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.entity.UserOnboarding;
-import com.semosan.api.domain.user.repository.UserOnboardingRepository;
 import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -50,7 +48,6 @@ public class MountainService {
     private final AmenityRepository amenityRepository;
     private final RestaurantSectionRepository restaurantSectionRepository;
     private final ReviewService reviewService;
-    private final UserOnboardingRepository userOnboardingRepository;
     private final HikingMemberRepository hikingMemberRepository;
     private final UserReader userReader;
     private final FitnessLevelCalculator fitnessLevelCalculator;
@@ -95,10 +92,8 @@ public class MountainService {
             Double lat,
             Double lng
     ) {
-        User user = userReader.findCompletedOnboardingUserById(userId);
-        UserOnboarding onboarding = userOnboardingRepository.findByUser_Id(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.ONBOARDING_NOT_FOUND));
-        FitnessLevel fitnessLevel = fitnessLevelCalculator.calculate(user, onboarding);
+        UserOnboarding onboarding = userReader.findCompletedOnboardingByUserId(userId);
+        FitnessLevel fitnessLevel = fitnessLevelCalculator.calculate(onboarding.getUser(), onboarding);
 
         Map<Long, RecommendationCandidate> candidateByMountainId = new LinkedHashMap<>();
         for (Course course : courseRepository.findAllWithMountainForRecommendation()) {

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
@@ -113,7 +113,11 @@ public class MountainService {
         return candidateByMountainId.values().stream()
                 .sorted(RecommendationCandidate.recommendationOrder())
                 .limit(3)
-                .map(candidate -> MountainRecommendationResponse.from(candidate.mountain()))
+                .map(candidate -> MountainRecommendationResponse.from(
+                        candidate.mountain(),
+                        candidate.evaluation().metrics(),
+                        fitnessLevel
+                ))
                 .toList();
     }
 

--- a/src/main/java/com/semosan/api/domain/mountain/service/recommendation/FitnessLevelCalculator.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/recommendation/FitnessLevelCalculator.java
@@ -1,0 +1,162 @@
+package com.semosan.api.domain.mountain.service.recommendation;
+
+import com.semosan.api.domain.mountain.enums.FitnessLevel;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.entity.UserOnboarding;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseDuration;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseFrequency;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseType;
+import com.semosan.api.domain.user.enums.onboarding.HikingLevel;
+import com.semosan.api.domain.user.enums.user.Gender;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+@Component
+public class FitnessLevelCalculator {
+
+    public FitnessLevel calculate(User user, UserOnboarding onboarding) {
+        if (onboarding.getExerciseType() == ExerciseType.NONE) {
+            return FitnessLevel.ENTRY;
+        }
+
+        double totalScore = hikingExperienceScore(onboarding.getHikingLevel())
+                + exerciseScore(onboarding)
+                + ageAdjustment(user.getBirthDate())
+                + bmiAdjustment(user.getGender(), user.getHeight(), user.getWeight());
+
+        FitnessLevel level = scoreToLevel(totalScore);
+
+        if (onboarding.getHikingLevel() == HikingLevel.BEGINNER && level.ordinal() > FitnessLevel.BEGINNER.ordinal()) {
+            return FitnessLevel.BEGINNER;
+        }
+        if (onboarding.getHikingLevel() == HikingLevel.EXPERT && totalScore < 55) {
+            return FitnessLevel.INTERMEDIATE;
+        }
+        return level;
+    }
+
+    private double hikingExperienceScore(HikingLevel hikingLevel) {
+        return switch (hikingLevel) {
+            case BEGINNER -> 10;
+            case EXPERIENCED -> 22;
+            case HOBBY -> 34;
+            case EXPERT -> 45;
+        };
+    }
+
+    private double exerciseScore(UserOnboarding onboarding) {
+        ExerciseFrequency frequency = onboarding.getExerciseFrequency();
+        ExerciseDuration duration = onboarding.getExerciseDuration();
+        if (frequency == null || duration == null) {
+            return 0;
+        }
+        return Math.min(35, 35
+                * exerciseTypeWeight(onboarding.getExerciseType())
+                * exerciseFrequencyMultiplier(frequency)
+                * exerciseDurationMultiplier(duration));
+    }
+
+    private double exerciseTypeWeight(ExerciseType exerciseType) {
+        return switch (exerciseType) {
+            case HIKING -> 1.00;
+            case CROSSFIT -> 0.95;
+            case RUNNING -> 0.90;
+            case SPORTS -> 0.75;
+            case GYM -> 0.70;
+            case SWIMMING -> 0.65;
+            case HOME_TRAINING -> 0.55;
+            case PILATES_YOGA -> 0.45;
+            case WALKING -> 0.40;
+            case NONE -> 0;
+        };
+    }
+
+    private double exerciseFrequencyMultiplier(ExerciseFrequency frequency) {
+        return switch (frequency) {
+            case LESS_THAN_MONTH_1 -> 0.35;
+            case MONTH_1_2 -> 0.55;
+            case WEEK_1_2 -> 0.75;
+            case WEEK_3_4 -> 1.00;
+            case DAILY -> 1.10;
+        };
+    }
+
+    private double exerciseDurationMultiplier(ExerciseDuration duration) {
+        return switch (duration) {
+            case UNDER_1H -> 0.70;
+            case HOUR_1_2 -> 0.90;
+            case HOUR_2_4 -> 1.00;
+            case OVER_4H -> 1.10;
+        };
+    }
+
+    private int ageAdjustment(LocalDate birthDate) {
+        if (birthDate == null) {
+            return 0;
+        }
+
+        int age = Period.between(birthDate, LocalDate.now()).getYears();
+        if (age >= 20 && age <= 39) {
+            return 2;
+        }
+        if ((age >= 15 && age <= 19) || (age >= 40 && age <= 54)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    private int bmiAdjustment(Gender gender, Double height, Double weight) {
+        if (gender == null || gender == Gender.NONE || height == null || weight == null || height <= 0) {
+            return 0;
+        }
+
+        double heightMeter = height / 100;
+        double bmi = weight / (heightMeter * heightMeter);
+        return switch (gender) {
+            case FEMALE -> femaleBmiAdjustment(bmi);
+            case MALE -> maleBmiAdjustment(bmi);
+            case NONE -> 0;
+        };
+    }
+
+    private int femaleBmiAdjustment(double bmi) {
+        if (bmi >= 18.5 && bmi < 23) {
+            return 3;
+        }
+        if (bmi >= 23 && bmi < 25) {
+            return 1;
+        }
+        if ((bmi >= 17 && bmi < 18.5) || (bmi >= 25 && bmi < 30)) {
+            return 0;
+        }
+        return -2;
+    }
+
+    private int maleBmiAdjustment(double bmi) {
+        if (bmi >= 20 && bmi < 25) {
+            return 3;
+        }
+        if (bmi >= 25 && bmi < 27) {
+            return 1;
+        }
+        if ((bmi >= 18.5 && bmi < 20) || (bmi >= 27 && bmi < 30)) {
+            return 0;
+        }
+        return -2;
+    }
+
+    private FitnessLevel scoreToLevel(double totalScore) {
+        if (totalScore >= 75) {
+            return FitnessLevel.ADVANCED;
+        }
+        if (totalScore >= 55) {
+            return FitnessLevel.INTERMEDIATE;
+        }
+        if (totalScore >= 35) {
+            return FitnessLevel.BEGINNER;
+        }
+        return FitnessLevel.ENTRY;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/mountain/service/recommendation/TrackScorer.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/recommendation/TrackScorer.java
@@ -5,6 +5,7 @@ import com.semosan.api.domain.mountain.enums.FitnessLevel;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 @Component
@@ -93,7 +94,9 @@ public class TrackScorer {
             ElevationRange elevationRange = ElevationRange.from(course);
             List<Course.CourseWaypoint> waypoints = course.getWaypoints() == null
                     ? List.of()
-                    : course.getWaypoints();
+                    : course.getWaypoints().stream()
+                    .filter(Objects::nonNull)
+                    .toList();
 
             return new TrackMetrics(
                     course.getDistance() / METERS_PER_KILOMETER,
@@ -108,12 +111,14 @@ public class TrackScorer {
 
         private static long countCategory(List<Course.CourseWaypoint> waypoints, String category) {
             return waypoints.stream()
+                    .filter(Objects::nonNull)
                     .filter(waypoint -> category.equals(waypoint.category()))
                     .count();
         }
 
         private static long countCategories(List<Course.CourseWaypoint> waypoints, Set<String> categories) {
             return waypoints.stream()
+                    .filter(Objects::nonNull)
                     .filter(waypoint -> categories.contains(waypoint.category()))
                     .count();
         }
@@ -128,12 +133,15 @@ public class TrackScorer {
         private static ElevationRange from(Course course) {
             List<Double> altitudes = course.getAltitudes();
             if (altitudes != null && !altitudes.isEmpty()) {
-                return fromNumbers(altitudes);
+                return fromNumbers(altitudes.stream()
+                        .filter(Objects::nonNull)
+                        .toList());
             }
 
             List<Double> waypointElevations = course.getWaypoints() == null
                     ? List.of()
                     : course.getWaypoints().stream()
+                    .filter(Objects::nonNull)
                     .map(Course.CourseWaypoint::ele)
                     .filter(ele -> ele != null && ele > 0)
                     .toList();
@@ -146,10 +154,12 @@ public class TrackScorer {
 
         private static ElevationRange fromNumbers(List<Double> values) {
             double min = values.stream()
+                    .filter(Objects::nonNull)
                     .mapToDouble(Double::doubleValue)
                     .min()
                     .orElse(0);
             double max = values.stream()
+                    .filter(Objects::nonNull)
                     .mapToDouble(Double::doubleValue)
                     .max()
                     .orElse(0);

--- a/src/main/java/com/semosan/api/domain/mountain/service/recommendation/TrackScorer.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/recommendation/TrackScorer.java
@@ -10,6 +10,8 @@ import java.util.Set;
 @Component
 public class TrackScorer {
 
+    // courses.distance 는 KOMOUNT distance_m 원본을 저장한 미터 단위 값이다.
+    private static final double METERS_PER_KILOMETER = 1000;
     private static final Set<String> SCENIC_CATEGORIES = Set.of("VIEW", "PHOTO", "PEAK");
     private static final Set<String> ACCESS_CATEGORIES = Set.of("TRANS", "PARK");
 
@@ -94,7 +96,7 @@ public class TrackScorer {
                     : course.getWaypoints();
 
             return new TrackMetrics(
-                    course.getDistance() / 1000,
+                    course.getDistance() / METERS_PER_KILOMETER,
                     elevationRange.gain(),
                     (int) Math.round(elevationRange.maxElevation()),
                     countCategory(waypoints, "DANGER"),

--- a/src/main/java/com/semosan/api/domain/mountain/service/recommendation/TrackScorer.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/recommendation/TrackScorer.java
@@ -1,0 +1,157 @@
+package com.semosan.api.domain.mountain.service.recommendation;
+
+import com.semosan.api.domain.mountain.entity.Course;
+import com.semosan.api.domain.mountain.enums.FitnessLevel;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class TrackScorer {
+
+    private static final Set<String> SCENIC_CATEGORIES = Set.of("VIEW", "PHOTO", "PEAK");
+    private static final Set<String> ACCESS_CATEGORIES = Set.of("TRANS", "PARK");
+
+    public TrackEvaluation evaluate(Course course, FitnessLevel level) {
+        TrackMetrics metrics = TrackMetrics.from(course);
+        double score = score(metrics, level);
+        return new TrackEvaluation(
+                course,
+                metrics,
+                isEligible(metrics, level),
+                score,
+                score - metrics.dangerCount() * 20
+        );
+    }
+
+    private boolean isEligible(TrackMetrics metrics, FitnessLevel level) {
+        return switch (level) {
+            case ENTRY -> metrics.distanceKm() <= 6
+                    && metrics.gain() <= 400
+                    && metrics.dangerCount() == 0;
+            case BEGINNER -> metrics.distanceKm() <= 9
+                    && metrics.gain() <= 600
+                    && metrics.dangerCount() <= 1;
+            case INTERMEDIATE -> metrics.distanceKm() <= 13
+                    && metrics.gain() <= 900
+                    && metrics.dangerCount() <= 3;
+            case ADVANCED -> true;
+        };
+    }
+
+    private double score(TrackMetrics metrics, FitnessLevel level) {
+        return switch (level) {
+            case ENTRY -> -metrics.distanceKm() * 3
+                    - metrics.gain() / 20
+                    - metrics.dangerCount() * 50
+                    + metrics.restCount() * 4
+                    + metrics.accessCount() * 6
+                    + metrics.scenicCount() * 2;
+            case BEGINNER -> -metrics.distanceKm() * 2
+                    - metrics.gain() / 30
+                    - metrics.dangerCount() * 30
+                    + metrics.restCount() * 3
+                    + metrics.accessCount() * 5
+                    + metrics.scenicCount() * 3;
+            case INTERMEDIATE -> -Math.abs(metrics.distanceKm() - 10) * 2
+                    - Math.abs(metrics.gain() - 700) / 35
+                    - metrics.dangerCount() * 10
+                    + metrics.restCount() * 2
+                    + metrics.accessCount() * 2
+                    + metrics.scenicCount() * 4;
+            case ADVANCED -> metrics.distanceKm() * 2
+                    + metrics.gain() / 35
+                    - metrics.dangerCount() * 4
+                    + metrics.restCount()
+                    + metrics.scenicCount() * 4;
+        };
+    }
+
+    public record TrackEvaluation(
+            Course course,
+            TrackMetrics metrics,
+            boolean eligible,
+            double score,
+            double fallbackScore
+    ) {
+    }
+
+    public record TrackMetrics(
+            double distanceKm,
+            double gain,
+            int mountainHeightM,
+            long dangerCount,
+            long scenicCount,
+            long restCount,
+            long accessCount
+    ) {
+
+        private static TrackMetrics from(Course course) {
+            ElevationRange elevationRange = ElevationRange.from(course);
+            List<Course.CourseWaypoint> waypoints = course.getWaypoints() == null
+                    ? List.of()
+                    : course.getWaypoints();
+
+            return new TrackMetrics(
+                    course.getDistance() / 1000,
+                    elevationRange.gain(),
+                    (int) Math.round(elevationRange.maxElevation()),
+                    countCategory(waypoints, "DANGER"),
+                    countCategories(waypoints, SCENIC_CATEGORIES),
+                    countCategory(waypoints, "REST"),
+                    countCategories(waypoints, ACCESS_CATEGORIES)
+            );
+        }
+
+        private static long countCategory(List<Course.CourseWaypoint> waypoints, String category) {
+            return waypoints.stream()
+                    .filter(waypoint -> category.equals(waypoint.category()))
+                    .count();
+        }
+
+        private static long countCategories(List<Course.CourseWaypoint> waypoints, Set<String> categories) {
+            return waypoints.stream()
+                    .filter(waypoint -> categories.contains(waypoint.category()))
+                    .count();
+        }
+    }
+
+    private record ElevationRange(double minElevation, double maxElevation) {
+
+        private double gain() {
+            return Math.max(0, maxElevation - minElevation);
+        }
+
+        private static ElevationRange from(Course course) {
+            List<Double> altitudes = course.getAltitudes();
+            if (altitudes != null && !altitudes.isEmpty()) {
+                return fromNumbers(altitudes);
+            }
+
+            List<Double> waypointElevations = course.getWaypoints() == null
+                    ? List.of()
+                    : course.getWaypoints().stream()
+                    .map(Course.CourseWaypoint::ele)
+                    .filter(ele -> ele != null && ele > 0)
+                    .toList();
+            if (!waypointElevations.isEmpty()) {
+                return fromNumbers(waypointElevations);
+            }
+
+            return new ElevationRange(0, 0);
+        }
+
+        private static ElevationRange fromNumbers(List<Double> values) {
+            double min = values.stream()
+                    .mapToDouble(Double::doubleValue)
+                    .min()
+                    .orElse(0);
+            double max = values.stream()
+                    .mapToDouble(Double::doubleValue)
+                    .max()
+                    .orElse(0);
+            return new ElevationRange(min, max);
+        }
+    }
+}

--- a/src/main/java/com/semosan/api/domain/user/repository/UserOnboardingRepository.java
+++ b/src/main/java/com/semosan/api/domain/user/repository/UserOnboardingRepository.java
@@ -1,6 +1,8 @@
 package com.semosan.api.domain.user.repository;
 
 import com.semosan.api.domain.user.entity.UserOnboarding;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,6 +12,15 @@ public interface UserOnboardingRepository extends JpaRepository<UserOnboarding, 
     boolean existsByUser_Id(Long userId);
 
     Optional<UserOnboarding> findByUser_Id(Long userId);
+
+    @Query("""
+            SELECT uo
+            FROM UserOnboarding uo
+            JOIN FETCH uo.user u
+            WHERE u.id = :userId
+              AND u.deleted = false
+            """)
+    Optional<UserOnboarding> findByUserIdWithUser(@Param("userId") Long userId);
 
     void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/com/semosan/api/domain/user/service/UserReader.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserReader.java
@@ -3,8 +3,10 @@ package com.semosan.api.domain.user.service;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.entity.UserOnboarding;
 import com.semosan.api.domain.user.enums.user.OnboardingStatus;
 import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.repository.UserOnboardingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserReader {
 
     private final UserRepository userRepository;
+    private final UserOnboardingRepository userOnboardingRepository;
 
     @Transactional(readOnly = true)
     public User findActiveUserById(Long userId) {
@@ -21,11 +24,19 @@ public class UserReader {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
+    public UserOnboarding findCompletedOnboardingByUserId(Long userId) {
+        UserOnboarding userOnboarding = userOnboardingRepository.findByUserIdWithUser(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ONBOARDING_NOT_FOUND));
+
+        if (userOnboarding.getUser().getOnboardingStatus() != OnboardingStatus.COMPLETE) {
+            throw new GeneralException(ErrorStatus.ONBOARDING_NOT_COMPLETED);
+        }
+        return userOnboarding;
+    }
+
+    @Transactional(readOnly = true)
     public User findCompletedOnboardingUserById(Long userId) {
-        User user = findActiveUserById(userId);
-//        if (user.getOnboardingStatus() != OnboardingStatus.COMPLETE) {
-//            throw new GeneralException(ErrorStatus.ONBOARDING_NOT_COMPLETED);
-//        }
-        return user;
+        return findCompletedOnboardingByUserId(userId).getUser();
     }
 }

--- a/src/main/resources/db/migration/V16__add_course_waypoints.sql
+++ b/src/main/resources/db/migration/V16__add_course_waypoints.sql
@@ -12,6 +12,7 @@ BEGIN
         SELECT 1
         FROM pg_constraint
         WHERE conname = 'courses_waypoints_array_check'
+          AND conrelid = 'courses'::regclass
     ) THEN
         ALTER TABLE courses
             ADD CONSTRAINT courses_waypoints_array_check

--- a/src/main/resources/db/migration/V16__add_course_waypoints.sql
+++ b/src/main/resources/db/migration/V16__add_course_waypoints.sql
@@ -1,0 +1,20 @@
+-- KOMOUNT 트랙별 waypoint/category 정보를 저장한다.
+-- 형식: [{"lat": 37.123, "lng": 127.123, "ele": 100.0, "name": "정상", "category": "PEAK"}, ...]
+ALTER TABLE courses
+    ADD COLUMN IF NOT EXISTS waypoints jsonb;
+
+COMMENT ON COLUMN courses.waypoints IS
+    'KOMOUNT course waypoints. Array of lat/lng/ele/name/category objects.';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'courses_waypoints_array_check'
+    ) THEN
+        ALTER TABLE courses
+            ADD CONSTRAINT courses_waypoints_array_check
+                CHECK (waypoints IS NULL OR jsonb_typeof(waypoints) = 'array');
+    END IF;
+END $$;

--- a/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
@@ -117,6 +117,8 @@ class MountainServiceTest {
                 .extracting(MountainRecommendationResponse::name)
                 .containsExactly("첫번째산", "두번째산", "세번째산");
         assertThat(result).hasSize(3);
+        assertThat(result.get(0).difficultyLabel()).isEqualTo("중");
+        assertThat(result.get(0).mountainHeightM()).isEqualTo(123);
     }
 
     private User user() {
@@ -166,7 +168,7 @@ class MountainServiceTest {
     private TrackScorer.TrackEvaluation evaluation(Course course, boolean eligible, double score) {
         return new TrackScorer.TrackEvaluation(
                 course,
-                new TrackScorer.TrackMetrics(1, 1, 1, 0, 0, 0, 0),
+                new TrackScorer.TrackMetrics(1, 1, 123, 0, 0, 0, 0),
                 eligible,
                 score,
                 score

--- a/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
@@ -30,8 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Constructor;
@@ -109,17 +107,16 @@ class MountainServiceTest {
         when(trackScorer.evaluate(fourthCourse, com.semosan.api.domain.mountain.enums.FitnessLevel.INTERMEDIATE))
                 .thenReturn(evaluation(fourthCourse, true, 40));
 
-        Page<MountainRecommendationResponse> result = mountainService.getRecommendedMountains(
+        List<MountainRecommendationResponse> result = mountainService.getRecommendedMountains(
                 1L,
                 37.0,
-                127.0,
-                PageRequest.of(0, 10)
+                127.0
         );
 
-        assertThat(result.getContent())
+        assertThat(result)
                 .extracting(MountainRecommendationResponse::name)
                 .containsExactly("첫번째산", "두번째산", "세번째산");
-        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result).hasSize(3);
     }
 
     private User user() {

--- a/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
@@ -1,0 +1,178 @@
+package com.semosan.api.domain.mountain.service;
+
+import com.semosan.api.domain.hiking.repository.HikingMemberRepository;
+import com.semosan.api.domain.mountain.dto.response.MountainRecommendationResponse;
+import com.semosan.api.domain.mountain.entity.Course;
+import com.semosan.api.domain.mountain.entity.Mountain;
+import com.semosan.api.domain.mountain.enums.Difficulty;
+import com.semosan.api.domain.mountain.repository.AmenityRepository;
+import com.semosan.api.domain.mountain.repository.CourseRepository;
+import com.semosan.api.domain.mountain.repository.MountainRepository;
+import com.semosan.api.domain.mountain.repository.RestaurantSectionRepository;
+import com.semosan.api.domain.mountain.repository.TransportationRepository;
+import com.semosan.api.domain.mountain.service.recommendation.FitnessLevelCalculator;
+import com.semosan.api.domain.mountain.service.recommendation.TrackScorer;
+import com.semosan.api.domain.review.service.ReviewService;
+import com.semosan.api.domain.user.dto.command.CompleteOnboardingCommand;
+import com.semosan.api.domain.user.dto.command.CreateUserOnboardingCommand;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.entity.UserOnboarding;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseDuration;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseFrequency;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseType;
+import com.semosan.api.domain.user.enums.onboarding.HikingLevel;
+import com.semosan.api.domain.user.enums.user.DeviceType;
+import com.semosan.api.domain.user.enums.user.Gender;
+import com.semosan.api.domain.user.repository.UserOnboardingRepository;
+import com.semosan.api.domain.user.service.UserReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MountainServiceTest {
+
+    @Mock
+    private MountainRepository mountainRepository;
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private TransportationRepository transportationRepository;
+
+    @Mock
+    private AmenityRepository amenityRepository;
+
+    @Mock
+    private RestaurantSectionRepository restaurantSectionRepository;
+
+    @Mock
+    private ReviewService reviewService;
+
+    @Mock
+    private UserOnboardingRepository userOnboardingRepository;
+
+    @Mock
+    private HikingMemberRepository hikingMemberRepository;
+
+    @Mock
+    private UserReader userReader;
+
+    @Mock
+    private FitnessLevelCalculator fitnessLevelCalculator;
+
+    @Mock
+    private TrackScorer trackScorer;
+
+    @InjectMocks
+    private MountainService mountainService;
+
+    @Test
+    void getRecommendedMountainsReturnsTopThreeMountainsByTrackScore() throws Exception {
+        User user = user();
+        UserOnboarding onboarding = onboarding(user);
+        Mountain first = mountain(1L, "첫번째산");
+        Mountain second = mountain(2L, "두번째산");
+        Mountain third = mountain(3L, "세번째산");
+        Mountain fourth = mountain(4L, "네번째산");
+        Course firstCourse = course(first);
+        Course secondCourse = course(second);
+        Course thirdCourse = course(third);
+        Course fourthCourse = course(fourth);
+
+        when(userReader.findCompletedOnboardingUserById(1L)).thenReturn(user);
+        when(userOnboardingRepository.findByUser_Id(1L)).thenReturn(Optional.of(onboarding));
+        when(courseRepository.findAllWithMountainForRecommendation())
+                .thenReturn(List.of(fourthCourse, secondCourse, firstCourse, thirdCourse));
+        when(fitnessLevelCalculator.calculate(user, onboarding))
+                .thenReturn(com.semosan.api.domain.mountain.enums.FitnessLevel.INTERMEDIATE);
+        when(trackScorer.evaluate(firstCourse, com.semosan.api.domain.mountain.enums.FitnessLevel.INTERMEDIATE))
+                .thenReturn(evaluation(firstCourse, true, 100));
+        when(trackScorer.evaluate(secondCourse, com.semosan.api.domain.mountain.enums.FitnessLevel.INTERMEDIATE))
+                .thenReturn(evaluation(secondCourse, true, 80));
+        when(trackScorer.evaluate(thirdCourse, com.semosan.api.domain.mountain.enums.FitnessLevel.INTERMEDIATE))
+                .thenReturn(evaluation(thirdCourse, true, 60));
+        when(trackScorer.evaluate(fourthCourse, com.semosan.api.domain.mountain.enums.FitnessLevel.INTERMEDIATE))
+                .thenReturn(evaluation(fourthCourse, true, 40));
+
+        Page<MountainRecommendationResponse> result = mountainService.getRecommendedMountains(
+                1L,
+                37.0,
+                127.0,
+                PageRequest.of(0, 10)
+        );
+
+        assertThat(result.getContent())
+                .extracting(MountainRecommendationResponse::name)
+                .containsExactly("첫번째산", "두번째산", "세번째산");
+        assertThat(result.getTotalElements()).isEqualTo(3);
+    }
+
+    private User user() {
+        User user = User.createTestUser("recommendation-test-user", DeviceType.IOS);
+        user.completeOnboarding(new CompleteOnboardingCommand(
+                "테스트",
+                null,
+                LocalDate.of(1990, 1, 1),
+                Gender.MALE,
+                175.0,
+                70.0
+        ));
+        return user;
+    }
+
+    private UserOnboarding onboarding(User user) {
+        return UserOnboarding.create(new CreateUserOnboardingCommand(
+                user,
+                HikingLevel.EXPERT,
+                ExerciseType.HIKING,
+                ExerciseFrequency.DAILY,
+                ExerciseDuration.OVER_4H
+        ));
+    }
+
+    private Mountain mountain(Long id, String name) throws Exception {
+        Constructor<Mountain> constructor = Mountain.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Mountain mountain = constructor.newInstance();
+        ReflectionTestUtils.setField(mountain, "id", id);
+        ReflectionTestUtils.setField(mountain, "name", name);
+        ReflectionTestUtils.setField(mountain, "difficulty", Difficulty.NORMAL);
+        ReflectionTestUtils.setField(mountain, "altitude", 500.0);
+        ReflectionTestUtils.setField(mountain, "address", "주소");
+        ReflectionTestUtils.setField(mountain, "imageUrls", List.of());
+        return mountain;
+    }
+
+    private Course course(Mountain mountain) throws Exception {
+        Constructor<Course> constructor = Course.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Course course = constructor.newInstance();
+        ReflectionTestUtils.setField(course, "mountain", mountain);
+        return course;
+    }
+
+    private TrackScorer.TrackEvaluation evaluation(Course course, boolean eligible, double score) {
+        return new TrackScorer.TrackEvaluation(
+                course,
+                new TrackScorer.TrackMetrics(1, 1, 1, 0, 0, 0, 0),
+                eligible,
+                score,
+                score
+        );
+    }
+}

--- a/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
@@ -23,7 +23,6 @@ import com.semosan.api.domain.user.enums.onboarding.ExerciseType;
 import com.semosan.api.domain.user.enums.onboarding.HikingLevel;
 import com.semosan.api.domain.user.enums.user.DeviceType;
 import com.semosan.api.domain.user.enums.user.Gender;
-import com.semosan.api.domain.user.repository.UserOnboardingRepository;
 import com.semosan.api.domain.user.service.UserReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,9 +61,6 @@ class MountainServiceTest {
     private ReviewService reviewService;
 
     @Mock
-    private UserOnboardingRepository userOnboardingRepository;
-
-    @Mock
     private HikingMemberRepository hikingMemberRepository;
 
     @Mock
@@ -92,8 +88,7 @@ class MountainServiceTest {
         Course thirdCourse = course(third);
         Course fourthCourse = course(fourth);
 
-        when(userReader.findCompletedOnboardingUserById(1L)).thenReturn(user);
-        when(userOnboardingRepository.findByUser_Id(1L)).thenReturn(Optional.of(onboarding));
+        when(userReader.findCompletedOnboardingByUserId(1L)).thenReturn(onboarding);
         when(courseRepository.findAllWithMountainForRecommendation())
                 .thenReturn(List.of(fourthCourse, secondCourse, firstCourse, thirdCourse));
         when(fitnessLevelCalculator.calculate(user, onboarding))

--- a/src/test/java/com/semosan/api/domain/mountain/service/recommendation/FitnessLevelCalculatorTest.java
+++ b/src/test/java/com/semosan/api/domain/mountain/service/recommendation/FitnessLevelCalculatorTest.java
@@ -1,0 +1,94 @@
+package com.semosan.api.domain.mountain.service.recommendation;
+
+import com.semosan.api.domain.mountain.enums.FitnessLevel;
+import com.semosan.api.domain.user.dto.command.CompleteOnboardingCommand;
+import com.semosan.api.domain.user.dto.command.CreateUserOnboardingCommand;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.entity.UserOnboarding;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseDuration;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseFrequency;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseType;
+import com.semosan.api.domain.user.enums.onboarding.HikingLevel;
+import com.semosan.api.domain.user.enums.user.DeviceType;
+import com.semosan.api.domain.user.enums.user.Gender;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FitnessLevelCalculatorTest {
+
+    private final FitnessLevelCalculator calculator = new FitnessLevelCalculator();
+
+    @Test
+    void calculatesAdvancedLevelWithHighExperienceAndExerciseHabit() {
+        User user = user(Gender.MALE, 175.0, 70.0);
+        UserOnboarding onboarding = onboarding(
+                user,
+                HikingLevel.EXPERT,
+                ExerciseType.HIKING,
+                ExerciseFrequency.DAILY,
+                ExerciseDuration.OVER_4H
+        );
+
+        assertThat(calculator.calculate(user, onboarding)).isEqualTo(FitnessLevel.ADVANCED);
+    }
+
+    @Test
+    void capsBeginnerHikingExperienceAtBeginnerLevel() {
+        User user = user(Gender.MALE, 175.0, 70.0);
+        UserOnboarding onboarding = onboarding(
+                user,
+                HikingLevel.BEGINNER,
+                ExerciseType.CROSSFIT,
+                ExerciseFrequency.DAILY,
+                ExerciseDuration.OVER_4H
+        );
+
+        assertThat(calculator.calculate(user, onboarding)).isEqualTo(FitnessLevel.BEGINNER);
+    }
+
+    @Test
+    void fixesExerciseNoneToEntryLevel() {
+        User user = user(Gender.FEMALE, 165.0, 55.0);
+        UserOnboarding onboarding = onboarding(
+                user,
+                HikingLevel.EXPERT,
+                ExerciseType.NONE,
+                null,
+                null
+        );
+
+        assertThat(calculator.calculate(user, onboarding)).isEqualTo(FitnessLevel.ENTRY);
+    }
+
+    private User user(Gender gender, Double height, Double weight) {
+        User user = User.createTestUser("fitness-test-user", DeviceType.IOS);
+        user.completeOnboarding(new CompleteOnboardingCommand(
+                "테스트",
+                null,
+                LocalDate.of(1990, 1, 1),
+                gender,
+                height,
+                weight
+        ));
+        return user;
+    }
+
+    private UserOnboarding onboarding(
+            User user,
+            HikingLevel hikingLevel,
+            ExerciseType exerciseType,
+            ExerciseFrequency exerciseFrequency,
+            ExerciseDuration exerciseDuration
+    ) {
+        return UserOnboarding.create(new CreateUserOnboardingCommand(
+                user,
+                hikingLevel,
+                exerciseType,
+                exerciseFrequency,
+                exerciseDuration
+        ));
+    }
+}

--- a/src/test/java/com/semosan/api/domain/mountain/service/recommendation/TrackScorerTest.java
+++ b/src/test/java/com/semosan/api/domain/mountain/service/recommendation/TrackScorerTest.java
@@ -1,0 +1,99 @@
+package com.semosan.api.domain.mountain.service.recommendation;
+
+import com.semosan.api.domain.mountain.entity.Course;
+import com.semosan.api.domain.mountain.enums.FitnessLevel;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TrackScorerTest {
+
+    private final TrackScorer scorer = new TrackScorer();
+
+    @Test
+    void evaluatesEntryEligibleTrackWithDerivedMetrics() throws Exception {
+        Course course = course(
+                5000.0,
+                List.of(100.0, 450.0),
+                List.of("REST", "TRANS", "PARK", "VIEW", "PEAK")
+        );
+
+        TrackScorer.TrackEvaluation evaluation = scorer.evaluate(course, FitnessLevel.ENTRY);
+
+        assertThat(evaluation.eligible()).isTrue();
+        assertThat(evaluation.metrics().distanceKm()).isEqualTo(5.0);
+        assertThat(evaluation.metrics().gain()).isEqualTo(350.0);
+        assertThat(evaluation.metrics().mountainHeightM()).isEqualTo(450);
+        assertThat(evaluation.metrics().restCount()).isEqualTo(1);
+        assertThat(evaluation.metrics().accessCount()).isEqualTo(2);
+        assertThat(evaluation.metrics().scenicCount()).isEqualTo(2);
+        assertThat(evaluation.score()).isEqualTo(-12.5);
+    }
+
+    @Test
+    void marksEntryTrackWithDangerAsIneligibleAndAppliesFallbackPenalty() throws Exception {
+        Course course = course(
+                5000.0,
+                List.of(100.0, 300.0),
+                List.of("DANGER", "REST")
+        );
+
+        TrackScorer.TrackEvaluation evaluation = scorer.evaluate(course, FitnessLevel.ENTRY);
+
+        assertThat(evaluation.eligible()).isFalse();
+        assertThat(evaluation.metrics().dangerCount()).isEqualTo(1);
+        assertThat(evaluation.fallbackScore()).isEqualTo(evaluation.score() - 20);
+    }
+
+    @Test
+    void scoresIntermediateTrackAroundTargetDistanceAndGainHigher() throws Exception {
+        Course nearTarget = course(
+                10000.0,
+                List.of(100.0, 800.0),
+                List.of("VIEW", "PHOTO", "PEAK")
+        );
+        Course farFromTarget = course(
+                4000.0,
+                List.of(100.0, 300.0),
+                List.of("VIEW", "PHOTO", "PEAK")
+        );
+
+        TrackScorer.TrackEvaluation nearEvaluation = scorer.evaluate(nearTarget, FitnessLevel.INTERMEDIATE);
+        TrackScorer.TrackEvaluation farEvaluation = scorer.evaluate(farFromTarget, FitnessLevel.INTERMEDIATE);
+
+        assertThat(nearEvaluation.eligible()).isTrue();
+        assertThat(farEvaluation.eligible()).isTrue();
+        assertThat(nearEvaluation.score()).isGreaterThan(farEvaluation.score());
+    }
+
+    @Test
+    void advancedLevelAllowsLongAndHighGainTrack() throws Exception {
+        Course course = course(
+                18000.0,
+                List.of(100.0, 1300.0),
+                List.of("DANGER", "VIEW", "PEAK")
+        );
+
+        TrackScorer.TrackEvaluation evaluation = scorer.evaluate(course, FitnessLevel.ADVANCED);
+
+        assertThat(evaluation.eligible()).isTrue();
+        assertThat(evaluation.metrics().gain()).isEqualTo(1200.0);
+    }
+
+    private Course course(Double distance, List<Double> altitudes, List<String> waypointCategories) throws Exception {
+        Constructor<Course> constructor = Course.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Course course = constructor.newInstance();
+
+        ReflectionTestUtils.setField(course, "distance", distance);
+        ReflectionTestUtils.setField(course, "altitudes", altitudes);
+        ReflectionTestUtils.setField(course, "waypoints", waypointCategories.stream()
+                .map(category -> new Course.CourseWaypoint(37.0, 127.0, 100.0, category, category))
+                .toList());
+        return course;
+    }
+}

--- a/src/test/java/com/semosan/api/domain/user/service/UserReaderTest.java
+++ b/src/test/java/com/semosan/api/domain/user/service/UserReaderTest.java
@@ -1,0 +1,97 @@
+package com.semosan.api.domain.user.service;
+
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.user.dto.command.CompleteOnboardingCommand;
+import com.semosan.api.domain.user.dto.command.CreateUserOnboardingCommand;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.entity.UserOnboarding;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseDuration;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseFrequency;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseType;
+import com.semosan.api.domain.user.enums.onboarding.HikingLevel;
+import com.semosan.api.domain.user.enums.user.DeviceType;
+import com.semosan.api.domain.user.enums.user.Gender;
+import com.semosan.api.domain.user.repository.UserOnboardingRepository;
+import com.semosan.api.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserReaderTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserOnboardingRepository userOnboardingRepository;
+
+    @Test
+    void findCompletedOnboardingByUserIdReturnsOnboardingWhenUserIsCompleted() {
+        User user = user();
+        UserOnboarding onboarding = onboarding(user);
+        when(userOnboardingRepository.findByUserIdWithUser(1L)).thenReturn(Optional.of(onboarding));
+
+        UserOnboarding result = new UserReader(userRepository, userOnboardingRepository)
+                .findCompletedOnboardingByUserId(1L);
+
+        assertThat(result).isSameAs(onboarding);
+        assertThat(result.getUser()).isSameAs(user);
+    }
+
+    @Test
+    void findCompletedOnboardingByUserIdThrowsWhenOnboardingMissing() {
+        when(userOnboardingRepository.findByUserIdWithUser(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> new UserReader(userRepository, userOnboardingRepository)
+                .findCompletedOnboardingByUserId(1L))
+                .isInstanceOf(GeneralException.class)
+                .extracting("errorStatus")
+                .isEqualTo(ErrorStatus.ONBOARDING_NOT_FOUND);
+    }
+
+    @Test
+    void findCompletedOnboardingByUserIdThrowsWhenUserNotCompleted() {
+        User user = User.createTestUser("reader-test-user", DeviceType.IOS);
+        UserOnboarding onboarding = onboarding(user);
+        when(userOnboardingRepository.findByUserIdWithUser(1L)).thenReturn(Optional.of(onboarding));
+
+        assertThatThrownBy(() -> new UserReader(userRepository, userOnboardingRepository)
+                .findCompletedOnboardingByUserId(1L))
+                .isInstanceOf(GeneralException.class)
+                .extracting("errorStatus")
+                .isEqualTo(ErrorStatus.ONBOARDING_NOT_COMPLETED);
+    }
+
+    private User user() {
+        User user = User.createTestUser("reader-test-user", DeviceType.IOS);
+        user.completeOnboarding(new CompleteOnboardingCommand(
+                "테스트",
+                null,
+                LocalDate.of(1990, 1, 1),
+                Gender.MALE,
+                175.0,
+                70.0
+        ));
+        return user;
+    }
+
+    private UserOnboarding onboarding(User user) {
+        return UserOnboarding.create(new CreateUserOnboardingCommand(
+                user,
+                HikingLevel.EXPERT,
+                ExerciseType.HIKING,
+                ExerciseFrequency.DAILY,
+                ExerciseDuration.OVER_4H
+        ));
+    }
+}


### PR DESCRIPTION
## 🧾 요약
  - 라이브 액티비티용 산 추천 로직을 온보딩 점수 기반 체계로 교체
  - 추천 응답을 PageResponse 없이 최대 3개 리스트로 반환하도록 변경
  - 추천용 온보딩 조회를 단일 쿼리로 정리하고, 산/코스 점수 계산 구조를 분리

  ## 🔗 이슈
  - close #100

  ## ✨ 변경 내용

  - FitnessLevelCalculator, TrackScorer 추가로 유저 체력 레벨 및 코스 점수 계산 분리
  - MountainService.getRecommendedMountains()를 새 추천 로직으로 교체
  - 추천 응답을 difficultyLabel, mountainHeightM 중심으로 스펙에 맞게 수정
  - UserReader에 온보딩 조회를 합쳐 추천용 조회를 단일화
  - 추천 관련 단위 테스트 추가 및 수정

  ## ✅ 확인

  - [x] 빌드 OK
  - [x] 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personalized mountain recommendations now return a curated list of 3 suggestions based on your onboarding-derived fitness level.
  * Course/route data now includes waypoint information for richer route details.

* **Changes**
  * Recommendations endpoint returns an unpaged, fixed top-3 list instead of paginated results.
  * Recommendation items show improved difficulty labels and a clearer mountain height metric.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->