### PR TITLE
[Fix] 자유게시한 댓글 대댓글 삭제 정책

### DIFF
--- a/src/main/java/com/semosan/api/domain/community/comment/dto/CommentResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/dto/CommentResponse.java
@@ -11,16 +11,21 @@ public record CommentResponse(
         String content,
         Long parentId,
         AuthorResponse mentionedUser,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        boolean isDeleted
 ) {
+    private static final String DELETED_CONTENT = "삭제된 댓글입니다";
+
     public static CommentResponse from(Comment comment) {
+        boolean deleted = comment.isDeleted();
         return new CommentResponse(
                 comment.getId(),
                 AuthorResponse.from(comment.getAuthor()),
-                comment.getContent(),
+                deleted ? DELETED_CONTENT : comment.getContent(),
                 comment.getParent() != null ? comment.getParent().getId() : null,
                 comment.getMentionedUser() != null ? AuthorResponse.from(comment.getMentionedUser()) : null,
-                comment.getCreatedAt()
+                comment.getCreatedAt(),
+                deleted
         );
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/repository/CommentRepository.java
@@ -15,7 +15,15 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Optional<Comment> findByIdAndDeletedFalse(Long id);
 
-    Page<Comment> findByPostAndParentIsNullAndDeletedFalse(Post post, Pageable pageable);
+    /**
+     * 게시글의 최상위 댓글 목록을 페이징 조회.
+     * 삭제된 부모라도 살아있는 대댓글이 하나라도 있으면 placeholder("삭제된 댓글입니다") 노출용으로 함께 반환한다.
+     * 자식이 전부 삭제됐거나 처음부터 없는 삭제 부모는 응답에서 제외해 노이즈를 줄인다.
+     */
+    @Query("SELECT c FROM Comment c WHERE c.post = :post AND c.parent IS NULL " +
+            "AND (c.deleted = false " +
+            "     OR EXISTS (SELECT 1 FROM Comment r WHERE r.parent = c AND r.deleted = false))")
+    Page<Comment> findVisibleParentsByPost(@Param("post") Post post, Pageable pageable);
 
     List<Comment> findByParentAndDeletedFalseOrderByCreatedAtAsc(Comment parent);
 

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -55,11 +55,16 @@ public class CommentService {
 
     public Page<Comment> getCommentsByPost(Long postId, Pageable pageable) {
         Post post = findPostOrThrow(postId);
-        return commentRepository.findByPostAndParentIsNullAndDeletedFalse(post, pageable);
+        return commentRepository.findVisibleParentsByPost(post, pageable);
     }
 
     public List<Comment> getReplies(Long parentId) {
-        Comment parent = findActiveCommentOrThrow(parentId);
+        // 부모가 삭제됐더라도 살아있는 대댓글이 있으면 댓글 목록 응답에 placeholder 로 노출된다.
+        // 클라가 placeholder 의 id 로 이 엔드포인트를 호출했을 때 404 가 나면 일관성이 깨지므로
+        // findActiveCommentOrThrow 대신 deleted 여부를 가리지 않는 findById 로 조회한다.
+        // 대댓글 자체는 deleted=false 만 반환하므로 placeholder + 빈 자식 케이스도 자연스럽게 빈 리스트.
+        Comment parent = commentRepository.findById(parentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
         return commentRepository.findByParentAndDeletedFalseOrderByCreatedAtAsc(parent);
     }
 


### PR DESCRIPTION
## 🧾 요약
- 자유게시한 댓글 대댓글 삭제 정책 적용

## 🔗 이슈
- close #111 

## ✨ 변경 내용
- 댓글 삭제 시 삭제된 댓글 이라고 응답
- 대댓글이 있던 댓글이면 대댓글은 그대로 내려감 
- 댓글 수는 삭제된 댓글을 제외한 수를 응답
- 삭제된 댓글 글쓴이의 이름은 따로 제외하지 않고 응답에 포함시켰음
- 단, 대댓글은 삭제되어도 댓글 트리 구성에 영향이 없기에 그냥 삭제시켜버렸음


## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deleted comments now display as "deleted comment" placeholders instead of being completely removed.
  * Thread structure is preserved when parent comments are deleted but have active replies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->