### PR TITLE
[Fix] notifications_type_check 제약 SEMOFEED_EMOJI 누락 수정

### DIFF
--- a/src/main/resources/db/migration/V28__add_semofeed_emoji_notification_type.sql
+++ b/src/main/resources/db/migration/V28__add_semofeed_emoji_notification_type.sql
@@ -1,0 +1,18 @@
+-- =====================================================================
+-- V28__add_semofeed_emoji_notification_type.sql
+-- 목적: notifications.type CHECK 제약에 SEMOFEED_EMOJI 타입을 포함시킨다.
+-- 배경: V22 에서 COMMUNITY_REPLY/COMMUNITY_POST_LIKE 추가 시 SEMOFEED_EMOJI 가 누락됨.
+-- 멱등: DROP IF EXISTS → ADD 패턴.
+-- =====================================================================
+
+ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
+
+ALTER TABLE notifications ADD CONSTRAINT notifications_type_check
+    CHECK (type IN (
+        'COMMUNITY_COMMENT',
+        'COMMUNITY_REPLY',
+        'COMMUNITY_POST_LIKE',
+        'SEMOFEED_EMOJI',
+        'TRACKING_PHOTO_MILESTONE',
+        'TRACKING_SUMMIT_REACHED'
+    ));


### PR DESCRIPTION
## 🧾 요약
- V22 마이그레이션에서 SEMOFEED_EMOJI 타입이 누락돼 세모피드 이모지 반응 알림 저장 시 DB 체크 제약 위반 오류 발생

## 🔗 이슈
- close #191

## ✨ 변경 내용
- V28 Flyway 마이그레이션 추가: `notifications_type_check` 제약에 `SEMOFEED_EMOJI` 포함
- 현재 모든 `NotificationType` enum 값이 DB 제약과 일치하도록 정렬

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
