### PR TITLE
[Fix] 트래킹 세션 생성 시 사진 마일스톤 초기화 호출 

### DIFF
--- a/src/main/java/com/semosan/api/domain/tracking/service/TrackingSessionService.java
+++ b/src/main/java/com/semosan/api/domain/tracking/service/TrackingSessionService.java
@@ -68,6 +68,12 @@ public class TrackingSessionService {
 
         TrackingSession session = TrackingSession.create(user, mountain, course, request.isFreeRecording());
         TrackingSession saved = saveSession(session);
+
+        // 세션 생성과 동시에 사진 마일스톤 거리 리스트(코스 4컷 / 자유 6컷)를 Redis 에 적재한다.
+        // 이후 GPS Consumer 가 매 점마다 evaluate 호출 시 이 키를 읽어 마일스톤 도달을 판정하므로,
+        // 여기서 빠지면 모든 photo-window OPEN/CLOSED 와 FCM 알림이 영영 발송되지 않는다.
+        photoTriggerService.initializeMilestones(saved);
+
         return TrackingSessionResponse.from(saved);
     }
 


### PR DESCRIPTION
## 🧾 요약
- 트래킹 세션 생성 시 사진 마일스톤 초기화 호출 

## 🔗 이슈
- close #106 

## ✨ 변경 내용
- 트래킹 세션 생성 시 사진 마일스톤 초기화 호출 
-

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an initialization issue with photo milestone tracking when a tracking session is created. This resolves problems preventing GPS milestone evaluation and photo-related notifications from functioning properly after session creation. The system now correctly initializes all required photo milestone data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->