### PR TITLE
[Feat] 데모 시연용 트래킹 사진 조회 API 구현

### DIFF
--- a/src/main/java/com/semosan/api/common/config/DemoProperties.java
+++ b/src/main/java/com/semosan/api/common/config/DemoProperties.java
@@ -1,0 +1,10 @@
+package com.semosan.api.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "demo")
+public record DemoProperties(
+        List<String> photoFilenames
+) {}

--- a/src/main/java/com/semosan/api/common/config/DemoProperties.java
+++ b/src/main/java/com/semosan/api/common/config/DemoProperties.java
@@ -7,4 +7,8 @@ import java.util.List;
 @ConfigurationProperties(prefix = "demo")
 public record DemoProperties(
         List<String> photoFilenames
-) {}
+) {
+    public DemoProperties {
+        photoFilenames = photoFilenames == null ? List.of() : photoFilenames;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/demo/controller/DemoController.java
+++ b/src/main/java/com/semosan/api/domain/demo/controller/DemoController.java
@@ -1,39 +1,24 @@
 package com.semosan.api.domain.demo.controller;
 
 import com.semosan.api.common.config.DemoProperties;
-import com.semosan.api.common.config.MinioProperties;
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.status.SuccessStatus;
 import com.semosan.api.domain.demo.controller.docs.DemoControllerDocs;
-import com.semosan.api.domain.tracking.entity.TrackingPhoto;
-import com.semosan.api.domain.tracking.repository.TrackingPhotoRepository;
-import io.minio.GetPresignedObjectUrlArgs;
-import io.minio.MinioClient;
-import io.minio.http.Method;
+import com.semosan.api.domain.demo.service.DemoService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-@Slf4j
 @RestController
 @RequestMapping("/api/demo")
 @RequiredArgsConstructor
 @EnableConfigurationProperties(DemoProperties.class)
 public class DemoController implements DemoControllerDocs {
 
-    private static final String BUCKET = "tracking-photos";
-
-    private final DemoProperties demoProperties;
-    private final MinioClient minioClient;
-    private final MinioProperties minioProperties;
-    private final TrackingPhotoRepository trackingPhotoRepository;
+    private final DemoService demoService;
 
     @GetMapping("/tracking/sessions/{sessionId}/photos")
     @Override
@@ -41,39 +26,7 @@ public class DemoController implements DemoControllerDocs {
             @PathVariable Long sessionId,
             @RequestParam(defaultValue = "3") int count
     ) {
-        List<String> shuffled = new ArrayList<>(demoProperties.photoFilenames());
-        Collections.shuffle(shuffled);
-        List<String> randomUrls = shuffled.subList(0, Math.min(count, shuffled.size()))
-                .stream()
-                .map(this::presignedGetUrl)
-                .toList();
-
-        List<String> uploadedUrls = trackingPhotoRepository
-                .findByTrackingSession_IdOrderByMilestoneIndexAsc(sessionId)
-                .stream()
-                .map(TrackingPhoto::getImageUrl)
-                .toList();
-
-        List<String> combined = new ArrayList<>(randomUrls);
-        combined.addAll(uploadedUrls);
-
+        List<String> combined = demoService.getDemoPhotos(sessionId, count);
         return ApiResponse.success(SuccessStatus.TRACKING_PHOTO_LIST_SUCCESS, combined);
-    }
-
-    private String presignedGetUrl(String objectKey) {
-        try {
-            String url = minioClient.getPresignedObjectUrl(
-                    GetPresignedObjectUrlArgs.builder()
-                            .method(Method.GET)
-                            .bucket(BUCKET)
-                            .object(objectKey)
-                            .expiry(1, TimeUnit.HOURS)
-                            .build()
-            );
-            return url.replace(minioProperties.endpoint(), minioProperties.publicUrl());
-        } catch (Exception e) {
-            log.warn("Failed to generate presigned URL for {}", objectKey, e);
-            return minioProperties.publicUrl() + "/" + BUCKET + "/" + objectKey;
-        }
     }
 }

--- a/src/main/java/com/semosan/api/domain/demo/controller/DemoController.java
+++ b/src/main/java/com/semosan/api/domain/demo/controller/DemoController.java
@@ -1,0 +1,79 @@
+package com.semosan.api.domain.demo.controller;
+
+import com.semosan.api.common.config.DemoProperties;
+import com.semosan.api.common.config.MinioProperties;
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.demo.controller.docs.DemoControllerDocs;
+import com.semosan.api.domain.tracking.entity.TrackingPhoto;
+import com.semosan.api.domain.tracking.repository.TrackingPhotoRepository;
+import io.minio.GetPresignedObjectUrlArgs;
+import io.minio.MinioClient;
+import io.minio.http.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/demo")
+@RequiredArgsConstructor
+@EnableConfigurationProperties(DemoProperties.class)
+public class DemoController implements DemoControllerDocs {
+
+    private static final String BUCKET = "tracking-photos";
+
+    private final DemoProperties demoProperties;
+    private final MinioClient minioClient;
+    private final MinioProperties minioProperties;
+    private final TrackingPhotoRepository trackingPhotoRepository;
+
+    @GetMapping("/tracking/sessions/{sessionId}/photos")
+    @Override
+    public ResponseEntity<ApiResponse<List<String>>> getDemoPhotos(
+            @PathVariable Long sessionId,
+            @RequestParam(defaultValue = "3") int count
+    ) {
+        List<String> shuffled = new ArrayList<>(demoProperties.photoFilenames());
+        Collections.shuffle(shuffled);
+        List<String> randomUrls = shuffled.subList(0, Math.min(count, shuffled.size()))
+                .stream()
+                .map(this::presignedGetUrl)
+                .toList();
+
+        List<String> uploadedUrls = trackingPhotoRepository
+                .findByTrackingSession_IdOrderByMilestoneIndexAsc(sessionId)
+                .stream()
+                .map(TrackingPhoto::getImageUrl)
+                .toList();
+
+        List<String> combined = new ArrayList<>(randomUrls);
+        combined.addAll(uploadedUrls);
+
+        return ApiResponse.success(SuccessStatus.TRACKING_PHOTO_LIST_SUCCESS, combined);
+    }
+
+    private String presignedGetUrl(String objectKey) {
+        try {
+            String url = minioClient.getPresignedObjectUrl(
+                    GetPresignedObjectUrlArgs.builder()
+                            .method(Method.GET)
+                            .bucket(BUCKET)
+                            .object(objectKey)
+                            .expiry(1, TimeUnit.HOURS)
+                            .build()
+            );
+            return url.replace(minioProperties.endpoint(), minioProperties.publicUrl());
+        } catch (Exception e) {
+            log.warn("Failed to generate presigned URL for {}", objectKey, e);
+            return minioProperties.publicUrl() + "/" + BUCKET + "/" + objectKey;
+        }
+    }
+}

--- a/src/main/java/com/semosan/api/domain/demo/controller/docs/DemoControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/demo/controller/docs/DemoControllerDocs.java
@@ -1,0 +1,33 @@
+package com.semosan.api.domain.demo.controller.docs;
+
+import com.semosan.api.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "Demo", description = "시연용 API")
+public interface DemoControllerDocs {
+
+    @Operation(
+            summary = "시연용 트래킹 사진 조회",
+            description = "MinIO에 미리 올려둔 사진 중 랜덤 N개 + 해당 세션에서 직접 촬영한 사진 URL을 합쳐서 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "시연용 사진 목록 조회 성공"
+            )
+    })
+    ResponseEntity<ApiResponse<List<String>>> getDemoPhotos(
+            @Parameter(description = "트래킹 세션 ID", required = true)
+            @PathVariable Long sessionId,
+            @Parameter(description = "랜덤 사진 개수 (기본값 3)", required = false)
+            @RequestParam(defaultValue = "3") int count
+    );
+}

--- a/src/main/java/com/semosan/api/domain/demo/service/DemoService.java
+++ b/src/main/java/com/semosan/api/domain/demo/service/DemoService.java
@@ -1,0 +1,69 @@
+
+package com.semosan.api.domain.demo.service;
+
+import com.semosan.api.common.config.DemoProperties;
+import com.semosan.api.common.config.MinioProperties;
+import com.semosan.api.domain.tracking.entity.TrackingPhoto;
+import com.semosan.api.domain.tracking.repository.TrackingPhotoRepository;
+import io.minio.GetPresignedObjectUrlArgs;
+import io.minio.MinioClient;
+import io.minio.http.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DemoService {
+
+    private static final String BUCKET = "tracking-photos";
+
+    private final DemoProperties demoProperties;
+    private final MinioClient minioClient;
+    private final MinioProperties minioProperties;
+    private final TrackingPhotoRepository trackingPhotoRepository;
+
+    public List<String> getDemoPhotos(Long sessionId, int count) {
+        List<String> shuffled = new ArrayList<>(demoProperties.photoFilenames());
+        Collections.shuffle(shuffled);
+        List<String> randomUrls = shuffled.subList(0, Math.min(count, shuffled.size()))
+                .stream()
+                .map(this::presignedGetUrl)
+                .toList();
+
+        List<String> uploadedUrls = trackingPhotoRepository
+                .findByTrackingSession_IdOrderByMilestoneIndexAsc(sessionId)
+                .stream()
+                .map(TrackingPhoto::getImageUrl)
+                .toList();
+
+        List<String> combined = new ArrayList<>(randomUrls);
+        combined.addAll(uploadedUrls);
+        return combined;
+    }
+
+    private String presignedGetUrl(String objectKey) {
+        try {
+            String url = minioClient.getPresignedObjectUrl(
+                    GetPresignedObjectUrlArgs.builder()
+                            .method(Method.GET)
+                            .bucket(BUCKET)
+                            .object(objectKey)
+                            .expiry(1, TimeUnit.HOURS)
+                            .build()
+            );
+            return url.replace(minioProperties.endpoint(), minioProperties.publicUrl());
+        } catch (Exception e) {
+            log.warn("Failed to generate presigned URL for {}", objectKey, e);
+            return minioProperties.publicUrl() + "/" + BUCKET + "/" + objectKey;
+        }
+    }
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -42,6 +42,9 @@ tracking:
 test:
   secret-key: ${TEST_SECRET_KEY}
 
+demo:
+  photo-filenames: ${DEMO_PHOTO_FILENAMES}
+
 discord:
   alert:
     enabled: ${DISCORD_ALERT_ENABLED}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,6 +60,9 @@ minio:
   secret-key: ${MINIO_SECRET_KEY}
   public-url: ${MINIO_PUBLIC_URL}
 
+demo:
+  photo-filenames: ${DEMO_PHOTO_FILENAMES}
+
 discord:
   alert:
     enabled: ${DISCORD_ALERT_ENABLED}


### PR DESCRIPTION
## 🧾 요약
- 데모 시연 시 트래킹 세션의 사진을 조회하는 API 구현

## 🔗 이슈
- close #134

## ✨ 변경 내용
- `DemoProperties` 설정 프로퍼티 추가 (데모 사진 파일명 목록)
- `GET /api/demo/tracking/sessions/{sessionId}/photos` API 구현
- MinIO presigned GET URL로 사진 반환 (1시간 유효)
- 설정된 데모 사진 중 랜덤 N개 + 해당 세션의 실제 업로드 사진을 합쳐서 반환
- `application.yaml`, `application-prod.yaml`에 데모 사진 파일명 설정 추가

## ✅ 확인
- [x] 빌드 OK
- [x] 로컬 테스트 OK