### PR TITLE
[Fix] 세모피드 image_url이 따옴표("")와 함께 저장되는 버그 수정

### DIFF
--- a/src/main/java/com/semosan/api/domain/semofeed/controller/SemoFeedController.java
+++ b/src/main/java/com/semosan/api/domain/semofeed/controller/SemoFeedController.java
@@ -4,6 +4,7 @@ import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.response.PageResponse;
 import com.semosan.api.common.status.SuccessStatus;
 import com.semosan.api.domain.semofeed.controller.docs.SemoFeedControllerDocs;
+import com.semosan.api.domain.semofeed.dto.SemoFeedCreateRequest;
 import com.semosan.api.domain.semofeed.dto.SemoFeedEmojiRequest;
 import com.semosan.api.domain.semofeed.dto.SemoFeedEmojiToggleResponse;
 import com.semosan.api.domain.semofeed.dto.SemoFeedResponse;
@@ -30,11 +31,12 @@ public class SemoFeedController implements SemoFeedControllerDocs {
 
     @PostMapping
     @Override
+    // @RequestBody String 대신 DTO를 사용해 Jackson이 JSON 따옴표를 제거한 뒤 imageUrl을 전달합니다.
     public ResponseEntity<ApiResponse<SemoFeedResponse>> create(
             @AuthenticationPrincipal Long userId,
-            @RequestBody String imageUrl
+            @Valid @RequestBody SemoFeedCreateRequest request
     ) {
-        SemoFeedResponse response = semoFeedService.create(userId, imageUrl);
+        SemoFeedResponse response = semoFeedService.create(userId, request.imageUrl());
         return ApiResponse.success(SuccessStatus.SEMOFEED_CREATE_SUCCESS, response);
     }
 

--- a/src/main/java/com/semosan/api/domain/semofeed/controller/docs/SemoFeedControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/semofeed/controller/docs/SemoFeedControllerDocs.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.semofeed.controller.docs;
 
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.response.PageResponse;
+import com.semosan.api.domain.semofeed.dto.SemoFeedCreateRequest;
 import com.semosan.api.domain.semofeed.dto.SemoFeedEmojiRequest;
 import com.semosan.api.domain.semofeed.dto.SemoFeedEmojiToggleResponse;
 import com.semosan.api.domain.semofeed.dto.SemoFeedResponse;
@@ -42,7 +43,7 @@ public interface SemoFeedControllerDocs {
     })
     ResponseEntity<ApiResponse<SemoFeedResponse>> create(
             @AuthenticationPrincipal Long userId,
-            @RequestBody String imageUrl
+            @RequestBody SemoFeedCreateRequest request
     );
 
     @Operation(

--- a/src/main/java/com/semosan/api/domain/semofeed/dto/SemoFeedCreateRequest.java
+++ b/src/main/java/com/semosan/api/domain/semofeed/dto/SemoFeedCreateRequest.java
@@ -1,0 +1,13 @@
+package com.semosan.api.domain.semofeed.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 세모피드 생성 요청 DTO.
+ * {@code @RequestBody String} 대신 사용하여 Jackson이 JSON 문자열의 따옴표를 올바르게 제거하도록 한다.
+ */
+public record SemoFeedCreateRequest(
+        @NotBlank(message = "imageUrl 은 필수입니다.")
+        String imageUrl
+) {
+}


### PR DESCRIPTION
## 🧾 요약
  - `@RequestBody String` 대신 DTO를 사용해 image_url이 따옴표("")와 함께
  저장되는 버그 수정

  ## 🔗 이슈
  - close #149

  ## ✨ 변경 내용
  - `SemoFeedCreateRequest` DTO 추가 (`imageUrl` 필드, `@NotBlank` 검증)
  - `SemoFeedController`, `SemoFeedControllerDocs` create 메서드 파라미터를
  `String` → `SemoFeedCreateRequest`로 교체

  ## ✅ 확인
  - [x] 빌드 OK
  - [ ] 테스트 OK

  > ⚠️ **프론트 변경 필요**
  > 요청 body 형식이 변경되므로 프론트와 배포 타이밍을 맞춰야 합니다.
  > - 변경 전: `"https://..."` (raw string)
  > - 변경 후: `{ "imageUrl": "https://..." }` (JSON object)