### PR TITLE
[Fix] 세모피드 이모지 알림 메시지에 이모지 문자 표시

### DIFF
--- a/src/main/java/com/semosan/api/domain/semofeed/enums/SemoFeedEmojiType.java
+++ b/src/main/java/com/semosan/api/domain/semofeed/enums/SemoFeedEmojiType.java
@@ -1,8 +1,15 @@
 package com.semosan.api.domain.semofeed.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum SemoFeedEmojiType {
-    FIRE,
-    HEART,
-    CONGRATS,
-    LAUGH
+    FIRE("🔥"),
+    HEART("❤️"),
+    CONGRATS("🎉"),
+    LAUGH("😂");
+
+    private final String emoji;
 }

--- a/src/main/java/com/semosan/api/domain/semofeed/notification/service/SemoFeedNotificationService.java
+++ b/src/main/java/com/semosan/api/domain/semofeed/notification/service/SemoFeedNotificationService.java
@@ -28,7 +28,7 @@ public class SemoFeedNotificationService {
                         "actorId", reactor.getId(),
                         "actorName", reactor.displayName(),
                         "semoFeedId", semoFeed.getId(),
-                        "emojiType", emojiType.name()
+                        "emojiType", emojiType.getEmoji()
                 )
         );
     }


### PR DESCRIPTION
## 🧾 요약
- 세모피드 이모지 반응 알림에 enum 이름(HEART, FIRE 등)이 텍스트로 노출되던 문제를 이모지 문자로 교체

## 🔗 이슈
- close #194

## ✨ 변경 내용
- `SemoFeedEmojiType` enum에 각 타입별 이모지 문자 필드 추가 (FIRE → 🔥, HEART → ❤️, CONGRATS → 🎉, LAUGH → 😂)
- 알림 파라미터 전달 시 `.name()` 대신 `.getEmoji()` 사용

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
