### PR TITLE
[Refactor] 좋아요 동시 요청 충돌 처리 공통화

### DIFF
--- a/src/main/java/com/semosan/api/common/util/LikeConflictHandler.java
+++ b/src/main/java/com/semosan/api/common/util/LikeConflictHandler.java
@@ -1,0 +1,18 @@
+package com.semosan.api.common.util;
+
+import org.springframework.dao.DataIntegrityViolationException;
+
+public final class LikeConflictHandler {
+
+    private LikeConflictHandler() {}
+
+    public static boolean handleConcurrentCreate(Runnable createAction, Runnable conflictLogAction) {
+        try {
+            createAction.run();
+            return true;
+        } catch (DataIntegrityViolationException e) {
+            conflictLogAction.run();
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.community.like.service;
 
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.common.util.LikeConflictHandler;
 import com.semosan.api.domain.community.like.dto.PostLikeToggleResponse;
 import com.semosan.api.domain.community.like.entity.PostLike;
 import com.semosan.api.domain.community.like.repository.PostLikeRepository;
@@ -42,14 +43,10 @@ public class PostLikeService {
             return false;
         }
 
-        try {
+        return LikeConflictHandler.handleConcurrentCreate(() -> {
             postLikeRepository.save(PostLike.create(post, user));
             communityNotificationService.sendPostLikeNotification(post, user);
-            return true;
-        } catch (DataIntegrityViolationException e) {
-            log.warn("PostLike 동시 요청 감지: postId={}, userId={}", postId, userId);
-            return true;
-        }
+        }, () -> log.warn("PostLike 동시 요청 감지: postId={}, userId={}", postId, userId));
     }
 
     public long count(Long postId) {

--- a/src/main/java/com/semosan/api/domain/mountain/service/CourseLikeService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/CourseLikeService.java
@@ -40,13 +40,13 @@ public class CourseLikeService {
                     courseLikeRepository.delete(existing);
                     return false;
                 })
-                .orElseGet(() -> createCourseLike(user, course, userId, courseId));
+                .orElseGet(() -> createCourseLike(user, course));
     }
 
-    private boolean createCourseLike(User user, Course course, Long userId, Long courseId) {
+    private boolean createCourseLike(User user, Course course) {
         return LikeConflictHandler.handleConcurrentCreate(
                 () -> courseLikeRepository.save(CourseLike.create(user, course)),
-                () -> log.warn("CourseLike 동시 요청 감지: courseId={}, userId={}", courseId, userId)
+                () -> log.warn("CourseLike 동시 요청 감지: courseId={}, userId={}", course.getId(), user.getId())
         );
     }
 

--- a/src/main/java/com/semosan/api/domain/mountain/service/CourseLikeService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/CourseLikeService.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.mountain.service;
 
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.common.util.LikeConflictHandler;
 import com.semosan.api.domain.mountain.dto.response.CourseLikeToggleResponse;
 import com.semosan.api.domain.mountain.entity.Course;
 import com.semosan.api.domain.mountain.entity.CourseLike;
@@ -43,13 +44,10 @@ public class CourseLikeService {
     }
 
     private boolean createCourseLike(User user, Course course, Long userId, Long courseId) {
-        try {
-            courseLikeRepository.save(CourseLike.create(user, course));
-            return true;
-        } catch (DataIntegrityViolationException e) {
-            log.warn("CourseLike 동시 요청 감지: courseId={}, userId={}", courseId, userId);
-            return true;
-        }
+        return LikeConflictHandler.handleConcurrentCreate(
+                () -> courseLikeRepository.save(CourseLike.create(user, course)),
+                () -> log.warn("CourseLike 동시 요청 감지: courseId={}, userId={}", courseId, userId)
+        );
     }
 
     private Course findCourseById(Long courseId) {

--- a/src/test/java/com/semosan/api/common/util/LikeConflictHandlerTest.java
+++ b/src/test/java/com/semosan/api/common/util/LikeConflictHandlerTest.java
@@ -1,0 +1,54 @@
+package com.semosan.api.common.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LikeConflictHandlerTest {
+
+    @Test
+    void handleConcurrentCreateReturnsTrueWhenCreateActionSucceeds() {
+        AtomicBoolean createCalled = new AtomicBoolean(false);
+        AtomicBoolean logCalled = new AtomicBoolean(false);
+
+        boolean result = LikeConflictHandler.handleConcurrentCreate(
+                () -> createCalled.set(true),
+                () -> logCalled.set(true)
+        );
+
+        assertThat(result).isTrue();
+        assertThat(createCalled).isTrue();
+        assertThat(logCalled).isFalse();
+    }
+
+    @Test
+    void handleConcurrentCreateReturnsTrueAndRunsLogActionWhenDataIntegrityViolationOccurs() {
+        AtomicBoolean logCalled = new AtomicBoolean(false);
+
+        boolean result = LikeConflictHandler.handleConcurrentCreate(
+                () -> {
+                    throw new DataIntegrityViolationException("duplicate");
+                },
+                () -> logCalled.set(true)
+        );
+
+        assertThat(result).isTrue();
+        assertThat(logCalled).isTrue();
+    }
+
+    @Test
+    void handleConcurrentCreateRethrowsUnexpectedException() {
+        RuntimeException exception = new IllegalStateException("unexpected");
+
+        assertThatThrownBy(() -> LikeConflictHandler.handleConcurrentCreate(
+                () -> {
+                    throw exception;
+                },
+                () -> {}
+        )).isSameAs(exception);
+    }
+}


### PR DESCRIPTION
## 🧾 요약
- PostLikeService와 CourseLikeService에 중복된 동시 요청 충돌 처리 패턴을 LikeConflictHandler로 통합

## 🔗 이슈
- close #174

## ✨ 변경 내용
- `LikeConflictHandler` 유틸 추가 — 좋아요 생성 충돌을 멱등하게 처리하는 공통 헬퍼
- `PostLikeService`, `CourseLikeService`의 `DataIntegrityViolationException` catch 블록을 `LikeConflictHandler`로 교체
- `LikeConflictHandlerTest` 추가 — 정상 생성 / 충돌 감지 / 타 예외 전파 경로 검증

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
