### PR TITLE
[Feat] 대댓글 및 좋아요 시 알림 기능 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
 - Use Java 21 and Gradle.
 - Follow the existing package structure, naming, and style.
 - Prefer existing services, repositories, DTOs, and response conventions over introducing new abstractions.
+- When adding code, avoid duplicating business rules, payload construction, validation checks, formatting, or helper logic across services. Extract shared behavior into an appropriate existing service/helper or a narrowly scoped new component, and keep callers focused on orchestration.
 
 ## Commands
 - Use `rg` first for searching.

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -61,7 +61,9 @@ public class CommentService {
         User mentionedUser = mentionedUserId != null ? findUserOrThrow(mentionedUserId) : null;
 
         Comment reply = Comment.reply(post, author, actualParent, mentionedUser, content);
-        return commentRepository.save(reply);
+        Comment savedReply = commentRepository.save(reply);
+        sendReplyNotification(post, author, actualParent, savedReply);
+        return savedReply;
     }
 
     public Page<CommentResponse> getCommentsByPost(Long postId, Long viewerId, Pageable pageable) {
@@ -123,6 +125,26 @@ public class CommentService {
                         "postId", post.getId(),
                         "commentId", comment.getId(),
                         "commentPreview", comment.getContent()
+                )
+        );
+    }
+
+    private void sendReplyNotification(Post post, User author, Comment parent, Comment reply) {
+        User receiver = parent.getAuthor();
+        if (receiver.getId().equals(author.getId())) {
+            return;
+        }
+
+        notificationService.send(
+                receiver.getId(),
+                NotificationType.COMMUNITY_REPLY,
+                Map.of(
+                        "actorId", author.getId(),
+                        "actorName", displayName(author),
+                        "postId", post.getId(),
+                        "parentCommentId", parent.getId(),
+                        "commentId", reply.getId(),
+                        "commentPreview", reply.getContent()
                 )
         );
     }

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -62,7 +62,7 @@ public class CommentService {
 
         Comment reply = Comment.reply(post, author, actualParent, mentionedUser, content);
         Comment savedReply = commentRepository.save(reply);
-        sendReplyNotification(post, author, actualParent, savedReply);
+        sendReplyNotification(post, author, actualParent, mentionedUser, savedReply);
         return savedReply;
     }
 
@@ -132,9 +132,26 @@ public class CommentService {
         );
     }
 
-    private void sendReplyNotification(Post post, User author, Comment parent, Comment reply) {
-        User receiver = parent.getAuthor();
+    private void sendReplyNotification(Post post, User author, Comment parent, User mentionedUser, Comment reply) {
+        Set<Long> sentReceiverIds = new HashSet<>();
+        sendReplyNotificationToReceiver(post, author, parent, reply, parent.getAuthor(), sentReceiverIds);
+        if (mentionedUser != null) {
+            sendReplyNotificationToReceiver(post, author, parent, reply, mentionedUser, sentReceiverIds);
+        }
+    }
+
+    private void sendReplyNotificationToReceiver(
+            Post post,
+            User author,
+            Comment parent,
+            Comment reply,
+            User receiver,
+            Set<Long> sentReceiverIds
+    ) {
         if (receiver.getId().equals(author.getId())) {
+            return;
+        }
+        if (!sentReceiverIds.add(receiver.getId())) {
             return;
         }
         if (!userRepository.existsByIdAndDeletedFalse(receiver.getId())) {

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -7,6 +7,8 @@ import com.semosan.api.domain.community.comment.entity.Comment;
 import com.semosan.api.domain.community.comment.repository.CommentRepository;
 import com.semosan.api.domain.community.post.entity.Post;
 import com.semosan.api.domain.community.post.repository.PostRepository;
+import com.semosan.api.domain.notification.enums.NotificationType;
+import com.semosan.api.domain.notification.service.NotificationService;
 import com.semosan.api.domain.user.repository.UserBlockRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.repository.UserRepository;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Service
@@ -29,6 +32,7 @@ public class CommentService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final UserBlockRepository userBlockRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public Comment create(Long postId, Long authorId, String content) {
@@ -36,7 +40,9 @@ public class CommentService {
         User author = findUserOrThrow(authorId);
 
         Comment comment = Comment.create(post, author, content);
-        return commentRepository.save(comment);
+        Comment savedComment = commentRepository.save(comment);
+        sendCommentNotification(post, author, savedComment);
+        return savedComment;
     }
 
     @Transactional
@@ -100,5 +106,34 @@ public class CommentService {
     private Comment findActiveCommentOrThrow(Long commentId) {
         return commentRepository.findByIdAndDeletedFalse(commentId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+    }
+
+    private void sendCommentNotification(Post post, User author, Comment comment) {
+        User receiver = post.getAuthor();
+        if (receiver.getId().equals(author.getId())) {
+            return;
+        }
+
+        notificationService.send(
+                receiver.getId(),
+                NotificationType.COMMUNITY_COMMENT,
+                Map.of(
+                        "actorId", author.getId(),
+                        "actorName", displayName(author),
+                        "postId", post.getId(),
+                        "commentId", comment.getId(),
+                        "commentPreview", comment.getContent()
+                )
+        );
+    }
+
+    private String displayName(User user) {
+        if (user.getNickname() != null && !user.getNickname().isBlank()) {
+            return user.getNickname();
+        }
+        if (user.getName() != null && !user.getName().isBlank()) {
+            return user.getName();
+        }
+        return "사용자";
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -5,10 +5,9 @@ import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.comment.dto.CommentResponse;
 import com.semosan.api.domain.community.comment.entity.Comment;
 import com.semosan.api.domain.community.comment.repository.CommentRepository;
+import com.semosan.api.domain.community.notification.service.CommunityNotificationService;
 import com.semosan.api.domain.community.post.entity.Post;
 import com.semosan.api.domain.community.post.repository.PostRepository;
-import com.semosan.api.domain.notification.enums.NotificationType;
-import com.semosan.api.domain.notification.service.NotificationService;
 import com.semosan.api.domain.user.repository.UserBlockRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.repository.UserRepository;
@@ -20,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 @Service
@@ -28,13 +26,11 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public class CommentService {
 
-    private static final int COMMENT_PREVIEW_MAX_LENGTH = 50;
-
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final UserBlockRepository userBlockRepository;
-    private final NotificationService notificationService;
+    private final CommunityNotificationService communityNotificationService;
 
     @Transactional
     public Comment create(Long postId, Long authorId, String content) {
@@ -43,7 +39,7 @@ public class CommentService {
 
         Comment comment = Comment.create(post, author, content);
         Comment savedComment = commentRepository.save(comment);
-        sendCommentNotification(post, author, savedComment);
+        communityNotificationService.sendCommentNotification(post, author, savedComment);
         return savedComment;
     }
 
@@ -64,7 +60,7 @@ public class CommentService {
 
         Comment reply = Comment.reply(post, author, actualParent, mentionedUser, content);
         Comment savedReply = commentRepository.save(reply);
-        sendReplyNotification(post, author, actualParent, mentionedUser, savedReply);
+        communityNotificationService.sendReplyNotification(post, author, actualParent, mentionedUser, savedReply);
         return savedReply;
     }
 
@@ -110,77 +106,5 @@ public class CommentService {
     private Comment findActiveCommentOrThrow(Long commentId) {
         return commentRepository.findByIdAndDeletedFalse(commentId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
-    }
-
-    private void sendCommentNotification(Post post, User author, Comment comment) {
-        User receiver = post.getAuthor();
-        if (receiver.getId().equals(author.getId())) {
-            return;
-        }
-        if (!userRepository.existsByIdAndDeletedFalse(receiver.getId())) {
-            return;
-        }
-
-        notificationService.send(
-                receiver.getId(),
-                NotificationType.COMMUNITY_COMMENT,
-                Map.of(
-                        "actorId", author.getId(),
-                        "actorName", author.displayName(),
-                        "postId", post.getId(),
-                        "commentId", comment.getId(),
-                        "commentPreview", preview(comment.getContent())
-                )
-        );
-    }
-
-    private void sendReplyNotification(Post post, User author, Comment parent, User mentionedUser, Comment reply) {
-        Set<Long> sentReceiverIds = new HashSet<>();
-        sendReplyNotificationToReceiver(post, author, parent, reply, parent.getAuthor(), sentReceiverIds);
-        if (mentionedUser != null) {
-            sendReplyNotificationToReceiver(post, author, parent, reply, mentionedUser, sentReceiverIds);
-        }
-    }
-
-    private void sendReplyNotificationToReceiver(
-            Post post,
-            User author,
-            Comment parent,
-            Comment reply,
-            User receiver,
-            Set<Long> sentReceiverIds
-    ) {
-        if (receiver.getId().equals(author.getId())) {
-            return;
-        }
-        if (!sentReceiverIds.add(receiver.getId())) {
-            return;
-        }
-        if (!userRepository.existsByIdAndDeletedFalse(receiver.getId())) {
-            return;
-        }
-
-        notificationService.send(
-                receiver.getId(),
-                NotificationType.COMMUNITY_REPLY,
-                Map.of(
-                        "actorId", author.getId(),
-                        "actorName", author.displayName(),
-                        "postId", post.getId(),
-                        "parentCommentId", parent.getId(),
-                        "commentId", reply.getId(),
-                        "commentPreview", preview(reply.getContent())
-                )
-        );
-    }
-
-    private String preview(String content) {
-        if (content == null) {
-            return "";
-        }
-        if (content.length() <= COMMENT_PREVIEW_MAX_LENGTH) {
-            return content;
-        }
-        return content.substring(0, COMMENT_PREVIEW_MAX_LENGTH) + "...";
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -124,7 +124,7 @@ public class CommentService {
                 NotificationType.COMMUNITY_COMMENT,
                 Map.of(
                         "actorId", author.getId(),
-                        "actorName", displayName(author),
+                        "actorName", author.displayName(),
                         "postId", post.getId(),
                         "commentId", comment.getId(),
                         "commentPreview", comment.getContent()
@@ -163,22 +163,12 @@ public class CommentService {
                 NotificationType.COMMUNITY_REPLY,
                 Map.of(
                         "actorId", author.getId(),
-                        "actorName", displayName(author),
+                        "actorName", author.displayName(),
                         "postId", post.getId(),
                         "parentCommentId", parent.getId(),
                         "commentId", reply.getId(),
                         "commentPreview", reply.getContent()
                 )
         );
-    }
-
-    private String displayName(User user) {
-        if (user.getNickname() != null && !user.getNickname().isBlank()) {
-            return user.getNickname();
-        }
-        if (user.getName() != null && !user.getName().isBlank()) {
-            return user.getName();
-        }
-        return "사용자";
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -115,6 +115,9 @@ public class CommentService {
         if (receiver.getId().equals(author.getId())) {
             return;
         }
+        if (!userRepository.existsByIdAndDeletedFalse(receiver.getId())) {
+            return;
+        }
 
         notificationService.send(
                 receiver.getId(),
@@ -132,6 +135,9 @@ public class CommentService {
     private void sendReplyNotification(Post post, User author, Comment parent, Comment reply) {
         User receiver = parent.getAuthor();
         if (receiver.getId().equals(author.getId())) {
+            return;
+        }
+        if (!userRepository.existsByIdAndDeletedFalse(receiver.getId())) {
             return;
         }
 

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -28,6 +28,8 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public class CommentService {
 
+    private static final int COMMENT_PREVIEW_MAX_LENGTH = 50;
+
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
@@ -127,7 +129,7 @@ public class CommentService {
                         "actorName", author.displayName(),
                         "postId", post.getId(),
                         "commentId", comment.getId(),
-                        "commentPreview", comment.getContent()
+                        "commentPreview", preview(comment.getContent())
                 )
         );
     }
@@ -167,8 +169,18 @@ public class CommentService {
                         "postId", post.getId(),
                         "parentCommentId", parent.getId(),
                         "commentId", reply.getId(),
-                        "commentPreview", reply.getContent()
+                        "commentPreview", preview(reply.getContent())
                 )
         );
+    }
+
+    private String preview(String content) {
+        if (content == null) {
+            return "";
+        }
+        if (content.length() <= COMMENT_PREVIEW_MAX_LENGTH) {
+            return content;
+        }
+        return content.substring(0, COMMENT_PREVIEW_MAX_LENGTH) + "...";
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -5,10 +5,9 @@ import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.like.dto.PostLikeToggleResponse;
 import com.semosan.api.domain.community.like.entity.PostLike;
 import com.semosan.api.domain.community.like.repository.PostLikeRepository;
+import com.semosan.api.domain.community.notification.service.CommunityNotificationService;
 import com.semosan.api.domain.community.post.entity.Post;
 import com.semosan.api.domain.community.post.repository.PostRepository;
-import com.semosan.api.domain.notification.enums.NotificationType;
-import com.semosan.api.domain.notification.service.NotificationService;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +16,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -29,7 +27,7 @@ public class PostLikeService {
     private final PostLikeRepository postLikeRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
-    private final NotificationService notificationService;
+    private final CommunityNotificationService communityNotificationService;
 
     /**
      * @return true = 좋아요 누름 / false = 좋아요 취소
@@ -46,7 +44,7 @@ public class PostLikeService {
 
         try {
             postLikeRepository.save(PostLike.create(post, user));
-            sendPostLikeNotification(post, user);
+            communityNotificationService.sendPostLikeNotification(post, user);
             return true;
         } catch (DataIntegrityViolationException e) {
             log.warn("PostLike 동시 요청 감지: postId={}, userId={}", postId, userId);
@@ -80,25 +78,5 @@ public class PostLikeService {
     private User findUserOrThrow(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-    }
-
-    private void sendPostLikeNotification(Post post, User user) {
-        User receiver = post.getAuthor();
-        if (receiver.getId().equals(user.getId())) {
-            return;
-        }
-        if (!userRepository.existsByIdAndDeletedFalse(receiver.getId())) {
-            return;
-        }
-
-        notificationService.send(
-                receiver.getId(),
-                NotificationType.COMMUNITY_POST_LIKE,
-                Map.of(
-                        "actorId", user.getId(),
-                        "actorName", user.displayName(),
-                        "postId", post.getId()
-                )
-        );
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -96,19 +96,9 @@ public class PostLikeService {
                 NotificationType.COMMUNITY_POST_LIKE,
                 Map.of(
                         "actorId", user.getId(),
-                        "actorName", displayName(user),
+                        "actorName", user.displayName(),
                         "postId", post.getId()
                 )
         );
-    }
-
-    private String displayName(User user) {
-        if (user.getNickname() != null && !user.getNickname().isBlank()) {
-            return user.getNickname();
-        }
-        if (user.getName() != null && !user.getName().isBlank()) {
-            return user.getName();
-        }
-        return "사용자";
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -87,6 +87,9 @@ public class PostLikeService {
         if (receiver.getId().equals(user.getId())) {
             return;
         }
+        if (!userRepository.existsByIdAndDeletedFalse(receiver.getId())) {
+            return;
+        }
 
         notificationService.send(
                 receiver.getId(),

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -7,6 +7,8 @@ import com.semosan.api.domain.community.like.entity.PostLike;
 import com.semosan.api.domain.community.like.repository.PostLikeRepository;
 import com.semosan.api.domain.community.post.entity.Post;
 import com.semosan.api.domain.community.post.repository.PostRepository;
+import com.semosan.api.domain.notification.enums.NotificationType;
+import com.semosan.api.domain.notification.service.NotificationService;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -26,6 +29,7 @@ public class PostLikeService {
     private final PostLikeRepository postLikeRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     /**
      * @return true = 좋아요 누름 / false = 좋아요 취소
@@ -42,6 +46,7 @@ public class PostLikeService {
 
         try {
             postLikeRepository.save(PostLike.create(post, user));
+            sendPostLikeNotification(post, user);
             return true;
         } catch (DataIntegrityViolationException e) {
             log.warn("PostLike 동시 요청 감지: postId={}, userId={}", postId, userId);
@@ -75,5 +80,32 @@ public class PostLikeService {
     private User findUserOrThrow(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    private void sendPostLikeNotification(Post post, User user) {
+        User receiver = post.getAuthor();
+        if (receiver.getId().equals(user.getId())) {
+            return;
+        }
+
+        notificationService.send(
+                receiver.getId(),
+                NotificationType.COMMUNITY_POST_LIKE,
+                Map.of(
+                        "actorId", user.getId(),
+                        "actorName", displayName(user),
+                        "postId", post.getId()
+                )
+        );
+    }
+
+    private String displayName(User user) {
+        if (user.getNickname() != null && !user.getNickname().isBlank()) {
+            return user.getNickname();
+        }
+        if (user.getName() != null && !user.getName().isBlank()) {
+            return user.getName();
+        }
+        return "사용자";
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/notification/service/CommunityNotificationService.java
+++ b/src/main/java/com/semosan/api/domain/community/notification/service/CommunityNotificationService.java
@@ -40,9 +40,10 @@ public class CommunityNotificationService {
 
     public void sendReplyNotification(Post post, User author, Comment parent, User mentionedUser, Comment reply) {
         Set<Long> sentReceiverIds = new HashSet<>();
-        sendReplyNotificationToReceiver(post, author, parent, reply, parent.getAuthor(), sentReceiverIds);
+        ReplyNotificationContext context = new ReplyNotificationContext(post, author, parent, reply);
+        sendReplyNotificationToReceiver(context, parent.getAuthor(), sentReceiverIds);
         if (mentionedUser != null) {
-            sendReplyNotificationToReceiver(post, author, parent, reply, mentionedUser, sentReceiverIds);
+            sendReplyNotificationToReceiver(context, mentionedUser, sentReceiverIds);
         }
     }
 
@@ -61,10 +62,7 @@ public class CommunityNotificationService {
     }
 
     private void sendReplyNotificationToReceiver(
-            Post post,
-            User author,
-            Comment parent,
-            Comment reply,
+            ReplyNotificationContext context,
             User receiver,
             Set<Long> sentReceiverIds
     ) {
@@ -74,15 +72,15 @@ public class CommunityNotificationService {
 
         sendIfEligible(
                 receiver,
-                author,
+                context.author(),
                 NotificationType.COMMUNITY_REPLY,
                 Map.of(
-                        "actorId", author.getId(),
-                        "actorName", author.displayName(),
-                        "postId", post.getId(),
-                        "parentCommentId", parent.getId(),
-                        "commentId", reply.getId(),
-                        "commentPreview", preview(reply.getContent())
+                        "actorId", context.author().getId(),
+                        "actorName", context.author().displayName(),
+                        "postId", context.post().getId(),
+                        "parentCommentId", context.parent().getId(),
+                        "commentId", context.reply().getId(),
+                        "commentPreview", preview(context.reply().getContent())
                 )
         );
     }
@@ -106,5 +104,13 @@ public class CommunityNotificationService {
             return content;
         }
         return content.substring(0, COMMENT_PREVIEW_MAX_LENGTH) + "...";
+    }
+
+    private record ReplyNotificationContext(
+            Post post,
+            User author,
+            Comment parent,
+            Comment reply
+    ) {
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/notification/service/CommunityNotificationService.java
+++ b/src/main/java/com/semosan/api/domain/community/notification/service/CommunityNotificationService.java
@@ -1,0 +1,110 @@
+package com.semosan.api.domain.community.notification.service;
+
+import com.semosan.api.domain.community.comment.entity.Comment;
+import com.semosan.api.domain.community.post.entity.Post;
+import com.semosan.api.domain.notification.enums.NotificationType;
+import com.semosan.api.domain.notification.service.NotificationService;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityNotificationService {
+
+    private static final int COMMENT_PREVIEW_MAX_LENGTH = 50;
+
+    private final NotificationService notificationService;
+    private final UserRepository userRepository;
+
+    public void sendCommentNotification(Post post, User author, Comment comment) {
+        User receiver = post.getAuthor();
+        sendIfEligible(
+                receiver,
+                author,
+                NotificationType.COMMUNITY_COMMENT,
+                Map.of(
+                        "actorId", author.getId(),
+                        "actorName", author.displayName(),
+                        "postId", post.getId(),
+                        "commentId", comment.getId(),
+                        "commentPreview", preview(comment.getContent())
+                )
+        );
+    }
+
+    public void sendReplyNotification(Post post, User author, Comment parent, User mentionedUser, Comment reply) {
+        Set<Long> sentReceiverIds = new HashSet<>();
+        sendReplyNotificationToReceiver(post, author, parent, reply, parent.getAuthor(), sentReceiverIds);
+        if (mentionedUser != null) {
+            sendReplyNotificationToReceiver(post, author, parent, reply, mentionedUser, sentReceiverIds);
+        }
+    }
+
+    public void sendPostLikeNotification(Post post, User user) {
+        User receiver = post.getAuthor();
+        sendIfEligible(
+                receiver,
+                user,
+                NotificationType.COMMUNITY_POST_LIKE,
+                Map.of(
+                        "actorId", user.getId(),
+                        "actorName", user.displayName(),
+                        "postId", post.getId()
+                )
+        );
+    }
+
+    private void sendReplyNotificationToReceiver(
+            Post post,
+            User author,
+            Comment parent,
+            Comment reply,
+            User receiver,
+            Set<Long> sentReceiverIds
+    ) {
+        if (!sentReceiverIds.add(receiver.getId())) {
+            return;
+        }
+
+        sendIfEligible(
+                receiver,
+                author,
+                NotificationType.COMMUNITY_REPLY,
+                Map.of(
+                        "actorId", author.getId(),
+                        "actorName", author.displayName(),
+                        "postId", post.getId(),
+                        "parentCommentId", parent.getId(),
+                        "commentId", reply.getId(),
+                        "commentPreview", preview(reply.getContent())
+                )
+        );
+    }
+
+    private void sendIfEligible(User receiver, User actor, NotificationType type, Map<String, Object> params) {
+        if (receiver.getId().equals(actor.getId())) {
+            return;
+        }
+        if (!userRepository.existsByIdAndDeletedFalse(receiver.getId())) {
+            return;
+        }
+
+        notificationService.send(receiver.getId(), type, params);
+    }
+
+    private String preview(String content) {
+        if (content == null) {
+            return "";
+        }
+        if (content.length() <= COMMENT_PREVIEW_MAX_LENGTH) {
+            return content;
+        }
+        return content.substring(0, COMMENT_PREVIEW_MAX_LENGTH) + "...";
+    }
+}

--- a/src/main/java/com/semosan/api/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/semosan/api/domain/notification/enums/NotificationType.java
@@ -8,11 +8,24 @@ import java.util.Set;
 
 public enum NotificationType {
 
-    // 테스트 용
     COMMUNITY_COMMENT(
             "새 댓글이 달렸어요",
             "{actorName}: {commentPreview}",
             Set.of("actorName", "commentPreview"),
+            false
+    ),
+
+    COMMUNITY_REPLY(
+            "새 답글이 달렸어요",
+            "{actorName}: {commentPreview}",
+            Set.of("actorName", "commentPreview"),
+            false
+    ),
+
+    COMMUNITY_POST_LIKE(
+            "게시글에 좋아요가 눌렸어요",
+            "{actorName}님이 게시글을 좋아합니다",
+            Set.of("actorName"),
             false
     ),
 

--- a/src/main/java/com/semosan/api/domain/user/entity/User.java
+++ b/src/main/java/com/semosan/api/domain/user/entity/User.java
@@ -144,6 +144,16 @@ public class User extends BaseEntity {
         this.nickname = nickname;
     }
 
+    public String displayName() {
+        if (this.nickname != null && !this.nickname.isBlank()) {
+            return this.nickname;
+        }
+        if (this.name != null && !this.name.isBlank()) {
+            return this.name;
+        }
+        return "사용자";
+    }
+
     // 온보딩 완료 처리
     public void completeOnboarding(CompleteOnboardingCommand command) {
         this.nickname = command.nickname();

--- a/src/main/resources/db/migration/V22__update_community_notification_types.sql
+++ b/src/main/resources/db/migration/V22__update_community_notification_types.sql
@@ -1,0 +1,16 @@
+-- =====================================================================
+-- V22__update_community_notification_types.sql
+-- 목적: notifications.type CHECK 제약에 커뮤니티 답글/좋아요 알림 타입을 포함시킨다.
+-- 배경: Hibernate enum 컬럼 CHECK 는 새 enum 추가 시 자동 갱신되지 않는다.
+-- =====================================================================
+
+ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
+
+ALTER TABLE notifications ADD CONSTRAINT notifications_type_check
+    CHECK (type IN (
+        'COMMUNITY_COMMENT',
+        'COMMUNITY_REPLY',
+        'COMMUNITY_POST_LIKE',
+        'TRACKING_PHOTO_MILESTONE',
+        'TRACKING_SUMMIT_REACHED'
+    ));

--- a/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
@@ -1,0 +1,114 @@
+package com.semosan.api.domain.community.comment.service;
+
+import com.semosan.api.domain.community.comment.entity.Comment;
+import com.semosan.api.domain.community.comment.repository.CommentRepository;
+import com.semosan.api.domain.community.post.entity.FreePost;
+import com.semosan.api.domain.community.post.repository.PostRepository;
+import com.semosan.api.domain.notification.enums.NotificationType;
+import com.semosan.api.domain.notification.service.NotificationService;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.enums.user.DeviceType;
+import com.semosan.api.domain.user.repository.UserBlockRepository;
+import com.semosan.api.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserBlockRepository userBlockRepository;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void createSendsCommentNotificationToPostAuthor() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User commentAuthor = user(2L, "comment-author");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(commentAuthor));
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment comment = invocation.getArgument(0);
+            ReflectionTestUtils.setField(comment, "id", 100L);
+            return comment;
+        });
+
+        Comment result = commentService.create(10L, 2L, "댓글입니다");
+
+        assertThat(result.getId()).isEqualTo(100L);
+
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notificationService).send(
+                eq(1L),
+                eq(NotificationType.COMMUNITY_COMMENT),
+                paramsCaptor.capture()
+        );
+        assertThat(paramsCaptor.getValue())
+                .containsEntry("actorId", 2L)
+                .containsEntry("actorName", "comment-author")
+                .containsEntry("postId", 10L)
+                .containsEntry("commentId", 100L)
+                .containsEntry("commentPreview", "댓글입니다");
+    }
+
+    @Test
+    void createDoesNotSendCommentNotificationToSelf() throws Exception {
+        User author = user(1L, "author");
+        FreePost post = freePost(10L, author, "제목", "본문");
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(author));
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        commentService.create(10L, 1L, "내 댓글");
+
+        verify(notificationService, never()).send(any(), any(), any());
+    }
+
+    private User user(Long id, String nickname) {
+        User user = User.createTestUser(nickname, DeviceType.IOS);
+        ReflectionTestUtils.setField(user, "id", id);
+        ReflectionTestUtils.setField(user, "nickname", nickname);
+        return user;
+    }
+
+    private FreePost freePost(Long id, User author, String title, String content) throws Exception {
+        Constructor<FreePost> constructor = FreePost.class.getDeclaredConstructor(User.class, String.class, String.class);
+        constructor.setAccessible(true);
+        FreePost post = constructor.newInstance(author, title, content);
+        ReflectionTestUtils.setField(post, "id", id);
+        return post;
+    }
+}

--- a/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
@@ -2,31 +2,25 @@ package com.semosan.api.domain.community.comment.service;
 
 import com.semosan.api.domain.community.comment.entity.Comment;
 import com.semosan.api.domain.community.comment.repository.CommentRepository;
+import com.semosan.api.domain.community.notification.service.CommunityNotificationService;
 import com.semosan.api.domain.community.post.entity.FreePost;
 import com.semosan.api.domain.community.post.repository.PostRepository;
-import com.semosan.api.domain.notification.enums.NotificationType;
-import com.semosan.api.domain.notification.service.NotificationService;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.enums.user.DeviceType;
 import com.semosan.api.domain.user.repository.UserBlockRepository;
 import com.semosan.api.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Constructor;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,21 +40,19 @@ class CommentServiceTest {
     private UserBlockRepository userBlockRepository;
 
     @Mock
-    private NotificationService notificationService;
+    private CommunityNotificationService communityNotificationService;
 
     @InjectMocks
     private CommentService commentService;
 
     @Test
-    @SuppressWarnings("unchecked")
-    void createSendsCommentNotificationToPostAuthor() throws Exception {
+    void createSavesCommentAndDelegatesNotification() throws Exception {
         User postAuthor = user(1L, "post-author");
         User commentAuthor = user(2L, "comment-author");
         FreePost post = freePost(10L, postAuthor, "제목", "본문");
 
         when(postRepository.findById(10L)).thenReturn(Optional.of(post));
         when(userRepository.findById(2L)).thenReturn(Optional.of(commentAuthor));
-        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(true);
         when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
             Comment comment = invocation.getArgument(0);
             ReflectionTestUtils.setField(comment, "id", 100L);
@@ -70,167 +62,11 @@ class CommentServiceTest {
         Comment result = commentService.create(10L, 2L, "댓글입니다");
 
         assertThat(result.getId()).isEqualTo(100L);
-
-        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(notificationService).send(
-                eq(1L),
-                eq(NotificationType.COMMUNITY_COMMENT),
-                paramsCaptor.capture()
-        );
-        assertThat(paramsCaptor.getValue())
-                .containsEntry("actorId", 2L)
-                .containsEntry("actorName", "comment-author")
-                .containsEntry("postId", 10L)
-                .containsEntry("commentId", 100L)
-                .containsEntry("commentPreview", "댓글입니다");
+        verify(communityNotificationService).sendCommentNotification(post, commentAuthor, result);
     }
 
     @Test
-    void createDoesNotSendCommentNotificationToSelf() throws Exception {
-        User author = user(1L, "author");
-        FreePost post = freePost(10L, author, "제목", "본문");
-
-        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(author));
-        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
-        commentService.create(10L, 1L, "내 댓글");
-
-        verify(notificationService, never()).send(any(), any(), any());
-    }
-
-    @Test
-    void createDoesNotSendCommentNotificationToInactivePostAuthor() throws Exception {
-        User postAuthor = user(1L, "post-author");
-        User commentAuthor = user(2L, "comment-author");
-        FreePost post = freePost(10L, postAuthor, "제목", "본문");
-
-        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(commentAuthor));
-        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(false);
-        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
-            Comment comment = invocation.getArgument(0);
-            ReflectionTestUtils.setField(comment, "id", 100L);
-            return comment;
-        });
-
-        Comment result = commentService.create(10L, 2L, "댓글입니다");
-
-        assertThat(result.getId()).isEqualTo(100L);
-        verify(notificationService, never()).send(any(), any(), any());
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    void createTrimsCommentPreview() throws Exception {
-        User postAuthor = user(1L, "post-author");
-        User commentAuthor = user(2L, "comment-author");
-        FreePost post = freePost(10L, postAuthor, "제목", "본문");
-        String longContent = "가".repeat(51);
-
-        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(commentAuthor));
-        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(true);
-        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
-            Comment comment = invocation.getArgument(0);
-            ReflectionTestUtils.setField(comment, "id", 100L);
-            return comment;
-        });
-
-        commentService.create(10L, 2L, longContent);
-
-        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(notificationService).send(
-                eq(1L),
-                eq(NotificationType.COMMUNITY_COMMENT),
-                paramsCaptor.capture()
-        );
-        assertThat(paramsCaptor.getValue())
-                .containsEntry("commentPreview", "가".repeat(50) + "...");
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    void replySendsReplyNotificationToParentCommentAuthor() throws Exception {
-        User postAuthor = user(1L, "post-author");
-        User parentAuthor = user(2L, "parent-author");
-        User replyAuthor = user(3L, "reply-author");
-        FreePost post = freePost(10L, postAuthor, "제목", "본문");
-        Comment parent = comment(100L, post, parentAuthor, "부모 댓글");
-
-        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(3L)).thenReturn(Optional.of(replyAuthor));
-        when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
-        when(userRepository.existsByIdAndDeletedFalse(2L)).thenReturn(true);
-        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
-            Comment comment = invocation.getArgument(0);
-            ReflectionTestUtils.setField(comment, "id", 101L);
-            return comment;
-        });
-
-        Comment result = commentService.reply(10L, 3L, 100L, null, "대댓글입니다");
-
-        assertThat(result.getId()).isEqualTo(101L);
-
-        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(notificationService).send(
-                eq(2L),
-                eq(NotificationType.COMMUNITY_REPLY),
-                paramsCaptor.capture()
-        );
-        assertThat(paramsCaptor.getValue())
-                .containsEntry("actorId", 3L)
-                .containsEntry("actorName", "reply-author")
-                .containsEntry("postId", 10L)
-                .containsEntry("parentCommentId", 100L)
-                .containsEntry("commentId", 101L)
-                .containsEntry("commentPreview", "대댓글입니다");
-    }
-
-    @Test
-    void replyDoesNotSendReplyNotificationToSelf() throws Exception {
-        User postAuthor = user(1L, "post-author");
-        User author = user(2L, "author");
-        FreePost post = freePost(10L, postAuthor, "제목", "본문");
-        Comment parent = comment(100L, post, author, "내 댓글");
-
-        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(author));
-        when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
-        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
-        commentService.reply(10L, 2L, 100L, null, "내 대댓글");
-
-        verify(notificationService, never()).send(any(), any(), any());
-    }
-
-    @Test
-    void replyDoesNotSendReplyNotificationToInactiveParentAuthor() throws Exception {
-        User postAuthor = user(1L, "post-author");
-        User parentAuthor = user(2L, "parent-author");
-        User replyAuthor = user(3L, "reply-author");
-        FreePost post = freePost(10L, postAuthor, "제목", "본문");
-        Comment parent = comment(100L, post, parentAuthor, "부모 댓글");
-
-        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(3L)).thenReturn(Optional.of(replyAuthor));
-        when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
-        when(userRepository.existsByIdAndDeletedFalse(2L)).thenReturn(false);
-        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
-            Comment comment = invocation.getArgument(0);
-            ReflectionTestUtils.setField(comment, "id", 101L);
-            return comment;
-        });
-
-        Comment result = commentService.reply(10L, 3L, 100L, null, "대댓글입니다");
-
-        assertThat(result.getId()).isEqualTo(101L);
-        verify(notificationService, never()).send(any(), any(), any());
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    void replySendsReplyNotificationToMentionedUser() throws Exception {
+    void replySavesReplyAndDelegatesNotification() throws Exception {
         User postAuthor = user(1L, "post-author");
         User parentAuthor = user(2L, "parent-author");
         User replyAuthor = user(3L, "reply-author");
@@ -242,59 +78,17 @@ class CommentServiceTest {
         when(userRepository.findById(3L)).thenReturn(Optional.of(replyAuthor));
         when(userRepository.findById(4L)).thenReturn(Optional.of(mentionedUser));
         when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
-        when(userRepository.existsByIdAndDeletedFalse(2L)).thenReturn(true);
-        when(userRepository.existsByIdAndDeletedFalse(4L)).thenReturn(true);
         when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
             Comment comment = invocation.getArgument(0);
             ReflectionTestUtils.setField(comment, "id", 101L);
             return comment;
         });
 
-        commentService.reply(10L, 3L, 100L, 4L, "대댓글입니다");
+        Comment result = commentService.reply(10L, 3L, 100L, 4L, "대댓글입니다");
 
-        ArgumentCaptor<Long> receiverCaptor = ArgumentCaptor.forClass(Long.class);
-        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(notificationService, times(2)).send(
-                receiverCaptor.capture(),
-                eq(NotificationType.COMMUNITY_REPLY),
-                paramsCaptor.capture()
-        );
-        assertThat(receiverCaptor.getAllValues()).containsExactly(2L, 4L);
-        assertThat(paramsCaptor.getAllValues().get(1))
-                .containsEntry("actorId", 3L)
-                .containsEntry("actorName", "reply-author")
-                .containsEntry("postId", 10L)
-                .containsEntry("parentCommentId", 100L)
-                .containsEntry("commentId", 101L)
-                .containsEntry("commentPreview", "대댓글입니다");
-    }
-
-    @Test
-    void replyDoesNotSendDuplicateNotificationWhenMentionedUserIsParentAuthor() throws Exception {
-        User postAuthor = user(1L, "post-author");
-        User parentAuthor = user(2L, "parent-author");
-        User replyAuthor = user(3L, "reply-author");
-        FreePost post = freePost(10L, postAuthor, "제목", "본문");
-        Comment parent = comment(100L, post, parentAuthor, "부모 댓글");
-
-        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(3L)).thenReturn(Optional.of(replyAuthor));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(parentAuthor));
-        when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
-        when(userRepository.existsByIdAndDeletedFalse(2L)).thenReturn(true);
-        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
-            Comment comment = invocation.getArgument(0);
-            ReflectionTestUtils.setField(comment, "id", 101L);
-            return comment;
-        });
-
-        commentService.reply(10L, 3L, 100L, 2L, "대댓글입니다");
-
-        verify(notificationService, times(1)).send(
-                eq(2L),
-                eq(NotificationType.COMMUNITY_REPLY),
-                any()
-        );
+        assertThat(result.getId()).isEqualTo(101L);
+        verify(communityNotificationService)
+                .sendReplyNotification(post, replyAuthor, parent, mentionedUser, result);
     }
 
     private User user(Long id, String nickname) {

--- a/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
@@ -122,6 +122,35 @@ class CommentServiceTest {
 
     @Test
     @SuppressWarnings("unchecked")
+    void createTrimsCommentPreview() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User commentAuthor = user(2L, "comment-author");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+        String longContent = "가".repeat(51);
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(commentAuthor));
+        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(true);
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment comment = invocation.getArgument(0);
+            ReflectionTestUtils.setField(comment, "id", 100L);
+            return comment;
+        });
+
+        commentService.create(10L, 2L, longContent);
+
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notificationService).send(
+                eq(1L),
+                eq(NotificationType.COMMUNITY_COMMENT),
+                paramsCaptor.capture()
+        );
+        assertThat(paramsCaptor.getValue())
+                .containsEntry("commentPreview", "가".repeat(50) + "...");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     void replySendsReplyNotificationToParentCommentAuthor() throws Exception {
         User postAuthor = user(1L, "post-author");
         User parentAuthor = user(2L, "parent-author");

--- a/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
@@ -59,6 +59,7 @@ class CommentServiceTest {
 
         when(postRepository.findById(10L)).thenReturn(Optional.of(post));
         when(userRepository.findById(2L)).thenReturn(Optional.of(commentAuthor));
+        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(true);
         when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
             Comment comment = invocation.getArgument(0);
             ReflectionTestUtils.setField(comment, "id", 100L);
@@ -98,6 +99,27 @@ class CommentServiceTest {
     }
 
     @Test
+    void createDoesNotSendCommentNotificationToInactivePostAuthor() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User commentAuthor = user(2L, "comment-author");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(commentAuthor));
+        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(false);
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment comment = invocation.getArgument(0);
+            ReflectionTestUtils.setField(comment, "id", 100L);
+            return comment;
+        });
+
+        Comment result = commentService.create(10L, 2L, "댓글입니다");
+
+        assertThat(result.getId()).isEqualTo(100L);
+        verify(notificationService, never()).send(any(), any(), any());
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void replySendsReplyNotificationToParentCommentAuthor() throws Exception {
         User postAuthor = user(1L, "post-author");
@@ -109,6 +131,7 @@ class CommentServiceTest {
         when(postRepository.findById(10L)).thenReturn(Optional.of(post));
         when(userRepository.findById(3L)).thenReturn(Optional.of(replyAuthor));
         when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
+        when(userRepository.existsByIdAndDeletedFalse(2L)).thenReturn(true);
         when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
             Comment comment = invocation.getArgument(0);
             ReflectionTestUtils.setField(comment, "id", 101L);
@@ -148,6 +171,30 @@ class CommentServiceTest {
 
         commentService.reply(10L, 2L, 100L, null, "내 대댓글");
 
+        verify(notificationService, never()).send(any(), any(), any());
+    }
+
+    @Test
+    void replyDoesNotSendReplyNotificationToInactiveParentAuthor() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User parentAuthor = user(2L, "parent-author");
+        User replyAuthor = user(3L, "reply-author");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+        Comment parent = comment(100L, post, parentAuthor, "부모 댓글");
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(replyAuthor));
+        when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
+        when(userRepository.existsByIdAndDeletedFalse(2L)).thenReturn(false);
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment comment = invocation.getArgument(0);
+            ReflectionTestUtils.setField(comment, "id", 101L);
+            return comment;
+        });
+
+        Comment result = commentService.reply(10L, 3L, 100L, null, "대댓글입니다");
+
+        assertThat(result.getId()).isEqualTo(101L);
         verify(notificationService, never()).send(any(), any(), any());
     }
 

--- a/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -196,6 +197,75 @@ class CommentServiceTest {
 
         assertThat(result.getId()).isEqualTo(101L);
         verify(notificationService, never()).send(any(), any(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void replySendsReplyNotificationToMentionedUser() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User parentAuthor = user(2L, "parent-author");
+        User replyAuthor = user(3L, "reply-author");
+        User mentionedUser = user(4L, "mentioned-user");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+        Comment parent = comment(100L, post, parentAuthor, "부모 댓글");
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(replyAuthor));
+        when(userRepository.findById(4L)).thenReturn(Optional.of(mentionedUser));
+        when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
+        when(userRepository.existsByIdAndDeletedFalse(2L)).thenReturn(true);
+        when(userRepository.existsByIdAndDeletedFalse(4L)).thenReturn(true);
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment comment = invocation.getArgument(0);
+            ReflectionTestUtils.setField(comment, "id", 101L);
+            return comment;
+        });
+
+        commentService.reply(10L, 3L, 100L, 4L, "대댓글입니다");
+
+        ArgumentCaptor<Long> receiverCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notificationService, times(2)).send(
+                receiverCaptor.capture(),
+                eq(NotificationType.COMMUNITY_REPLY),
+                paramsCaptor.capture()
+        );
+        assertThat(receiverCaptor.getAllValues()).containsExactly(2L, 4L);
+        assertThat(paramsCaptor.getAllValues().get(1))
+                .containsEntry("actorId", 3L)
+                .containsEntry("actorName", "reply-author")
+                .containsEntry("postId", 10L)
+                .containsEntry("parentCommentId", 100L)
+                .containsEntry("commentId", 101L)
+                .containsEntry("commentPreview", "대댓글입니다");
+    }
+
+    @Test
+    void replyDoesNotSendDuplicateNotificationWhenMentionedUserIsParentAuthor() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User parentAuthor = user(2L, "parent-author");
+        User replyAuthor = user(3L, "reply-author");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+        Comment parent = comment(100L, post, parentAuthor, "부모 댓글");
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(replyAuthor));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(parentAuthor));
+        when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
+        when(userRepository.existsByIdAndDeletedFalse(2L)).thenReturn(true);
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment comment = invocation.getArgument(0);
+            ReflectionTestUtils.setField(comment, "id", 101L);
+            return comment;
+        });
+
+        commentService.reply(10L, 3L, 100L, 2L, "대댓글입니다");
+
+        verify(notificationService, times(1)).send(
+                eq(2L),
+                eq(NotificationType.COMMUNITY_REPLY),
+                any()
+        );
     }
 
     private User user(Long id, String nickname) {

--- a/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
@@ -97,6 +97,60 @@ class CommentServiceTest {
         verify(notificationService, never()).send(any(), any(), any());
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void replySendsReplyNotificationToParentCommentAuthor() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User parentAuthor = user(2L, "parent-author");
+        User replyAuthor = user(3L, "reply-author");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+        Comment parent = comment(100L, post, parentAuthor, "부모 댓글");
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(replyAuthor));
+        when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment comment = invocation.getArgument(0);
+            ReflectionTestUtils.setField(comment, "id", 101L);
+            return comment;
+        });
+
+        Comment result = commentService.reply(10L, 3L, 100L, null, "대댓글입니다");
+
+        assertThat(result.getId()).isEqualTo(101L);
+
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notificationService).send(
+                eq(2L),
+                eq(NotificationType.COMMUNITY_REPLY),
+                paramsCaptor.capture()
+        );
+        assertThat(paramsCaptor.getValue())
+                .containsEntry("actorId", 3L)
+                .containsEntry("actorName", "reply-author")
+                .containsEntry("postId", 10L)
+                .containsEntry("parentCommentId", 100L)
+                .containsEntry("commentId", 101L)
+                .containsEntry("commentPreview", "대댓글입니다");
+    }
+
+    @Test
+    void replyDoesNotSendReplyNotificationToSelf() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User author = user(2L, "author");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+        Comment parent = comment(100L, post, author, "내 댓글");
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(author));
+        when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        commentService.reply(10L, 2L, 100L, null, "내 대댓글");
+
+        verify(notificationService, never()).send(any(), any(), any());
+    }
+
     private User user(Long id, String nickname) {
         User user = User.createTestUser(nickname, DeviceType.IOS);
         ReflectionTestUtils.setField(user, "id", id);
@@ -110,5 +164,11 @@ class CommentServiceTest {
         FreePost post = constructor.newInstance(author, title, content);
         ReflectionTestUtils.setField(post, "id", id);
         return post;
+    }
+
+    private Comment comment(Long id, FreePost post, User author, String content) {
+        Comment comment = Comment.create(post, author, content);
+        ReflectionTestUtils.setField(comment, "id", id);
+        return comment;
     }
 }

--- a/src/test/java/com/semosan/api/domain/community/like/service/PostLikeServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/like/service/PostLikeServiceTest.java
@@ -1,0 +1,139 @@
+package com.semosan.api.domain.community.like.service;
+
+import com.semosan.api.domain.community.like.entity.PostLike;
+import com.semosan.api.domain.community.like.repository.PostLikeRepository;
+import com.semosan.api.domain.community.post.entity.FreePost;
+import com.semosan.api.domain.community.post.repository.PostRepository;
+import com.semosan.api.domain.notification.enums.NotificationType;
+import com.semosan.api.domain.notification.service.NotificationService;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.enums.user.DeviceType;
+import com.semosan.api.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PostLikeServiceTest {
+
+    @Mock
+    private PostLikeRepository postLikeRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private PostLikeService postLikeService;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void toggleWithCountSendsLikeNotificationWhenLikeCreated() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User liker = user(2L, "liker");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+
+        when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(liker));
+        when(postLikeRepository.findByPostAndUser(post, liker)).thenReturn(Optional.empty());
+        when(postLikeRepository.countByPost(post)).thenReturn(1L);
+
+        postLikeService.toggleWithCount(10L, 2L);
+
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notificationService).send(
+                eq(1L),
+                eq(NotificationType.COMMUNITY_POST_LIKE),
+                paramsCaptor.capture()
+        );
+        assertThat(paramsCaptor.getValue())
+                .containsEntry("actorId", 2L)
+                .containsEntry("actorName", "liker")
+                .containsEntry("postId", 10L);
+    }
+
+    @Test
+    void toggleWithCountDoesNotSendLikeNotificationWhenUnlike() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User liker = user(2L, "liker");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+        PostLike existing = PostLike.create(post, liker);
+
+        when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(liker));
+        when(postLikeRepository.findByPostAndUser(post, liker)).thenReturn(Optional.of(existing));
+        when(postLikeRepository.countByPost(post)).thenReturn(0L);
+
+        postLikeService.toggleWithCount(10L, 2L);
+
+        verify(notificationService, never()).send(any(), any(), any());
+    }
+
+    @Test
+    void toggleWithCountDoesNotSendLikeNotificationToSelf() throws Exception {
+        User author = user(1L, "author");
+        FreePost post = freePost(10L, author, "제목", "본문");
+
+        when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(author));
+        when(postLikeRepository.findByPostAndUser(post, author)).thenReturn(Optional.empty());
+        when(postLikeRepository.countByPost(post)).thenReturn(1L);
+
+        postLikeService.toggleWithCount(10L, 1L);
+
+        verify(notificationService, never()).send(any(), any(), any());
+    }
+
+    @Test
+    void toggleWithCountDoesNotSendLikeNotificationWhenConcurrentDuplicateDetected() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User liker = user(2L, "liker");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+
+        when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(liker));
+        when(postLikeRepository.findByPostAndUser(post, liker)).thenReturn(Optional.empty());
+        when(postLikeRepository.save(any(PostLike.class))).thenThrow(new DataIntegrityViolationException("duplicate"));
+        when(postLikeRepository.countByPost(post)).thenReturn(1L);
+
+        postLikeService.toggleWithCount(10L, 2L);
+
+        verify(notificationService, never()).send(any(), any(), any());
+    }
+
+    private User user(Long id, String nickname) {
+        User user = User.createTestUser(nickname, DeviceType.IOS);
+        ReflectionTestUtils.setField(user, "id", id);
+        ReflectionTestUtils.setField(user, "nickname", nickname);
+        return user;
+    }
+
+    private FreePost freePost(Long id, User author, String title, String content) throws Exception {
+        Constructor<FreePost> constructor = FreePost.class.getDeclaredConstructor(User.class, String.class, String.class);
+        constructor.setAccessible(true);
+        FreePost post = constructor.newInstance(author, title, content);
+        ReflectionTestUtils.setField(post, "id", id);
+        return post;
+    }
+}

--- a/src/test/java/com/semosan/api/domain/community/like/service/PostLikeServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/like/service/PostLikeServiceTest.java
@@ -56,6 +56,7 @@ class PostLikeServiceTest {
 
         when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
         when(userRepository.findById(2L)).thenReturn(Optional.of(liker));
+        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(true);
         when(postLikeRepository.findByPostAndUser(post, liker)).thenReturn(Optional.empty());
         when(postLikeRepository.countByPost(post)).thenReturn(1L);
 
@@ -101,6 +102,23 @@ class PostLikeServiceTest {
         when(postLikeRepository.countByPost(post)).thenReturn(1L);
 
         postLikeService.toggleWithCount(10L, 1L);
+
+        verify(notificationService, never()).send(any(), any(), any());
+    }
+
+    @Test
+    void toggleWithCountDoesNotSendLikeNotificationToInactivePostAuthor() throws Exception {
+        User postAuthor = user(1L, "post-author");
+        User liker = user(2L, "liker");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+
+        when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(liker));
+        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(false);
+        when(postLikeRepository.findByPostAndUser(post, liker)).thenReturn(Optional.empty());
+        when(postLikeRepository.countByPost(post)).thenReturn(1L);
+
+        postLikeService.toggleWithCount(10L, 2L);
 
         verify(notificationService, never()).send(any(), any(), any());
     }

--- a/src/test/java/com/semosan/api/domain/community/like/service/PostLikeServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/like/service/PostLikeServiceTest.java
@@ -1,17 +1,16 @@
 package com.semosan.api.domain.community.like.service;
 
+import com.semosan.api.domain.community.like.dto.PostLikeToggleResponse;
 import com.semosan.api.domain.community.like.entity.PostLike;
 import com.semosan.api.domain.community.like.repository.PostLikeRepository;
+import com.semosan.api.domain.community.notification.service.CommunityNotificationService;
 import com.semosan.api.domain.community.post.entity.FreePost;
 import com.semosan.api.domain.community.post.repository.PostRepository;
-import com.semosan.api.domain.notification.enums.NotificationType;
-import com.semosan.api.domain.notification.service.NotificationService;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.enums.user.DeviceType;
 import com.semosan.api.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,12 +18,10 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Constructor;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,40 +39,31 @@ class PostLikeServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private NotificationService notificationService;
+    private CommunityNotificationService communityNotificationService;
 
     @InjectMocks
     private PostLikeService postLikeService;
 
     @Test
-    @SuppressWarnings("unchecked")
-    void toggleWithCountSendsLikeNotificationWhenLikeCreated() throws Exception {
+    void toggleWithCountDelegatesNotificationWhenLikeCreated() throws Exception {
         User postAuthor = user(1L, "post-author");
         User liker = user(2L, "liker");
         FreePost post = freePost(10L, postAuthor, "제목", "본문");
 
         when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
         when(userRepository.findById(2L)).thenReturn(Optional.of(liker));
-        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(true);
         when(postLikeRepository.findByPostAndUser(post, liker)).thenReturn(Optional.empty());
         when(postLikeRepository.countByPost(post)).thenReturn(1L);
 
-        postLikeService.toggleWithCount(10L, 2L);
+        PostLikeToggleResponse result = postLikeService.toggleWithCount(10L, 2L);
 
-        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(notificationService).send(
-                eq(1L),
-                eq(NotificationType.COMMUNITY_POST_LIKE),
-                paramsCaptor.capture()
-        );
-        assertThat(paramsCaptor.getValue())
-                .containsEntry("actorId", 2L)
-                .containsEntry("actorName", "liker")
-                .containsEntry("postId", 10L);
+        assertThat(result.liked()).isTrue();
+        assertThat(result.count()).isEqualTo(1L);
+        verify(communityNotificationService).sendPostLikeNotification(post, liker);
     }
 
     @Test
-    void toggleWithCountDoesNotSendLikeNotificationWhenUnlike() throws Exception {
+    void toggleWithCountDoesNotDelegateNotificationWhenUnlike() throws Exception {
         User postAuthor = user(1L, "post-author");
         User liker = user(2L, "liker");
         FreePost post = freePost(10L, postAuthor, "제목", "본문");
@@ -86,45 +74,15 @@ class PostLikeServiceTest {
         when(postLikeRepository.findByPostAndUser(post, liker)).thenReturn(Optional.of(existing));
         when(postLikeRepository.countByPost(post)).thenReturn(0L);
 
-        postLikeService.toggleWithCount(10L, 2L);
+        PostLikeToggleResponse result = postLikeService.toggleWithCount(10L, 2L);
 
-        verify(notificationService, never()).send(any(), any(), any());
+        assertThat(result.liked()).isFalse();
+        assertThat(result.count()).isZero();
+        verify(communityNotificationService, never()).sendPostLikeNotification(any(), any());
     }
 
     @Test
-    void toggleWithCountDoesNotSendLikeNotificationToSelf() throws Exception {
-        User author = user(1L, "author");
-        FreePost post = freePost(10L, author, "제목", "본문");
-
-        when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(author));
-        when(postLikeRepository.findByPostAndUser(post, author)).thenReturn(Optional.empty());
-        when(postLikeRepository.countByPost(post)).thenReturn(1L);
-
-        postLikeService.toggleWithCount(10L, 1L);
-
-        verify(notificationService, never()).send(any(), any(), any());
-    }
-
-    @Test
-    void toggleWithCountDoesNotSendLikeNotificationToInactivePostAuthor() throws Exception {
-        User postAuthor = user(1L, "post-author");
-        User liker = user(2L, "liker");
-        FreePost post = freePost(10L, postAuthor, "제목", "본문");
-
-        when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(liker));
-        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(false);
-        when(postLikeRepository.findByPostAndUser(post, liker)).thenReturn(Optional.empty());
-        when(postLikeRepository.countByPost(post)).thenReturn(1L);
-
-        postLikeService.toggleWithCount(10L, 2L);
-
-        verify(notificationService, never()).send(any(), any(), any());
-    }
-
-    @Test
-    void toggleWithCountDoesNotSendLikeNotificationWhenConcurrentDuplicateDetected() throws Exception {
+    void toggleWithCountDoesNotDelegateNotificationWhenConcurrentDuplicateDetected() throws Exception {
         User postAuthor = user(1L, "post-author");
         User liker = user(2L, "liker");
         FreePost post = freePost(10L, postAuthor, "제목", "본문");
@@ -135,9 +93,11 @@ class PostLikeServiceTest {
         when(postLikeRepository.save(any(PostLike.class))).thenThrow(new DataIntegrityViolationException("duplicate"));
         when(postLikeRepository.countByPost(post)).thenReturn(1L);
 
-        postLikeService.toggleWithCount(10L, 2L);
+        PostLikeToggleResponse result = postLikeService.toggleWithCount(10L, 2L);
 
-        verify(notificationService, never()).send(any(), any(), any());
+        assertThat(result.liked()).isTrue();
+        assertThat(result.count()).isEqualTo(1L);
+        verify(communityNotificationService, never()).sendPostLikeNotification(any(), any());
     }
 
     private User user(Long id, String nickname) {

--- a/src/test/java/com/semosan/api/domain/community/notification/service/CommunityNotificationServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/notification/service/CommunityNotificationServiceTest.java
@@ -1,0 +1,212 @@
+package com.semosan.api.domain.community.notification.service;
+
+import com.semosan.api.domain.community.comment.entity.Comment;
+import com.semosan.api.domain.community.post.entity.FreePost;
+import com.semosan.api.domain.notification.enums.NotificationType;
+import com.semosan.api.domain.notification.service.NotificationService;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.enums.user.DeviceType;
+import com.semosan.api.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommunityNotificationServiceTest {
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sendCommentNotificationSendsToPostAuthor() throws Exception {
+        CommunityNotificationService service = service();
+        User postAuthor = user(1L, "post-author");
+        User commentAuthor = user(2L, "comment-author");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+        Comment comment = comment(100L, post, commentAuthor, "댓글입니다");
+
+        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(true);
+
+        service.sendCommentNotification(post, commentAuthor, comment);
+
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notificationService).send(
+                eq(1L),
+                eq(NotificationType.COMMUNITY_COMMENT),
+                paramsCaptor.capture()
+        );
+        assertThat(paramsCaptor.getValue())
+                .containsEntry("actorId", 2L)
+                .containsEntry("actorName", "comment-author")
+                .containsEntry("postId", 10L)
+                .containsEntry("commentId", 100L)
+                .containsEntry("commentPreview", "댓글입니다");
+    }
+
+    @Test
+    void sendCommentNotificationSkipsSelfAndInactiveReceiver() throws Exception {
+        CommunityNotificationService service = service();
+        User author = user(1L, "author");
+        User inactivePostAuthor = user(2L, "inactive-author");
+        FreePost selfPost = freePost(10L, author, "제목", "본문");
+        FreePost inactiveAuthorPost = freePost(11L, inactivePostAuthor, "제목", "본문");
+
+        when(userRepository.existsByIdAndDeletedFalse(2L)).thenReturn(false);
+
+        service.sendCommentNotification(selfPost, author, comment(100L, selfPost, author, "내 댓글"));
+        service.sendCommentNotification(
+                inactiveAuthorPost,
+                author,
+                comment(101L, inactiveAuthorPost, author, "댓글입니다")
+        );
+
+        verify(notificationService, never()).send(any(), any(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sendReplyNotificationSendsToParentAndMentionedUserWithoutDuplicate() throws Exception {
+        CommunityNotificationService service = service();
+        User postAuthor = user(1L, "post-author");
+        User parentAuthor = user(2L, "parent-author");
+        User replyAuthor = user(3L, "reply-author");
+        User mentionedUser = user(4L, "mentioned-user");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+        Comment parent = comment(100L, post, parentAuthor, "부모 댓글");
+        Comment reply = reply(101L, post, replyAuthor, parent, mentionedUser, "대댓글입니다");
+
+        when(userRepository.existsByIdAndDeletedFalse(2L)).thenReturn(true);
+        when(userRepository.existsByIdAndDeletedFalse(4L)).thenReturn(true);
+
+        service.sendReplyNotification(post, replyAuthor, parent, mentionedUser, reply);
+
+        ArgumentCaptor<Long> receiverCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notificationService, times(2)).send(
+                receiverCaptor.capture(),
+                eq(NotificationType.COMMUNITY_REPLY),
+                paramsCaptor.capture()
+        );
+        assertThat(receiverCaptor.getAllValues()).containsExactly(2L, 4L);
+        assertThat(paramsCaptor.getAllValues().get(0))
+                .containsEntry("actorId", 3L)
+                .containsEntry("actorName", "reply-author")
+                .containsEntry("postId", 10L)
+                .containsEntry("parentCommentId", 100L)
+                .containsEntry("commentId", 101L)
+                .containsEntry("commentPreview", "대댓글입니다");
+    }
+
+    @Test
+    void sendReplyNotificationSkipsDuplicateMentionedUser() throws Exception {
+        CommunityNotificationService service = service();
+        User postAuthor = user(1L, "post-author");
+        User parentAuthor = user(2L, "parent-author");
+        User replyAuthor = user(3L, "reply-author");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+        Comment parent = comment(100L, post, parentAuthor, "부모 댓글");
+        Comment reply = reply(101L, post, replyAuthor, parent, parentAuthor, "대댓글입니다");
+
+        when(userRepository.existsByIdAndDeletedFalse(2L)).thenReturn(true);
+
+        service.sendReplyNotification(post, replyAuthor, parent, parentAuthor, reply);
+
+        verify(notificationService, times(1)).send(eq(2L), eq(NotificationType.COMMUNITY_REPLY), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sendPostLikeNotificationSendsToPostAuthor() throws Exception {
+        CommunityNotificationService service = service();
+        User postAuthor = user(1L, "post-author");
+        User liker = user(2L, "liker");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+
+        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(true);
+
+        service.sendPostLikeNotification(post, liker);
+
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notificationService).send(
+                eq(1L),
+                eq(NotificationType.COMMUNITY_POST_LIKE),
+                paramsCaptor.capture()
+        );
+        assertThat(paramsCaptor.getValue())
+                .containsEntry("actorId", 2L)
+                .containsEntry("actorName", "liker")
+                .containsEntry("postId", 10L);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sendCommentNotificationTrimsPreview() throws Exception {
+        CommunityNotificationService service = service();
+        User postAuthor = user(1L, "post-author");
+        User commentAuthor = user(2L, "comment-author");
+        FreePost post = freePost(10L, postAuthor, "제목", "본문");
+        Comment comment = comment(100L, post, commentAuthor, "가".repeat(51));
+
+        when(userRepository.existsByIdAndDeletedFalse(1L)).thenReturn(true);
+
+        service.sendCommentNotification(post, commentAuthor, comment);
+
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notificationService).send(
+                eq(1L),
+                eq(NotificationType.COMMUNITY_COMMENT),
+                paramsCaptor.capture()
+        );
+        assertThat(paramsCaptor.getValue())
+                .containsEntry("commentPreview", "가".repeat(50) + "...");
+    }
+
+    private CommunityNotificationService service() {
+        return new CommunityNotificationService(notificationService, userRepository);
+    }
+
+    private User user(Long id, String nickname) {
+        User user = User.createTestUser(nickname, DeviceType.IOS);
+        ReflectionTestUtils.setField(user, "id", id);
+        ReflectionTestUtils.setField(user, "nickname", nickname);
+        return user;
+    }
+
+    private FreePost freePost(Long id, User author, String title, String content) throws Exception {
+        Constructor<FreePost> constructor = FreePost.class.getDeclaredConstructor(User.class, String.class, String.class);
+        constructor.setAccessible(true);
+        FreePost post = constructor.newInstance(author, title, content);
+        ReflectionTestUtils.setField(post, "id", id);
+        return post;
+    }
+
+    private Comment comment(Long id, FreePost post, User author, String content) {
+        Comment comment = Comment.create(post, author, content);
+        ReflectionTestUtils.setField(comment, "id", id);
+        return comment;
+    }
+
+    private Comment reply(Long id, FreePost post, User author, Comment parent, User mentionedUser, String content) {
+        Comment comment = Comment.reply(post, author, parent, mentionedUser, content);
+        ReflectionTestUtils.setField(comment, "id", id);
+        return comment;
+    }
+}


### PR DESCRIPTION
## 🧾 요약
  - 커뮤니티 댓글, 대댓글, 게시글 좋아요에 대한 FCM 알림 발송 기능을 추가

  ## 🔗 이슈
  - close #126

  ## ✨ 변경 내용

  - 커뮤니티 알림 타입(COMMUNITY_COMMENT, COMMUNITY_REPLY, COMMUNITY_POST_LIKE) 및 DB check
    constraint migration 추가
  - 댓글 작성 시 게시글 작성자에게 알림 발송
  - 대댓글 작성 시 부모 댓글 작성자와 멘션된 사용자에게 알림 발송
  - 게시글 좋아요 생성 시 게시글 작성자에게 알림 발송
  - 본인/비활성 유저/중복 수신자는 알림 제외
  - 커뮤니티 알림 payload 구성, 수신자 필터링, 미리보기 제한 로직을 CommunityNotificationService로 공통화
  - commentPreview 50자 초과 시 말줄임 처리
  - User.displayName() 추가로 표시 이름 로직 공통화

  ## ✅ 확인
  - [x] 빌드 OK
  - [x] 테스트 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community notifications: receive alerts for new comments, replies, and post likes.
  * Notification previews are trimmed for concise display (shortened with "..." when long).
* **Enhancements**
  * Improved user display name selection with reliable fallbacks for clearer identification.
* **Chores**
  * Notification types updated to include community-related events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEMOSAN/SEMOSAN_BE/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->