### PR TITLE
[Feat] 트래킹 FCM 알림 title 설정

### DIFF
--- a/src/main/java/com/semosan/api/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/semosan/api/domain/notification/enums/NotificationType.java
@@ -17,10 +17,10 @@ public enum NotificationType {
 
     /**
      * 트래킹 중 거리 마일스톤 도달 시 사진 촬영 유도.
-     * iOS 잠금화면에 title 은 앱 이름(SEMOSAN)이 자동 표시되므로 본 title 은 빈 문자열.
+     * iOS 배너 노출을 위해 notification.title 에 앱 이름을 명시한다.
      */
     TRACKING_PHOTO_MILESTONE(
-            "",
+            "SEMOSAN",
             "{distance}m 돌파! 인증 사진을 남겨보세요!",
             Set.of("distance")
     ),
@@ -28,10 +28,10 @@ public enum NotificationType {
     /**
      * 코스 거리 50% 도달 시 정상 인증 유도.
      * 진짜 정상 좌표가 식별 불가해 코스 절반 지점을 "정상" 근처로 간주하는 임시 정책.
-     * iOS 잠금화면에 title 은 앱 이름(SEMOSAN)이 자동 표시되므로 본 title 은 빈 문자열.
+     * iOS 배너 노출을 위해 notification.title 에 앱 이름을 명시한다.
      */
     TRACKING_SUMMIT_REACHED(
-            "",
+            "SEMOSAN",
             "정상에 도착했나요? 정상 인증하기!",
             Set.of()
     );


### PR DESCRIPTION
## 🧾 요약
  - iOS에서 트래킹 FCM 배너가 정상 노출되도록 알림 title을 `SEMOSAN`으로 설정

  ## 🔗 이슈
  - close #116

  ## ✨ 변경 내용
  - `TRACKING_PHOTO_MILESTONE` 알림 title을 빈 문자열에서 `SEMOSAN`으로 변경
  - `TRACKING_SUMMIT_REACHED` 알림 title을 빈 문자열에서 `SEMOSAN`으로 변경
  - title을 비워둔다는 기존 주석을 iOS 배너 노출 목적에 맞게 수정

  ## ✅ 확인
  - [x] 빌드 OK
  - [ ] 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * iOS push notifications for photo milestones and summit achievements now display the app name "SEMOSAN" in the notification title for improved clarity and app identification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->