### PR TITLE
[Fix] APNs silent push 설정을 추가

### DIFF
--- a/src/main/java/com/semosan/api/common/fcm/FcmService.java
+++ b/src/main/java/com/semosan/api/common/fcm/FcmService.java
@@ -31,7 +31,9 @@ public class FcmService {
                     .setBody(body)
                     .build();
             builder.setNotification(notification);
-        } else {
+        }
+
+        if (dataOnly) {
             builder.setApnsConfig(silentPushApnsConfig());
         }
 

--- a/src/main/java/com/semosan/api/common/fcm/FcmService.java
+++ b/src/main/java/com/semosan/api/common/fcm/FcmService.java
@@ -1,5 +1,7 @@
 package com.semosan.api.common.fcm;
 
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -29,6 +31,8 @@ public class FcmService {
                     .setBody(body)
                     .build();
             builder.setNotification(notification);
+        } else {
+            builder.setApnsConfig(silentPushApnsConfig());
         }
 
         if (data != null && !data.isEmpty()) {
@@ -38,6 +42,14 @@ public class FcmService {
         String response = FirebaseMessaging.getInstance().send(builder.build());
         log.info("FCM 발송 성공: {}", response);
         return response;
+    }
+
+    private ApnsConfig silentPushApnsConfig() {
+        return ApnsConfig.builder()
+                .setAps(Aps.builder()
+                        .setContentAvailable(true)
+                        .build())
+                .build();
     }
 
 }


### PR DESCRIPTION
## 🧾 요약

  - iOS 백그라운드 상태에서도 트래킹 data-only FCM 알림이 처리될 수 있도록 APNs silent push 설정을 추가했습니다.

  ## 🔗 이슈
  - close #135

  ## ✨ 변경 내용
  - dataOnly=true FCM 메시지에 APNs contentAvailable=true 설정 추가
  - 일반 notification payload 알림은 기존 동작 유지
  - dataOnly 조건을 명시적으로 분리해 APNs 설정 적용 의도 개선

  ## ✅ 확인
  - [x] 빌드 OK
      - ./gradlew compileJava
  - [x] 테스트 OK
      - ./gradlew test --tests
        com.semosan.api.domain.notification.dispatcher.AsyncNotificationDispatcherTest