### PR TITLE
[Fix] FCM APNs 헤더 설정 버그 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ scripts/
 ## 로컬 개발 전용
 docker-compose.local.yml
 work/
+outputs/

--- a/src/main/java/com/semosan/api/common/fcm/FcmService.java
+++ b/src/main/java/com/semosan/api/common/fcm/FcmService.java
@@ -8,7 +8,6 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -16,9 +15,6 @@ import java.util.Map;
 @Slf4j
 @Service
 public class FcmService {
-
-    @Value("${fcm.apns-environment:production}")
-    private String apnsEnvironment;
 
     public String sendMessage(
             String token,
@@ -51,7 +47,7 @@ public class FcmService {
 
     private ApnsConfig normalPushApnsConfig(String title, String body) {
         return ApnsConfig.builder()
-                .putHeader("apns-environment", apnsEnvironment)
+                .putHeader("apns-push-type", "alert")
                 .putHeader("apns-priority", "10")
                 .setAps(Aps.builder()
                         .setAlert(ApsAlert.builder()
@@ -66,7 +62,8 @@ public class FcmService {
 
     private ApnsConfig silentPushApnsConfig() {
         return ApnsConfig.builder()
-                .putHeader("apns-environment", apnsEnvironment)
+                .putHeader("apns-push-type", "background")
+                .putHeader("apns-priority", "5")
                 .setAps(Aps.builder()
                         .setContentAvailable(true)
                         .build())

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,9 +46,6 @@ test:
 firebase:
   service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH}
 
-fcm:
-  apns-environment: ${FCM_APNS_ENVIRONMENT:production}
-
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
@@ -90,4 +87,3 @@ discord:
     enabled: ${DISCORD_ALERT_ENABLED}
     webhook-url: ${DISCORD_WEBHOOK_URL}
     report-webhook-url: ${DISCORD_REPORT_WEBHOOK_URL}
-


### PR DESCRIPTION
## 🧾 요약
- FCM APNs 비표준 헤더를 제거하고 push type별 표준 헤더를 적용해 iOS 푸시 발송 실패를 수정합니다.

## 🔗 이슈
- close #188

## ✨ 변경 내용
- `apns-environment` 헤더와 관련 설정값 제거
- 일반 알림 APNs 설정에 `apns-push-type=alert`, `apns-priority=10` 적용
- silent/background 알림 APNs 설정에 `apns-push-type=background`, `apns-priority=5` 적용
- 로컬 산출물 디렉터리 `outputs/`를 git 추적 대상에서 제외

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
