### PR TITLE
[Fix] 지도 산 조회 부분에서 imageUrl이 항상 null인 문제 수정

### DIFF
--- a/src/main/java/com/semosan/api/domain/mountain/repository/MountainRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/MountainRepository.java
@@ -78,14 +78,7 @@ public interface MountainRepository extends JpaRepository<Mountain, Long> {
                         m.latitude AS latitude,
                         m.longitude AS longitude,
                         COUNT(hm.user_id) AS visitCount,
-                        (
-                            SELECT COALESCE(hr2.photo_report_image_url, hr2.clive_image_url)
-                            FROM hiking_records hr2
-                            JOIN hiking_members hm2 ON hm2.hiking_record_id = hr2.id
-                            WHERE hr2.mountain_id = m.id AND hm2.user_id = :userId
-                            ORDER BY hr2.created_at DESC
-                            LIMIT 1
-                        ) AS imageUrl
+                        m.image_urls->>0 AS imageUrl
                     FROM mountains m
                     LEFT JOIN hiking_records hr ON hr.mountain_id = m.id
                     LEFT JOIN hiking_members hm ON hm.hiking_record_id = hr.id AND hm.user_id = :userId


### PR DESCRIPTION
## 🧾 요약
- 지도 영역 내 산 조회 API(`/api/mountains/map`)에서 imageUrl이 항상 null로 내려오는 문제 수정 — 산 기본 이미지를 반환하도록 쿼리 변경

## 🔗 이슈
- close #182

## ✨ 변경 내용
- `MountainRepository.findInBBoxWithUserHikingStats` 쿼리에서 등산 기록 사진 서브쿼리를 `m.image_urls->>0`(산 기본 이미지)으로 교체

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK
