### PR TITLE
[Feat] 트래킹 푸시(사진 마일스톤/정상 도달) mixed payload 전환

### DIFF
--- a/src/main/java/com/semosan/api/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/semosan/api/domain/notification/enums/NotificationType.java
@@ -38,25 +38,28 @@ public enum NotificationType {
 
     /**
      * 트래킹 중 거리 마일스톤 도달 시 사진 촬영 유도.
-     * 포그라운드 즉시 표시를 위해 FCM data-only 로 발송하고, 앱에서 로컬 알림을 생성한다.
+     * iOS 백그라운드/잠금화면/앱 종료 상태에서도 시스템이 즉시 배너를 표시하도록 mixed payload
+     * (notification 키 + data 키) 로 발송한다. 포그라운드 자동 배너 차단은 클라(앱) 의
+     * setForegroundNotificationPresentationOptions 에서 처리한다.
      */
     TRACKING_PHOTO_MILESTONE(
             "SEMOSAN",
             "{distance}m 돌파! 인증 사진을 남겨보세요!",
             Set.of("distance"),
-            true
+            false
     ),
 
     /**
      * 코스 거리 50% 도달 시 정상 인증 유도.
      * 진짜 정상 좌표가 식별 불가해 코스 절반 지점을 "정상" 근처로 간주하는 임시 정책.
-     * 포그라운드 즉시 표시를 위해 FCM data-only 로 발송하고, 앱에서 로컬 알림을 생성한다.
+     * iOS 백그라운드/잠금화면/앱 종료 상태에서도 시스템이 즉시 배너를 표시하도록 mixed payload
+     * (notification 키 + data 키) 로 발송한다.
      */
     TRACKING_SUMMIT_REACHED(
             "SEMOSAN",
             "정상에 도착했나요? 정상 인증하기!",
             Set.of(),
-            true
+            false
     );
 
     private final String titleTemplate;

--- a/src/main/java/com/semosan/api/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/semosan/api/domain/notification/enums/NotificationType.java
@@ -39,8 +39,10 @@ public enum NotificationType {
     /**
      * 트래킹 중 거리 마일스톤 도달 시 사진 촬영 유도.
      * iOS 백그라운드/잠금화면/앱 종료 상태에서도 시스템이 즉시 배너를 표시하도록 mixed payload
-     * (notification 키 + data 키) 로 발송한다. 포그라운드 자동 배너 차단은 클라(앱) 의
-     * setForegroundNotificationPresentationOptions 에서 처리한다.
+     * (notification 키 + data 키) 로 발송한다. 포그라운드 배너 노출 여부는 클라(앱) 의
+     * UNUserNotificationCenterDelegate(willPresent) 에서 알림 타입(data.type) 을 식별해
+     * 동적으로 제어한다. (setForegroundNotificationPresentationOptions 는 앱 전역 옵션이라
+     * 다른 알림 타입에도 영향이 가므로 사용하지 않는다.)
      */
     TRACKING_PHOTO_MILESTONE(
             "SEMOSAN",
@@ -53,7 +55,8 @@ public enum NotificationType {
      * 코스 거리 50% 도달 시 정상 인증 유도.
      * 진짜 정상 좌표가 식별 불가해 코스 절반 지점을 "정상" 근처로 간주하는 임시 정책.
      * iOS 백그라운드/잠금화면/앱 종료 상태에서도 시스템이 즉시 배너를 표시하도록 mixed payload
-     * (notification 키 + data 키) 로 발송한다.
+     * (notification 키 + data 키) 로 발송한다. 포그라운드 배너 제어는 TRACKING_PHOTO_MILESTONE
+     * 과 동일하게 UNUserNotificationCenterDelegate(willPresent) 에서 동적으로 처리한다.
      */
     TRACKING_SUMMIT_REACHED(
             "SEMOSAN",


### PR DESCRIPTION
## 🧾 요약
- silent push(data-only) 일 때 iOS APNs 의 background throttle/묶음 전달로 마일스톤 알림이 한꺼번에 도착하거나 앱 종료 상태에서 누락되는 문제가 있었다.

## 🔗 이슈
- close #190 

## ✨ 변경 내용
- notification 키를 함께 발송(mixed) 하도록 NotificationType 의 dataOnly 를 false 로 전환해 iOS 시스템이 직접 즉시 배너를 표시하도록 한다.
- 변경 enum: TRACKING_PHOTO_MILESTONE, TRACKING_SUMMIT_REACHED
-  data 키 / 라우팅 키 / 본문 결정 흐름은 그대로
- 다른 NotificationType 영향 없음, 마이그레이션 불필요

## ✅ 확인
- [x] 빌드 OK
- [ ] 테스트 OK