### PR TITLE
[Feat] 코스 모드 사진 마일스톤을 정상까지 거리로 4등분

### DIFF
--- a/src/main/java/com/semosan/api/domain/tracking/service/TrackingMilestoneCalculator.java
+++ b/src/main/java/com/semosan/api/domain/tracking/service/TrackingMilestoneCalculator.java
@@ -9,7 +9,9 @@ import java.util.List;
 
 /**
  * 트래킹 세션의 사진 촬영 마일스톤 거리 리스트를 계산한다.
- *  - 코스 따라가기: course.distance(미터) 의 1/4, 2/4, 3/4, 4/4 지점 (총 4컷)
+ *  - 코스 따라가기: 정상까지(=course.distance/2, 임시 정책) 를 1/4, 2/4, 3/4, 4/4 로 등분한 지점 (총 4컷).
+ *    즉 코스 전체 distance 기준으로는 12.5% / 25% / 37.5% / 50% 지점에 해당.
+ *    4/4 가 정상 도달 시점이며 {@link TrackingMilestoneTriggerService#evaluateSummit} 와 같은 임계가 된다.
  *  - 자유 기록: 500m 간격, 정책상 최대 6컷 (500/1000/1500/2000/2500/3000m)
  *
  * 단위 정책: 입력/출력 모두 미터(m). distanceTotal(Haversine 누적, m) 과 비교될 값이라 단위 일치 필수.
@@ -31,9 +33,11 @@ public class TrackingMilestoneCalculator {
 
     private List<Double> courseMilestones(Course course) {
         double totalMeters = course.getDistance() == null ? 0.0 : course.getDistance();
+        // 정상 = 코스 절반(임시 정책). 사진 4컷을 정상까지 거리에 균등 분배한다.
+        double summitMeters = totalMeters / 2.0;
         List<Double> result = new ArrayList<>(COURSE_MILESTONE_COUNT);
         for (int i = 1; i <= COURSE_MILESTONE_COUNT; i++) {
-            result.add(totalMeters * i / COURSE_MILESTONE_COUNT);
+            result.add(summitMeters * i / COURSE_MILESTONE_COUNT);
         }
         return result;
     }

--- a/src/main/java/com/semosan/api/domain/tracking/service/TrackingMilestoneTriggerService.java
+++ b/src/main/java/com/semosan/api/domain/tracking/service/TrackingMilestoneTriggerService.java
@@ -89,8 +89,8 @@ public class TrackingMilestoneTriggerService {
             }
         }
 
-        // 코스 모드(마일스톤 4개)일 때만 정상(=코스 절반 지점) 알림 평가.
-        // 마지막 마일스톤(4/4)이 곧 코스 distance 이므로 그걸 courseDistance 로 사용.
+        // 코스 모드(마일스톤 4개)일 때만 정상 알림 평가.
+        // 마지막 마일스톤(4/4)이 곧 정상 지점(= course.distance / 2, 임시 정책) 이라 그걸 summitMark 로 전달한다.
         if (milestones.size() == COURSE_MILESTONE_COUNT) {
             evaluateSummit(sessionId, userId, distanceTotal, milestones.get(milestones.size() - 1));
         }
@@ -149,36 +149,37 @@ public class TrackingMilestoneTriggerService {
     }
 
     /**
-     * 코스 거리 50% 지점 도달 시 1회 정상 알림을 발송한다.
-     *  - 자유 기록(session.course == null) 인 경우 정상 개념이 없으니 호출자에서 courseDistance=0 으로 넘기면 skip.
+     * 정상 도달 시 1회 정상 알림을 발송한다.
+     *  - 호출자({@link #evaluate})가 마지막 사진 마일스톤 거리(= 정상 지점) 을 그대로 summitMark 로 전달한다.
+     *    현재 정책상 정상 = course.distance / 2 이지만, 향후 정상 좌표가 식별되면 그 거리로 바꿔주기만 하면 된다.
+     *  - 자유 기록(session.course == null) 인 경우 정상 개념이 없어 호출자에서 summitMark=0 으로 넘기면 skip.
      *  - Redis SADD 의 반환값으로 idempotent — 두 인스턴스가 동시 호출해도 한 인스턴스만 발송.
      *  - WebSocket /topic/tracking/{sessionId}/summit + FCM 둘 다 발송.
      */
-    public void evaluateSummit(Long sessionId, Long userId, double distanceTotal, double courseDistance) {
-        if (courseDistance <= 0) {
+    public void evaluateSummit(Long sessionId, Long userId, double distanceTotal, double summitMark) {
+        if (summitMark <= 0) {
             return;
         }
-        double halfwayMark = courseDistance / 2.0;
-        if (distanceTotal < halfwayMark) {
+        if (distanceTotal < summitMark) {
             return;
         }
         String key = summitNotifiedKey(sessionId);
         Long added = redisTemplate.opsForSet().add(key, "1");
         if (added == null || added == 0L) {
             // 이미 다른 호출에서 보낸 상태 — silent skip.
-            // EXPIRE 도 함께 skip 해야 50% 통과 후 매 GPS 점마다 TTL 이 리셋되는 핫패스 부하를 막을 수 있다.
+            // EXPIRE 도 함께 skip 해야 정상 통과 후 매 GPS 점마다 TTL 이 리셋되는 핫패스 부하를 막을 수 있다.
             return;
         }
         redisTemplate.expire(key, TTL);
-        sendSummit(sessionId, userId, halfwayMark);
+        sendSummit(sessionId, userId, summitMark);
     }
 
-    private void sendSummit(Long sessionId, Long userId, double halfwayMark) {
+    private void sendSummit(Long sessionId, Long userId, double summitMark) {
         Map<String, Object> payload = new LinkedHashMap<>();
-        payload.put("halfwayMark", halfwayMark);
+        payload.put("summitMark", summitMark);
         payload.put("reachedAt", LocalDateTime.now().toString());
         messagingTemplate.convertAndSend(summitTopic(sessionId), payload);
-        log.info("Summit reached: sessionId={} userId={} halfwayMark={}m", sessionId, userId, (int) Math.round(halfwayMark));
+        log.info("Summit reached: sessionId={} userId={} summitMark={}m", sessionId, userId, (int) Math.round(summitMark));
 
         try {
             notificationService.send(


### PR DESCRIPTION
## 🧾 요약
- 코스 마일스톤(1/4·2/4·3/4·4/4) 을 코스 전체 distance 가 아닌 정상까지(=course.distance/2, 임시 정책) 거리에 균등 분배하도록 변경.

## 🔗 이슈
- close #196 

## ✨ 변경 내용
- 코스 4/4 가 곧 정상 도달 시점이 되어 SUMMIT 임계와 일치한다.
- TrackingMilestoneCalculator.courseMilestones: summitMeters = totalMeters/2 도입
- TrackingMilestoneTriggerService.evaluateSummit: 호출자가 정상 지점을 그대로 전달하므로 내부 halfwayMark/2 제거. 
- 변수/파라미터/payload 키를 summitMark 로 통일
- 자유 기록(500m 6컷) / NotificationType / FCM 흐름 / DB 영향 없음

## ✅ 확인
- [x] 빌드 OK
- [ ] 테스트 OK