### PR TITLE
[Fix] CourseInfo schema 이름 충돌 분리

### DIFF
--- a/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainDetailResponse.java
+++ b/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainDetailResponse.java
@@ -5,6 +5,7 @@ import com.semosan.api.domain.mountain.enums.AmenityType;
 import com.semosan.api.domain.mountain.enums.Difficulty;
 import com.semosan.api.domain.mountain.enums.TransportationType;
 import com.semosan.api.domain.review.entity.Review;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,7 @@ public record MountainDetailResponse(
         }
     }
 
+    @Schema(name = "MountainDetailCourseInfo")
     public record CourseInfo(
             Long courseId,
             String name,

--- a/src/main/java/com/semosan/api/domain/tracking/dto/response/NearbyMountainResponse.java
+++ b/src/main/java/com/semosan/api/domain/tracking/dto/response/NearbyMountainResponse.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.tracking.dto.response;
 import com.semosan.api.domain.mountain.entity.Course;
 import com.semosan.api.domain.mountain.entity.Mountain;
 import com.semosan.api.domain.mountain.enums.Difficulty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
@@ -44,6 +45,7 @@ public record NearbyMountainResponse(
      * 시안의 코스 카드에 표시되는 정보 중 현재 도메인 모델로 채울 수 있는 것만 포함.
      * TODO: ascent / descent / maxAltitude 컬럼이 Course 에 추가되면 함께 노출.
      */
+    @Schema(name = "NearbyMountainCourseInfo")
     public record CourseInfo(
             Long courseId,
             String name,


### PR DESCRIPTION

## 🧾 요약
- courseinfo 스웨거에서 스키마 안보이는 현상 수정

## 🔗 이슈
- close #147 

## ✨ 변경 내용
- MountainDetailResponse.CourseInfo 와 NearbyMountainResponse.CourseInfo 가 같은 simple name 으로 OpenAPI schema 트리에서 충돌해 startName/endName 등 추가된 필드가 swagger 에 노출되지 않던 문제를 @Schema(name) 명시로 해결.


## ✅ 확인
- [x] 빌드 OK
- [ ] 테스트 OK