### PR TITLE
[Fix] Actuator 별도 포트 SecurityFilterChain 추가

### DIFF
--- a/src/main/java/com/semosan/api/common/config/ManagementSecurityConfig.java
+++ b/src/main/java/com/semosan/api/common/config/ManagementSecurityConfig.java
@@ -1,0 +1,23 @@
+package com.semosan.api.common.config;
+
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class ManagementSecurityConfig {
+
+    @Bean
+    @Order(0)
+    public SecurityFilterChain managementSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher(EndpointRequest.toAnyEndpoint())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(AbstractHttpConfigurer::disable);
+        return http.build();
+    }
+}


### PR DESCRIPTION
## 🧾 요약
- Actuator 포트(9090) 분리 후 Spring Security가 요청을 차단하는 문제 수정

## 🔗 이슈
- #144

## ✨ 변경 내용
- ManagementSecurityConfig 추가 — EndpointRequest 기반 Actuator 엔드포인트 permitAll 처리
- @Order(0)으로 메인 SecurityFilterChain보다 먼저 매칭되도록 설정

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK (배포 후 /actuator/health 200 확인 필요)