### PR TITLE
[Refactor] ConstraintViolationException 파싱 로직 유틸로 통합

### DIFF
--- a/src/main/java/com/semosan/api/common/exception/ConstraintViolationUtils.java
+++ b/src/main/java/com/semosan/api/common/exception/ConstraintViolationUtils.java
@@ -2,16 +2,16 @@ package com.semosan.api.common.exception;
 
 import org.hibernate.exception.ConstraintViolationException;
 
+import java.util.regex.Pattern;
+
 public final class ConstraintViolationUtils {
 
     private ConstraintViolationUtils() {}
 
-    /**
-     * 예외 체인 전체를 탐색해 특정 DB 제약 조건 이름이 원인인지 확인한다.
-     * Hibernate ConstraintViolationException의 constraintName과 메시지 문자열을 모두 검사해
-     * 드라이버마다 다른 예외 래핑 방식에 대응한다.
-     */
     public static boolean isViolation(Throwable exception, String constraintName) {
+        Pattern constraintNamePattern = Pattern.compile(
+                "(?<![A-Za-z0-9_])" + Pattern.quote(constraintName) + "(?![A-Za-z0-9_])"
+        );
         Throwable current = exception;
         while (current != null) {
             if (current instanceof ConstraintViolationException constraintViolation
@@ -19,7 +19,8 @@ public final class ConstraintViolationUtils {
                 return true;
             }
             String message = current.getMessage();
-            if (message != null && message.contains(constraintName)) {
+            // 드라이버마다 다른 예외 래핑에 대응하되, 다른 제약명 일부와 겹치는 오탐은 막는다.
+            if (message != null && constraintNamePattern.matcher(message).find()) {
                 return true;
             }
             current = current.getCause();

--- a/src/main/java/com/semosan/api/common/exception/ConstraintViolationUtils.java
+++ b/src/main/java/com/semosan/api/common/exception/ConstraintViolationUtils.java
@@ -1,0 +1,29 @@
+package com.semosan.api.common.exception;
+
+import org.hibernate.exception.ConstraintViolationException;
+
+public final class ConstraintViolationUtils {
+
+    private ConstraintViolationUtils() {}
+
+    /**
+     * 예외 체인 전체를 탐색해 특정 DB 제약 조건 이름이 원인인지 확인한다.
+     * Hibernate ConstraintViolationException의 constraintName과 메시지 문자열을 모두 검사해
+     * 드라이버마다 다른 예외 래핑 방식에 대응한다.
+     */
+    public static boolean isViolation(Throwable exception, String constraintName) {
+        Throwable current = exception;
+        while (current != null) {
+            if (current instanceof ConstraintViolationException constraintViolation
+                    && constraintName.equals(constraintViolation.getConstraintName())) {
+                return true;
+            }
+            String message = current.getMessage();
+            if (message != null && message.contains(constraintName)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostReportService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostReportService.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.community.post.service;
 import com.semosan.api.common.alert.DiscordAlertClient;
 import com.semosan.api.common.alert.dto.DiscordEmbed;
 import com.semosan.api.common.alert.dto.DiscordMessage;
+import com.semosan.api.common.exception.ConstraintViolationUtils;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.post.entity.FreePost;
@@ -13,7 +14,6 @@ import com.semosan.api.domain.community.post.repository.FreePostRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,7 +61,7 @@ public class FreePostReportService {
             });
             return saved;
         } catch (DataIntegrityViolationException e) {
-            if (isUniqueViolation(e)) {
+            if (ConstraintViolationUtils.isViolation(e, REPORT_UNIQUE_CONSTRAINT)) {
                 throw new GeneralException(ErrorStatus.FREE_POST_REPORT_ALREADY_EXISTS);
             }
             throw e;
@@ -91,22 +91,6 @@ public class FreePostReportService {
                 "자유게시판 신고 접수",
                 List.of(new DiscordEmbed("신고 상세", content, DISCORD_COLOR))
         );
-    }
-
-    private boolean isUniqueViolation(Throwable exception) {
-        Throwable current = exception;
-        while (current != null) {
-            if (current instanceof ConstraintViolationException constraintViolation
-                    && REPORT_UNIQUE_CONSTRAINT.equals(constraintViolation.getConstraintName())) {
-                return true;
-            }
-            String message = current.getMessage();
-            if (message != null && message.contains(REPORT_UNIQUE_CONSTRAINT)) {
-                return true;
-            }
-            current = current.getCause();
-        }
-        return false;
     }
 
     private User findReporterOrThrow(Long reporterId) {

--- a/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
+++ b/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
@@ -19,10 +19,10 @@ import com.semosan.api.domain.tracking.entity.TrackingPhoto;
 import com.semosan.api.domain.tracking.repository.TrackingPhotoRepository;
 import com.semosan.api.domain.tracking.repository.TrackingPointRepository;
 import com.semosan.api.domain.tracking.repository.projection.TrackingPathProjection;
+import com.semosan.api.common.exception.ConstraintViolationUtils;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -147,26 +147,11 @@ public class HikingRecordService {
         try {
             return CourseDifficultyFeedbackResponse.from(courseDifficultyFeedbackRepository.saveAndFlush(feedback));
         } catch (DataIntegrityViolationException e) {
-            if (isDifficultyFeedbackHikingRecordUniqueViolation(e)) {
+            // 동시 요청으로 유니크 제약 위반 시 이미 피드백이 존재하는 에러로 변환
+            if (ConstraintViolationUtils.isViolation(e, DIFFICULTY_FEEDBACK_HIKING_RECORD_UNIQUE_CONSTRAINT)) {
                 throw new GeneralException(ErrorStatus.COURSE_DIFFICULTY_FEEDBACK_ALREADY_EXISTS);
             }
             throw e;
         }
-    }
-
-    private boolean isDifficultyFeedbackHikingRecordUniqueViolation(Throwable exception) {
-        Throwable current = exception;
-        while (current != null) {
-            if (current instanceof ConstraintViolationException constraintViolation
-                    && DIFFICULTY_FEEDBACK_HIKING_RECORD_UNIQUE_CONSTRAINT.equals(constraintViolation.getConstraintName())) {
-                return true;
-            }
-            String message = current.getMessage();
-            if (message != null && message.contains(DIFFICULTY_FEEDBACK_HIKING_RECORD_UNIQUE_CONSTRAINT)) {
-                return true;
-            }
-            current = current.getCause();
-        }
-        return false;
     }
 }

--- a/src/main/java/com/semosan/api/domain/tracking/service/TrackingSessionService.java
+++ b/src/main/java/com/semosan/api/domain/tracking/service/TrackingSessionService.java
@@ -16,11 +16,11 @@ import com.semosan.api.domain.tracking.entity.TrackingSession;
 import com.semosan.api.domain.tracking.enums.TrackingSessionStatus;
 import com.semosan.api.domain.tracking.event.TrackingSessionTerminatedEvent;
 import com.semosan.api.domain.tracking.repository.TrackingSessionRepository;
+import com.semosan.api.common.exception.ConstraintViolationUtils;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -178,26 +178,11 @@ public class TrackingSessionService {
         try {
             return trackingSessionRepository.save(session);
         } catch (DataIntegrityViolationException e) {
-            if (isActiveSessionUniqueViolation(e)) {
+            // 동시 요청으로 유니크 제약 위반 시 이미 진행 중인 세션 존재 에러로 변환
+            if (ConstraintViolationUtils.isViolation(e, ACTIVE_SESSION_UNIQUE_INDEX)) {
                 throw new GeneralException(ErrorStatus.TRACKING_SESSION_ALREADY_IN_PROGRESS);
             }
             throw e;
         }
-    }
-
-    private boolean isActiveSessionUniqueViolation(Throwable exception) {
-        Throwable current = exception;
-        while (current != null) {
-            if (current instanceof ConstraintViolationException constraintViolation
-                    && ACTIVE_SESSION_UNIQUE_INDEX.equals(constraintViolation.getConstraintName())) {
-                return true;
-            }
-            String message = current.getMessage();
-            if (message != null && message.contains(ACTIVE_SESSION_UNIQUE_INDEX)) {
-                return true;
-            }
-            current = current.getCause();
-        }
-        return false;
     }
 }

--- a/src/main/java/com/semosan/api/domain/user/service/UserBlockService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserBlockService.java
@@ -1,5 +1,6 @@
 package com.semosan.api.domain.user.service;
 
+import com.semosan.api.common.exception.ConstraintViolationUtils;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.post.entity.FreePost;
@@ -9,7 +10,6 @@ import com.semosan.api.domain.user.entity.UserBlock;
 import com.semosan.api.domain.user.repository.UserBlockRepository;
 import com.semosan.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,7 +40,8 @@ public class UserBlockService {
         try {
             userBlockRepository.saveAndFlush(UserBlock.create(blocker, blockedUser));
         } catch (DataIntegrityViolationException e) {
-            if (!isUniqueViolation(e)) {
+            // 동시 요청으로 유니크 제약 위반 시 멱등 처리 (이미 차단된 상태로 간주)
+            if (!ConstraintViolationUtils.isViolation(e, BLOCK_UNIQUE_CONSTRAINT)) {
                 throw e;
             }
         }
@@ -51,22 +52,6 @@ public class UserBlockService {
         FreePost post = freePostRepository.findByIdAndDeletedFalse(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
         block(blockerId, post.getAuthor().getId());
-    }
-
-    private boolean isUniqueViolation(Throwable exception) {
-        Throwable current = exception;
-        while (current != null) {
-            if (current instanceof ConstraintViolationException constraintViolation
-                    && BLOCK_UNIQUE_CONSTRAINT.equals(constraintViolation.getConstraintName())) {
-                return true;
-            }
-            String message = current.getMessage();
-            if (message != null && message.contains(BLOCK_UNIQUE_CONSTRAINT)) {
-                return true;
-            }
-            current = current.getCause();
-        }
-        return false;
     }
 
     private User findActiveUserOrThrow(Long userId) {

--- a/src/test/java/com/semosan/api/common/exception/ConstraintViolationUtilsTest.java
+++ b/src/test/java/com/semosan/api/common/exception/ConstraintViolationUtilsTest.java
@@ -1,0 +1,52 @@
+package com.semosan.api.common.exception;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConstraintViolationUtilsTest {
+
+    private static final String CONSTRAINT_NAME = "uk_user_blocks_blocker_blocked";
+
+    @Test
+    void isViolationReturnsTrueWhenHibernateConstraintNameMatches() {
+        ConstraintViolationException cause = new ConstraintViolationException(
+                "duplicate",
+                new SQLException("unique violation"),
+                CONSTRAINT_NAME
+        );
+
+        boolean result = ConstraintViolationUtils.isViolation(
+                new DataIntegrityViolationException("duplicate", cause),
+                CONSTRAINT_NAME
+        );
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isViolationReturnsTrueWhenMessageContainsExactConstraintToken() {
+        DataIntegrityViolationException exception = new DataIntegrityViolationException(
+                "ERROR: duplicate key value violates unique constraint \"" + CONSTRAINT_NAME + "\""
+        );
+
+        boolean result = ConstraintViolationUtils.isViolation(exception, CONSTRAINT_NAME);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isViolationReturnsFalseWhenMessageContainsOnlyConstraintNamePrefix() {
+        DataIntegrityViolationException exception = new DataIntegrityViolationException(
+                "ERROR: duplicate key value violates unique constraint \"" + CONSTRAINT_NAME + "_idx\""
+        );
+
+        boolean result = ConstraintViolationUtils.isViolation(exception, CONSTRAINT_NAME);
+
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
## 🧾 요약
- 3곳에 중복된 ConstraintViolationException 파싱 로직을 ConstraintViolationUtils로 통합 — 버그 수정 시 누락 방지

## 🔗 이슈
- close #171

## ✨ 변경 내용
- `ConstraintViolationUtils.isViolation()` 유틸 클래스 추가 (common/exception)
- `TrackingSessionService.isActiveSessionUniqueViolation()` 제거 후 유틸로 교체
- `HikingRecordService.isDifficultyFeedbackHikingRecordUniqueViolation()` 제거 후 유틸로 교체
- `UserBlockService.isUniqueViolation()` 제거 후 유틸로 교체

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
