### PR TITLE
[Fix] 회원탈퇴 시 course_difficulty_feedbacks FK 제약 위반 500 에러 수정

### DIFF
--- a/src/main/java/com/semosan/api/domain/hiking/repository/CourseDifficultyFeedbackRepository.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/CourseDifficultyFeedbackRepository.java
@@ -3,7 +3,13 @@ package com.semosan.api.domain.hiking.repository;
 import com.semosan.api.domain.hiking.entity.CourseDifficultyFeedback;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CourseDifficultyFeedbackRepository extends JpaRepository<CourseDifficultyFeedback, Long> {
 
     boolean existsByHikingRecord_Id(Long hikingRecordId);
+
+    void deleteByUser_Id(Long userId);
+
+    void deleteByHikingRecord_IdIn(List<Long> hikingRecordIds);
 }

--- a/src/main/java/com/semosan/api/domain/hiking/repository/CourseDifficultyFeedbackRepository.java
+++ b/src/main/java/com/semosan/api/domain/hiking/repository/CourseDifficultyFeedbackRepository.java
@@ -2,6 +2,9 @@ package com.semosan.api.domain.hiking.repository;
 
 import com.semosan.api.domain.hiking.entity.CourseDifficultyFeedback;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -9,7 +12,11 @@ public interface CourseDifficultyFeedbackRepository extends JpaRepository<Course
 
     boolean existsByHikingRecord_Id(Long hikingRecordId);
 
-    void deleteByUser_Id(Long userId);
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM CourseDifficultyFeedback cdf WHERE cdf.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 
-    void deleteByHikingRecord_IdIn(List<Long> hikingRecordIds);
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM CourseDifficultyFeedback cdf WHERE cdf.hikingRecord.id IN :hikingRecordIds")
+    void deleteByHikingRecordIdIn(@Param("hikingRecordIds") List<Long> hikingRecordIds);
 }

--- a/src/main/java/com/semosan/api/domain/user/service/UserService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.user.service;
 
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.hiking.repository.CourseDifficultyFeedbackRepository;
 import com.semosan.api.domain.hiking.repository.HikingMemberRepository;
 import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
 import com.semosan.api.domain.mountain.repository.CourseLikeRepository;
@@ -38,6 +39,7 @@ public class UserService {
     private final ReviewRepository reviewRepository;
     private final HikingMemberRepository hikingMemberRepository;
     private final HikingRecordRepository hikingRecordRepository;
+    private final CourseDifficultyFeedbackRepository courseDifficultyFeedbackRepository;
     private final NotificationRepository notificationRepository;
     private final DefaultNicknameGenerator defaultNicknameGenerator;
     private final NicknamePolicy nicknamePolicy;
@@ -147,9 +149,11 @@ public class UserService {
         mountainLikeRepository.deleteByUser_Id(userId);
         courseLikeRepository.deleteByUser_Id(userId);
         reviewRepository.deleteByUser_Id(userId);
+        courseDifficultyFeedbackRepository.deleteByUser_Id(userId);
         List<Long> recordIdsToDelete = hikingRecordRepository.findRecordIdsOnlyParticipatedByUser(userId);
         hikingMemberRepository.deleteByUser_Id(userId);
         if (!recordIdsToDelete.isEmpty()) {
+            courseDifficultyFeedbackRepository.deleteByHikingRecord_IdIn(recordIdsToDelete);
             hikingRecordRepository.deleteAllByIdInBatch(recordIdsToDelete);
         }
         notificationRepository.deleteAllByUserId(userId);

--- a/src/main/java/com/semosan/api/domain/user/service/UserService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserService.java
@@ -149,11 +149,11 @@ public class UserService {
         mountainLikeRepository.deleteByUser_Id(userId);
         courseLikeRepository.deleteByUser_Id(userId);
         reviewRepository.deleteByUser_Id(userId);
-        courseDifficultyFeedbackRepository.deleteByUser_Id(userId);
+        courseDifficultyFeedbackRepository.deleteByUserId(userId);
         List<Long> recordIdsToDelete = hikingRecordRepository.findRecordIdsOnlyParticipatedByUser(userId);
         hikingMemberRepository.deleteByUser_Id(userId);
         if (!recordIdsToDelete.isEmpty()) {
-            courseDifficultyFeedbackRepository.deleteByHikingRecord_IdIn(recordIdsToDelete);
+            courseDifficultyFeedbackRepository.deleteByHikingRecordIdIn(recordIdsToDelete);
             hikingRecordRepository.deleteAllByIdInBatch(recordIdsToDelete);
         }
         notificationRepository.deleteAllByUserId(userId);

--- a/src/test/java/com/semosan/api/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/user/service/UserServiceTest.java
@@ -179,10 +179,10 @@ class UserServiceTest {
 
         verify(mountainLikeRepository).deleteByUser_Id(1L);
         verify(reviewRepository).deleteByUser_Id(1L);
-        verify(courseDifficultyFeedbackRepository).deleteByUser_Id(1L);
+        verify(courseDifficultyFeedbackRepository).deleteByUserId(1L);
         verify(hikingRecordRepository).findRecordIdsOnlyParticipatedByUser(1L);
         verify(hikingMemberRepository).deleteByUser_Id(1L);
-        verify(courseDifficultyFeedbackRepository).deleteByHikingRecord_IdIn(List.of(10L, 11L));
+        verify(courseDifficultyFeedbackRepository).deleteByHikingRecordIdIn(List.of(10L, 11L));
         verify(hikingRecordRepository).deleteAllByIdInBatch(List.of(10L, 11L));
         verify(notificationRepository).deleteAllByUserId(1L);
         verify(userOnboardingRepository).deleteByUser_Id(1L);
@@ -197,9 +197,9 @@ class UserServiceTest {
         assertThat(user.getOnboardingStatus()).isEqualTo(OnboardingStatus.INCOMPLETE);
 
         InOrder deleteOrder = inOrder(courseDifficultyFeedbackRepository, hikingRecordRepository);
-        deleteOrder.verify(courseDifficultyFeedbackRepository).deleteByUser_Id(1L);
+        deleteOrder.verify(courseDifficultyFeedbackRepository).deleteByUserId(1L);
         deleteOrder.verify(hikingRecordRepository).findRecordIdsOnlyParticipatedByUser(1L);
-        deleteOrder.verify(courseDifficultyFeedbackRepository).deleteByHikingRecord_IdIn(List.of(10L, 11L));
+        deleteOrder.verify(courseDifficultyFeedbackRepository).deleteByHikingRecordIdIn(List.of(10L, 11L));
         deleteOrder.verify(hikingRecordRepository).deleteAllByIdInBatch(List.of(10L, 11L));
     }
 }

--- a/src/test/java/com/semosan/api/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/user/service/UserServiceTest.java
@@ -197,6 +197,8 @@ class UserServiceTest {
         assertThat(user.getOnboardingStatus()).isEqualTo(OnboardingStatus.INCOMPLETE);
 
         InOrder deleteOrder = inOrder(courseDifficultyFeedbackRepository, hikingRecordRepository);
+        deleteOrder.verify(courseDifficultyFeedbackRepository).deleteByUser_Id(1L);
+        deleteOrder.verify(hikingRecordRepository).findRecordIdsOnlyParticipatedByUser(1L);
         deleteOrder.verify(courseDifficultyFeedbackRepository).deleteByHikingRecord_IdIn(List.of(10L, 11L));
         deleteOrder.verify(hikingRecordRepository).deleteAllByIdInBatch(List.of(10L, 11L));
     }

--- a/src/test/java/com/semosan/api/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.semosan.api.domain.user.service;
 
+import com.semosan.api.domain.hiking.repository.CourseDifficultyFeedbackRepository;
 import com.semosan.api.domain.hiking.repository.HikingMemberRepository;
 import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
 import com.semosan.api.domain.mountain.repository.CourseLikeRepository;
@@ -17,6 +18,7 @@ import com.semosan.api.domain.user.repository.UserOnboardingRepository;
 import com.semosan.api.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,6 +29,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -56,6 +59,9 @@ class UserServiceTest {
 
     @Mock
     private HikingRecordRepository hikingRecordRepository;
+
+    @Mock
+    private CourseDifficultyFeedbackRepository courseDifficultyFeedbackRepository;
 
     @Mock
     private NotificationRepository notificationRepository;
@@ -173,8 +179,10 @@ class UserServiceTest {
 
         verify(mountainLikeRepository).deleteByUser_Id(1L);
         verify(reviewRepository).deleteByUser_Id(1L);
+        verify(courseDifficultyFeedbackRepository).deleteByUser_Id(1L);
         verify(hikingRecordRepository).findRecordIdsOnlyParticipatedByUser(1L);
         verify(hikingMemberRepository).deleteByUser_Id(1L);
+        verify(courseDifficultyFeedbackRepository).deleteByHikingRecord_IdIn(List.of(10L, 11L));
         verify(hikingRecordRepository).deleteAllByIdInBatch(List.of(10L, 11L));
         verify(notificationRepository).deleteAllByUserId(1L);
         verify(userOnboardingRepository).deleteByUser_Id(1L);
@@ -187,5 +195,9 @@ class UserServiceTest {
         assertThat(user.getNickname()).isNull();
         assertThat(user.getOauthId()).isEqualTo("WITHDRAWN:1:TEST");
         assertThat(user.getOnboardingStatus()).isEqualTo(OnboardingStatus.INCOMPLETE);
+
+        InOrder deleteOrder = inOrder(courseDifficultyFeedbackRepository, hikingRecordRepository);
+        deleteOrder.verify(courseDifficultyFeedbackRepository).deleteByHikingRecord_IdIn(List.of(10L, 11L));
+        deleteOrder.verify(hikingRecordRepository).deleteAllByIdInBatch(List.of(10L, 11L));
     }
 }


### PR DESCRIPTION
## 🧾 요약
- 회원탈퇴(DELETE /api/auth/withdraw) 시 hiking_records 삭제 전 course_difficulty_feedbacks를 먼저 삭제하지 않아 FK 제약 위반으로 500 에러가 발생하던 버그 수정

## 🔗 이슈
- close #167

## ✨ 변경 내용
- `UserService` 탈퇴 로직에 `course_difficulty_feedbacks` 삭제 순서 추가 — `hiking_records` 삭제 전에 선행 처리
- `CourseDifficultyFeedbackRepository`에 `deleteByUser_Id`, `deleteByHikingRecord_IdIn` 메서드 추가
- `UserServiceTest`에 삭제 순서 InOrder 검증 추가

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
