### PR TITLE
[Fix] 내가 다녀온 산 목록 API에서 imageUrl null 반환 수정

### DIFF
--- a/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/HikingRecordRepository.java
@@ -35,14 +35,14 @@ public interface HikingRecordRepository extends JpaRepository<HikingRecord, Long
                     SELECT
                         hr.mountain_id AS mountainId,
                         m.name AS mountainName,
-                        m.image_url AS imageUrl,
+                        m.image_urls->>0 AS imageUrl,
                         COUNT(hr.id) AS hikingCount,
                         MAX(hr.created_at) AS lastHikedAt
                     FROM hiking_records hr
                     JOIN hiking_members hm ON hm.hiking_record_id = hr.id
                     JOIN mountains m ON m.id = hr.mountain_id
                     WHERE hm.user_id = :userId
-                    GROUP BY hr.mountain_id, m.name, m.image_url
+                    GROUP BY hr.mountain_id, m.name, m.image_urls->>0
                     ORDER BY MAX(hr.created_at) DESC, hr.mountain_id DESC
                     """,
             countQuery = """


### PR DESCRIPTION
## 🧾 요약
- 내가 다녀온 산 목록 API(`/api/hiking-records/me/mountains`)에서 `imageUrl`이 null로 내려오는 버그 수정 — 존재하지 않는 `image_url` 컬럼 대신 `image_urls->>0`으로 변경

## 🔗 이슈
- close #158

## ✨ 변경 내용
- `HikingRecordRepository.findUserHikingMountainRecordsByUserId` 쿼리에서 `m.image_url` → `m.image_urls->>0`으로 변경
- `GROUP BY` 절도 동일하게 수정

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK