### PR TITLE
[Feat] 자유게시글 상세 조회 응답에 로그인 사용자의 좋아요 여부를 추가

### DIFF
--- a/src/main/java/com/semosan/api/domain/community/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/like/repository/PostLikeRepository.java
@@ -14,6 +14,8 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     boolean existsByPostAndUser(Post post, User user);
 
+    boolean existsByPostIdAndUserId(Long postId, Long userId);
+
     long countByPost(Post post);
 
     Optional<PostLike> findByPostAndUser(Post post, User user);

--- a/src/main/java/com/semosan/api/domain/community/post/dto/FreePostDetailResponse.java
+++ b/src/main/java/com/semosan/api/domain/community/post/dto/FreePostDetailResponse.java
@@ -14,6 +14,7 @@ public record FreePostDetailResponse(
         List<PostImageResponse> images,
         Integer viewCount,
         Long likeCount,
+        boolean likedByMe,
         Long commentCount,
         LocalDateTime createdAt
 ) {
@@ -21,7 +22,8 @@ public record FreePostDetailResponse(
             FreePost post,
             List<PostImage> images,
             long likeCount,
-            long commentCount
+            long commentCount,
+            boolean likedByMe
     ) {
         return new FreePostDetailResponse(
                 post.getId(),
@@ -31,6 +33,7 @@ public record FreePostDetailResponse(
                 images.stream().map(PostImageResponse::from).toList(),
                 post.getViewCount(),
                 likeCount,
+                likedByMe,
                 commentCount,
                 post.getCreatedAt()
         );

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -55,7 +55,7 @@ public class FreePostService {
 
         List<PostImage> images = saveImages(post, imageUrls, mainImageIndex);
 
-        return FreePostDetailResponse.of(post, images, 0L, 0L);
+        return FreePostDetailResponse.of(post, images, 0L, 0L, false);
     }
 
     public Page<FreePostListResponse> getList(Long viewerId, Pageable pageable) {
@@ -87,8 +87,11 @@ public class FreePostService {
         List<PostImage> images = postImageRepository.findByPostOrderBySortOrderAsc(post);
         long likeCount = postLikeRepository.countByPost(post);
         long commentCount = commentRepository.countByPostAndDeletedFalse(post);
+        User viewer = userRepository.findById(viewerId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        boolean likedByMe = postLikeRepository.existsByPostAndUser(post, viewer);
 
-        return FreePostDetailResponse.of(post, images, likeCount, commentCount);
+        return FreePostDetailResponse.of(post, images, likeCount, commentCount, likedByMe);
     }
 
     @Transactional

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -87,9 +87,7 @@ public class FreePostService {
         List<PostImage> images = postImageRepository.findByPostOrderBySortOrderAsc(post);
         long likeCount = postLikeRepository.countByPost(post);
         long commentCount = commentRepository.countByPostAndDeletedFalse(post);
-        User viewer = userRepository.findById(viewerId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-        boolean likedByMe = postLikeRepository.existsByPostAndUser(post, viewer);
+        boolean likedByMe = postLikeRepository.existsByPostIdAndUserId(post.getId(), viewerId);
 
         return FreePostDetailResponse.of(post, images, likeCount, commentCount, likedByMe);
     }

--- a/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
@@ -80,7 +80,6 @@ class FreePostServiceTest {
 
     @Test
     void getDetailReturnsLikedByMe() throws Exception {
-        User viewer = user(1L, "viewer");
         User author = user(2L, "author");
         FreePost post = freePost(10L, author, "제목", "본문");
 
@@ -89,8 +88,7 @@ class FreePostServiceTest {
         when(postImageRepository.findByPostOrderBySortOrderAsc(post)).thenReturn(List.of());
         when(postLikeRepository.countByPost(post)).thenReturn(3L);
         when(commentRepository.countByPostAndDeletedFalse(post)).thenReturn(2L);
-        when(userRepository.findById(1L)).thenReturn(Optional.of(viewer));
-        when(postLikeRepository.existsByPostAndUser(post, viewer)).thenReturn(true);
+        when(postLikeRepository.existsByPostIdAndUserId(10L, 1L)).thenReturn(true);
 
         FreePostDetailResponse result = freePostService.getDetail(1L, 10L);
 

--- a/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
@@ -67,8 +67,8 @@ class FreePostServiceTest {
         Page<FreePost> page = new PageImpl<>(List.of(post), PageRequest.of(0, 10), 1);
 
         when(freePostRepository.findVisibleByViewerId(1L, PageRequest.of(0, 10))).thenReturn(page);
-        when(postLikeRepository.countByPostIdsGrouped(anyList())).thenReturn(List.of(new Object[]{10L, 3L}));
-        when(commentRepository.countByPostIdsGrouped(anyList())).thenReturn(List.of(new Object[]{10L, 2L}));
+        when(postLikeRepository.countByPostIdsGrouped(anyList())).thenReturn(List.<Object[]>of(new Object[]{10L, 3L}));
+        when(commentRepository.countByPostIdsGrouped(anyList())).thenReturn(List.<Object[]>of(new Object[]{10L, 2L}));
         when(postImageRepository.findMainImagesByPostIds(anyList())).thenReturn(List.of());
         when(postImageRepository.countByPostIdsGrouped(anyList())).thenReturn(List.of());
 
@@ -76,6 +76,27 @@ class FreePostServiceTest {
 
         assertThat(result).hasSize(1);
         verify(freePostRepository).findVisibleByViewerId(eq(1L), eq(PageRequest.of(0, 10)));
+    }
+
+    @Test
+    void getDetailReturnsLikedByMe() throws Exception {
+        User viewer = user(1L, "viewer");
+        User author = user(2L, "author");
+        FreePost post = freePost(10L, author, "제목", "본문");
+
+        when(freePostRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(userBlockRepository.existsByBlocker_IdAndBlockedUser_Id(1L, 2L)).thenReturn(false);
+        when(postImageRepository.findByPostOrderBySortOrderAsc(post)).thenReturn(List.of());
+        when(postLikeRepository.countByPost(post)).thenReturn(3L);
+        when(commentRepository.countByPostAndDeletedFalse(post)).thenReturn(2L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(viewer));
+        when(postLikeRepository.existsByPostAndUser(post, viewer)).thenReturn(true);
+
+        FreePostDetailResponse result = freePostService.getDetail(1L, 10L);
+
+        assertThat(result.likedByMe()).isTrue();
+        assertThat(result.likeCount()).isEqualTo(3L);
+        assertThat(result.commentCount()).isEqualTo(2L);
     }
 
     @Test


### PR DESCRIPTION
## 🧾 요약
  - 자유게시글 상세 조회 응답에 로그인 사용자의 좋아요 여부를 추가

## 🔗 이슈

  - close #120

  ## ✨ 변경 내용

  - GET /api/community/free-posts/{postId} 응답에 likedByMe 필드 추가
  - 게시글 상세 조회 시 postId, userId 기반으로 좋아요 여부 조회
  - 게시글 생성 응답은 likedByMe=false로 반환
  - FreePostServiceTest에 좋아요 여부 검증 추가
  - 기존 테스트의 List<Object[]> 타입 추론 컴파일 오류 수정

  ## ✅ 확인

  - [x] 빌드 OK
  - [x] 테스트 OK