### PR TITLE
[Fix] user_onboardings 운동 유형 제약 조건 현행화

### DIFF
--- a/src/main/resources/db/migration/V25__update_user_onboarding_exercise_type_check.sql
+++ b/src/main/resources/db/migration/V25__update_user_onboarding_exercise_type_check.sql
@@ -4,8 +4,11 @@
 -- 배경: 기존 DB 제약은 CARDIO, PILATES, YOGA, WALKING_HIKING를 허용하지만
 --       현재 enum은 WALKING, RUNNING, PILATES_YOGA, HIKING를 사용한다.
 --       신규 enum 값 저장 시 UPDATE/INSERT가 실패하지 않도록 기존 데이터를 변환한다.
--- 멱등: UPDATE 후 DROP IF EXISTS -> ADD 패턴.
+-- 멱등: DROP IF EXISTS -> UPDATE -> ADD 패턴.
 -- =====================================================================
+
+ALTER TABLE user_onboardings
+    DROP CONSTRAINT IF EXISTS user_onboardings_exercise_type_check;
 
 UPDATE user_onboardings
 SET exercise_type = 'WALKING'
@@ -18,9 +21,6 @@ WHERE exercise_type IN ('PILATES', 'YOGA');
 UPDATE user_onboardings
 SET exercise_type = 'HIKING'
 WHERE exercise_type = 'WALKING_HIKING';
-
-ALTER TABLE user_onboardings
-    DROP CONSTRAINT IF EXISTS user_onboardings_exercise_type_check;
 
 ALTER TABLE user_onboardings
     ADD CONSTRAINT user_onboardings_exercise_type_check

--- a/src/main/resources/db/migration/V25__update_user_onboarding_exercise_type_check.sql
+++ b/src/main/resources/db/migration/V25__update_user_onboarding_exercise_type_check.sql
@@ -1,0 +1,38 @@
+-- =====================================================================
+-- V25__update_user_onboarding_exercise_type_check.sql
+-- 목적: user_onboardings.exercise_type CHECK 제약을 현재 ExerciseType enum과 맞춘다.
+-- 배경: 기존 DB 제약은 CARDIO, PILATES, YOGA, WALKING_HIKING를 허용하지만
+--       현재 enum은 WALKING, RUNNING, PILATES_YOGA, HIKING를 사용한다.
+--       신규 enum 값 저장 시 UPDATE/INSERT가 실패하지 않도록 기존 데이터를 변환한다.
+-- 멱등: UPDATE 후 DROP IF EXISTS -> ADD 패턴.
+-- =====================================================================
+
+UPDATE user_onboardings
+SET exercise_type = 'WALKING'
+WHERE exercise_type = 'CARDIO';
+
+UPDATE user_onboardings
+SET exercise_type = 'PILATES_YOGA'
+WHERE exercise_type IN ('PILATES', 'YOGA');
+
+UPDATE user_onboardings
+SET exercise_type = 'HIKING'
+WHERE exercise_type = 'WALKING_HIKING';
+
+ALTER TABLE user_onboardings
+    DROP CONSTRAINT IF EXISTS user_onboardings_exercise_type_check;
+
+ALTER TABLE user_onboardings
+    ADD CONSTRAINT user_onboardings_exercise_type_check
+        CHECK (exercise_type IN (
+            'GYM',
+            'HOME_TRAINING',
+            'PILATES_YOGA',
+            'WALKING',
+            'RUNNING',
+            'HIKING',
+            'SPORTS',
+            'CROSSFIT',
+            'SWIMMING',
+            'NONE'
+        ));


### PR DESCRIPTION
  ## 🧾 요약
  - user_onboardings 테이블의 exercise_type CHECK 제약을 현재 ExerciseType enum 값과 일치하도록 수정

  ## 🔗 이슈
  - close #152

  ## ✨ 변경 내용
  - V25 마이그레이션 추가: 기존 레거시 enum 값(CARDIO, PILATES, YOGA,
  WALKING_HIKING)을 현행 enum(WALKING, RUNNING, PILATES_YOGA, HIKING)으로 데이터 변환
  - 기존 CHECK 제약 DROP 후 현행 ExerciseType 전체 값 기준으로 재설정

  ## ✅ 확인
  - [ ] 빌드 OK
  - [ ] 테스트 OK