### PR TITLE
[Fix] iOS 일반 푸시 알림 미수신 해결을 위한 APNs 페이로드 필수 필드 추가

### DIFF
--- a/src/main/java/com/semosan/api/common/fcm/FcmService.java
+++ b/src/main/java/com/semosan/api/common/fcm/FcmService.java
@@ -2,6 +2,7 @@ package com.semosan.api.common.fcm;
 
 import com.google.firebase.messaging.ApnsConfig;
 import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.ApsAlert;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -37,7 +38,7 @@ public class FcmService {
             builder.setNotification(notification);
         }
 
-        builder.setApnsConfig(dataOnly ? silentPushApnsConfig() : normalPushApnsConfig());
+        builder.setApnsConfig(dataOnly ? silentPushApnsConfig() : normalPushApnsConfig(title, body));
 
         if (data != null && !data.isEmpty()) {
             builder.putAllData(data);
@@ -48,9 +49,18 @@ public class FcmService {
         return response;
     }
 
-    private ApnsConfig normalPushApnsConfig() {
+    private ApnsConfig normalPushApnsConfig(String title, String body) {
         return ApnsConfig.builder()
                 .putHeader("apns-environment", apnsEnvironment)
+                .putHeader("apns-priority", "10")
+                .setAps(Aps.builder()
+                        .setAlert(ApsAlert.builder()
+                                .setTitle(title)
+                                .setBody(body)
+                                .build())
+                        .setSound("default")
+                        .setContentAvailable(true)
+                        .build())
                 .build();
     }
 


### PR DESCRIPTION
## 🧾 요약
- normalPushApnsConfig에 누락된 APNs 필수 필드를 추가해 iOS 일반 푸시 알림이 정상 수신되도록 수정

## 🔗 이슈
- close #186

## ✨ 변경 내용
- `apns-priority: 10` 헤더 추가
- `aps.alert` (title/body) 추가
- `aps.sound = "default"` 추가
- `aps.content-available = true` 추가

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
