### PR TITLE
[Refactor] UserReader를 통한 유저 조회 통일

### DIFF
--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -10,7 +10,7 @@ import com.semosan.api.domain.community.post.entity.Post;
 import com.semosan.api.domain.community.post.repository.PostRepository;
 import com.semosan.api.domain.user.repository.UserBlockRepository;
 import com.semosan.api.domain.user.entity.User;
-import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,7 +28,7 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
-    private final UserRepository userRepository;
+    private final UserReader userReader;
     private final UserBlockRepository userBlockRepository;
     private final CommunityNotificationService communityNotificationService;
 
@@ -99,8 +99,7 @@ public class CommentService {
     }
 
     private User findUserOrThrow(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        return userReader.findActiveUserById(userId);
     }
 
     private Comment findActiveCommentOrThrow(Long commentId) {

--- a/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/service/CommentService.java
@@ -35,7 +35,7 @@ public class CommentService {
     @Transactional
     public Comment create(Long postId, Long authorId, String content) {
         Post post = findPostOrThrow(postId);
-        User author = findUserOrThrow(authorId);
+        User author = userReader.findActiveUserById(authorId);
 
         Comment comment = Comment.create(post, author, content);
         Comment savedComment = commentRepository.save(comment);
@@ -46,7 +46,7 @@ public class CommentService {
     @Transactional
     public Comment reply(Long postId, Long authorId, Long parentId, Long mentionedUserId, String content) {
         Post post = findPostOrThrow(postId);
-        User author = findUserOrThrow(authorId);
+        User author = userReader.findActiveUserById(authorId);
         Comment requestedParent = findActiveCommentOrThrow(parentId);
 
         if (!requestedParent.getPost().getId().equals(postId)) {
@@ -56,7 +56,7 @@ public class CommentService {
         // 대댓글에 답글을 달면 트리 깊이를 2로 유지하기 위해 1뎁스 댓글로 정규화
         Comment actualParent = requestedParent.isReply() ? requestedParent.getParent() : requestedParent;
 
-        User mentionedUser = mentionedUserId != null ? findUserOrThrow(mentionedUserId) : null;
+        User mentionedUser = mentionedUserId != null ? userReader.findActiveUserById(mentionedUserId) : null;
 
         Comment reply = Comment.reply(post, author, actualParent, mentionedUser, content);
         Comment savedReply = commentRepository.save(reply);
@@ -96,10 +96,6 @@ public class CommentService {
     private Post findPostOrThrow(Long postId) {
         return postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
-    }
-
-    private User findUserOrThrow(Long userId) {
-        return userReader.findActiveUserById(userId);
     }
 
     private Comment findActiveCommentOrThrow(Long commentId) {

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -9,7 +9,7 @@ import com.semosan.api.domain.community.notification.service.CommunityNotificati
 import com.semosan.api.domain.community.post.entity.Post;
 import com.semosan.api.domain.community.post.repository.PostRepository;
 import com.semosan.api.domain.user.entity.User;
-import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -26,7 +26,7 @@ public class PostLikeService {
 
     private final PostLikeRepository postLikeRepository;
     private final PostRepository postRepository;
-    private final UserRepository userRepository;
+    private final UserReader userReader;
     private final CommunityNotificationService communityNotificationService;
 
     /**
@@ -76,7 +76,6 @@ public class PostLikeService {
     }
 
     private User findUserOrThrow(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        return userReader.findActiveUserById(userId);
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -12,7 +12,7 @@ import com.semosan.api.domain.community.post.repository.FreePostRepository;
 import com.semosan.api.domain.community.post.repository.PostImageRepository;
 import com.semosan.api.domain.user.repository.UserBlockRepository;
 import com.semosan.api.domain.user.entity.User;
-import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -34,7 +34,7 @@ public class FreePostService {
     private final PostLikeRepository postLikeRepository;
     private final CommentRepository commentRepository;
     private final UserBlockRepository userBlockRepository;
-    private final UserRepository userRepository;
+    private final UserReader userReader;
 
     @Transactional
     public FreePostDetailResponse create(
@@ -47,8 +47,7 @@ public class FreePostService {
         if (content == null || content.isBlank()) {
             throw new GeneralException(ErrorStatus.POST_CONTENT_REQUIRED);
         }
-        User author = userRepository.findById(authorId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        User author = userReader.findActiveUserById(authorId);
 
         FreePost post = FreePost.create(author, title, content);
         freePostRepository.save(post);
@@ -71,8 +70,7 @@ public class FreePostService {
     }
 
     public Page<FreePostListResponse> getMyList(Long authorId, Pageable pageable) {
-        User author = userRepository.findById(authorId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        User author = userReader.findActiveUserById(authorId);
         return enrichWithCounts(freePostRepository.findByAuthorAndDeletedFalse(author, pageable));
     }
 

--- a/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
@@ -8,7 +8,7 @@ import com.semosan.api.domain.hiking.entity.HikingRecord;
 import com.semosan.api.domain.hiking.repository.HikingMemberRepository;
 import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
 import com.semosan.api.domain.user.entity.User;
-import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,12 +23,11 @@ public class RecordPostService {
     private final RecordPostRepository recordPostRepository;
     private final HikingRecordRepository hikingRecordRepository;
     private final HikingMemberRepository hikingMemberRepository;
-    private final UserRepository userRepository;
+    private final UserReader userReader;
 
     @Transactional
     public RecordPost create(Long authorId, Long hikingRecordId, String content) {
-        User author = userRepository.findById(authorId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        User author = userReader.findActiveUserById(authorId);
         HikingRecord hikingRecord = hikingRecordRepository.findById(hikingRecordId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.HIKING_RECORD_NOT_FOUND));
 
@@ -45,8 +44,7 @@ public class RecordPostService {
     }
 
     public Page<RecordPost> getMyList(Long authorId, Pageable pageable) {
-        User author = userRepository.findById(authorId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        User author = userReader.findActiveUserById(authorId);
         return recordPostRepository.findByAuthorAndDeletedFalse(author, pageable);
     }
 

--- a/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/comment/service/CommentServiceTest.java
@@ -8,7 +8,7 @@ import com.semosan.api.domain.community.post.repository.PostRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.enums.user.DeviceType;
 import com.semosan.api.domain.user.repository.UserBlockRepository;
-import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.service.UserReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -34,7 +34,7 @@ class CommentServiceTest {
     private PostRepository postRepository;
 
     @Mock
-    private UserRepository userRepository;
+    private UserReader userReader;
 
     @Mock
     private UserBlockRepository userBlockRepository;
@@ -52,7 +52,7 @@ class CommentServiceTest {
         FreePost post = freePost(10L, postAuthor, "제목", "본문");
 
         when(postRepository.findById(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(commentAuthor));
+        when(userReader.findActiveUserById(2L)).thenReturn(commentAuthor);
         when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
             Comment comment = invocation.getArgument(0);
             ReflectionTestUtils.setField(comment, "id", 100L);
@@ -75,8 +75,8 @@ class CommentServiceTest {
         Comment parent = comment(100L, post, parentAuthor, "부모 댓글");
 
         when(postRepository.findById(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(3L)).thenReturn(Optional.of(replyAuthor));
-        when(userRepository.findById(4L)).thenReturn(Optional.of(mentionedUser));
+        when(userReader.findActiveUserById(3L)).thenReturn(replyAuthor);
+        when(userReader.findActiveUserById(4L)).thenReturn(mentionedUser);
         when(commentRepository.findByIdAndDeletedFalse(100L)).thenReturn(Optional.of(parent));
         when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
             Comment comment = invocation.getArgument(0);

--- a/src/test/java/com/semosan/api/domain/community/like/service/PostLikeServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/like/service/PostLikeServiceTest.java
@@ -8,7 +8,7 @@ import com.semosan.api.domain.community.post.entity.FreePost;
 import com.semosan.api.domain.community.post.repository.PostRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.enums.user.DeviceType;
-import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.service.UserReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -36,7 +36,7 @@ class PostLikeServiceTest {
     private PostRepository postRepository;
 
     @Mock
-    private UserRepository userRepository;
+    private UserReader userReader;
 
     @Mock
     private CommunityNotificationService communityNotificationService;
@@ -51,7 +51,7 @@ class PostLikeServiceTest {
         FreePost post = freePost(10L, postAuthor, "제목", "본문");
 
         when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(liker));
+        when(userReader.findActiveUserById(2L)).thenReturn(liker);
         when(postLikeRepository.findByPostAndUser(post, liker)).thenReturn(Optional.empty());
         when(postLikeRepository.countByPost(post)).thenReturn(1L);
 
@@ -70,7 +70,7 @@ class PostLikeServiceTest {
         PostLike existing = PostLike.create(post, liker);
 
         when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(liker));
+        when(userReader.findActiveUserById(2L)).thenReturn(liker);
         when(postLikeRepository.findByPostAndUser(post, liker)).thenReturn(Optional.of(existing));
         when(postLikeRepository.countByPost(post)).thenReturn(0L);
 
@@ -88,7 +88,7 @@ class PostLikeServiceTest {
         FreePost post = freePost(10L, postAuthor, "제목", "본문");
 
         when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(liker));
+        when(userReader.findActiveUserById(2L)).thenReturn(liker);
         when(postLikeRepository.findByPostAndUser(post, liker)).thenReturn(Optional.empty());
         when(postLikeRepository.save(any(PostLike.class))).thenThrow(new DataIntegrityViolationException("duplicate"));
         when(postLikeRepository.countByPost(post)).thenReturn(1L);

--- a/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
@@ -13,7 +13,7 @@ import com.semosan.api.domain.community.post.repository.PostImageRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.enums.user.DeviceType;
 import com.semosan.api.domain.user.repository.UserBlockRepository;
-import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.service.UserReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -55,7 +55,7 @@ class FreePostServiceTest {
     private UserBlockRepository userBlockRepository;
 
     @Mock
-    private UserRepository userRepository;
+    private UserReader userReader;
 
     @InjectMocks
     private FreePostService freePostService;


### PR DESCRIPTION
## 🧾 요약
- 여러 도메인 서비스에서 UserRepository를 직접 의존하던 유저 조회 로직을 UserReader로 통일

## 🔗 이슈
- close #172

## ✨ 변경 내용
- `CommentService`, `PostLikeService`, `FreePostService`, `RecordPostService`, `HikingRecordService`, `TrackingSessionService`, `UserBlockService`에서 `UserRepository` 의존 제거
- 각 서비스의 중복 `findUserOrThrow()` 메서드 제거 및 `UserReader.findActiveUserById()`로 위임 통일
- 관련 서비스 테스트에서 `UserRepository` → `UserReader` 모킹 대상 교체

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
