### PR TITLE
[Fix] TestFlight iOS 백그라운드 푸시 미수신 버그 수정

### DIFF
--- a/src/main/java/com/semosan/api/common/fcm/FcmService.java
+++ b/src/main/java/com/semosan/api/common/fcm/FcmService.java
@@ -7,6 +7,7 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -14,6 +15,9 @@ import java.util.Map;
 @Slf4j
 @Service
 public class FcmService {
+
+    @Value("${fcm.apns-environment:production}")
+    private String apnsEnvironment;
 
     public String sendMessage(
             String token,
@@ -33,9 +37,7 @@ public class FcmService {
             builder.setNotification(notification);
         }
 
-        if (dataOnly) {
-            builder.setApnsConfig(silentPushApnsConfig());
-        }
+        builder.setApnsConfig(dataOnly ? silentPushApnsConfig() : normalPushApnsConfig());
 
         if (data != null && !data.isEmpty()) {
             builder.putAllData(data);
@@ -46,8 +48,15 @@ public class FcmService {
         return response;
     }
 
+    private ApnsConfig normalPushApnsConfig() {
+        return ApnsConfig.builder()
+                .putHeader("apns-environment", apnsEnvironment)
+                .build();
+    }
+
     private ApnsConfig silentPushApnsConfig() {
         return ApnsConfig.builder()
+                .putHeader("apns-environment", apnsEnvironment)
                 .setAps(Aps.builder()
                         .setContentAvailable(true)
                         .build())

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,6 +46,9 @@ test:
 firebase:
   service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH}
 
+fcm:
+  apns-environment: ${FCM_APNS_ENVIRONMENT:production}
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html


### PR DESCRIPTION
## 🧾 요약
- FCM에서 APNs 환경을 명시하지 않아 TestFlight(Production APNs)에서 iOS 백그라운드 푸시가 수신되지 않던 문제 수정

## 🔗 이슈
- close #184

## ✨ 변경 내용
- `FcmService`에 `apns-environment` 헤더 추가 (백그라운드/일반 알림 모두 적용)
- 일반 알림(`dataOnly=false`) 경로에 `ApnsConfig` 누락 추가
- `application.yaml`에 `fcm.apns-environment` 환경변수 분리 (prod 기본값: `production`, local: `sandbox`)

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
