### PR TITLE
[Feat] 등산 기록 응답에 트래킹 세션 ID를 추가

### DIFF
--- a/src/main/java/com/semosan/api/domain/demo/service/DemoService.java
+++ b/src/main/java/com/semosan/api/domain/demo/service/DemoService.java
@@ -34,7 +34,7 @@ public class DemoService {
     public List<String> getDemoPhotos(Long sessionId, int count) {
         List<String> shuffled = new ArrayList<>(demoProperties.photoFilenames());
         Collections.shuffle(shuffled);
-        List<String> randomUrls = shuffled.subList(0, Math.min(count, shuffled.size()))
+        List<String> randomUrls = shuffled.subList(0, safeRandomPhotoCount(count, shuffled.size()))
                 .stream()
                 .map(this::presignedGetUrl)
                 .toList();
@@ -48,6 +48,11 @@ public class DemoService {
         List<String> combined = new ArrayList<>(randomUrls);
         combined.addAll(uploadedUrls);
         return combined;
+    }
+
+    // 음수 count 요청이 들어와도 subList 범위를 벗어나지 않도록 보정합니다.
+    private int safeRandomPhotoCount(int count, int availableCount) {
+        return Math.max(0, Math.min(count, availableCount));
     }
 
     private String presignedGetUrl(String objectKey) {

--- a/src/main/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingRecordResponse.java
+++ b/src/main/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingRecordResponse.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 public record GetUserHikingRecordResponse(
         Long hikingRecordId,
+        Long sessionId,
         Long mountainId,
         String mountainName,
         Long courseId,
@@ -23,6 +24,7 @@ public record GetUserHikingRecordResponse(
     public static GetUserHikingRecordResponse from(UserHikingRecordProjection projection) {
         return new GetUserHikingRecordResponse(
                 projection.getHikingRecordId(),
+                projection.getSessionId(),
                 projection.getMountainId(),
                 projection.getMountainName(),
                 projection.getCourseId(),
@@ -34,6 +36,7 @@ public record GetUserHikingRecordResponse(
         );
     }
 
+    // 사진 URL 필드 중 존재하는 값만 응답 순서에 맞춰 모읍니다.
     private static List<String> buildImageUrls(String photoReportImageUrl, String cliveImageUrl) {
         List<String> urls = new ArrayList<>(2);
         if (photoReportImageUrl != null) {

--- a/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
@@ -62,6 +62,7 @@ public interface HikingRecordRepository extends JpaRepository<HikingRecord, Long
             value = """
                     SELECT
                         hr.id AS hikingRecordId,
+                        hr.tracking_session_id AS sessionId,
                         m.id AS mountainId,
                         m.name AS mountainName,
                         c.id AS courseId,
@@ -109,6 +110,7 @@ public interface HikingRecordRepository extends JpaRepository<HikingRecord, Long
             value = """
                     SELECT
                         hr.id AS hikingRecordId,
+                        hr.tracking_session_id AS sessionId,
                         m.id AS mountainId,
                         m.name AS mountainName,
                         c.id AS courseId,

--- a/src/main/java/com/semosan/api/domain/hiking/repository/projection/UserHikingRecordProjection.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/projection/UserHikingRecordProjection.java
@@ -6,6 +6,8 @@ public interface UserHikingRecordProjection {
 
     Long getHikingRecordId();
 
+    Long getSessionId();
+
     Long getMountainId();
 
     String getMountainName();

--- a/src/test/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingRecordResponseTest.java
+++ b/src/test/java/com/semosan/api/domain/hiking/dto/response/GetUserHikingRecordResponseTest.java
@@ -1,0 +1,80 @@
+package com.semosan.api.domain.hiking.dto.response;
+
+import com.semosan.api.domain.hiking.repository.projection.UserHikingRecordProjection;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GetUserHikingRecordResponseTest {
+
+    @Test
+    void fromMapsSessionId() {
+        GetUserHikingRecordResponse response = GetUserHikingRecordResponse.from(projection());
+
+        assertThat(response.hikingRecordId()).isEqualTo(1L);
+        assertThat(response.sessionId()).isEqualTo(10L);
+        assertThat(response.hikedAt()).isEqualTo(LocalDate.of(2026, 5, 28));
+    }
+
+    private UserHikingRecordProjection projection() {
+        return new UserHikingRecordProjection() {
+            @Override
+            public Long getHikingRecordId() {
+                return 1L;
+            }
+
+            @Override
+            public Long getSessionId() {
+                return 10L;
+            }
+
+            @Override
+            public Long getMountainId() {
+                return 2L;
+            }
+
+            @Override
+            public String getMountainName() {
+                return "관악산";
+            }
+
+            @Override
+            public Long getCourseId() {
+                return 3L;
+            }
+
+            @Override
+            public String getCourseName() {
+                return "연주대 코스";
+            }
+
+            @Override
+            public String getPhotoReportImageUrl() {
+                return "photo-report";
+            }
+
+            @Override
+            public String getCliveImageUrl() {
+                return "clive";
+            }
+
+            @Override
+            public Double getDistance() {
+                return 6200.0;
+            }
+
+            @Override
+            public Integer getDuration() {
+                return 3600;
+            }
+
+            @Override
+            public LocalDateTime getHikedAt() {
+                return LocalDateTime.of(2026, 5, 28, 10, 0);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 🧾 요약
  - 등산 기록 응답에 트래킹 세션 ID를 추가해, 트래킹 사진 조회 API와 바로 연결할 수 있도록 함

  ## 🔗 이슈
  - close #145 

  ## ✨ 변경 내용
  - `GetUserHikingRecordResponse`에 `sessionId` 필드 추가
  - `UserHikingRecordProjection`에 `sessionId` 조회 필드 추가
  - 등산 기록 목록 조회 쿼리 2곳에 `hr.tracking_session_id AS sessionId` 반영
  - DTO 변환 로직에서 `sessionId` 매핑 추가
  - `GetUserHikingRecordResponse` 매핑 테스트 추가

  ## ✅ 확인
  - [x] 빌드 OK
  - [x] 테스트 OK