### PR TITLE
[Feat] Redis Stream 트리밍 정책 추가

### DIFF
--- a/src/main/java/com/semosan/api/common/config/RedisStreamConfig.java
+++ b/src/main/java/com/semosan/api/common/config/RedisStreamConfig.java
@@ -2,11 +2,14 @@ package com.semosan.api.common.config;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
 
+@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class RedisStreamConfig {
@@ -24,6 +27,15 @@ public class RedisStreamConfig {
             );
         } catch (RedisSystemException e) {
             // consumer group already exists
+        }
+    }
+
+    @Scheduled(fixedDelay = 60_000L)
+    public void trimStream() {
+        Long trimmed = redisTemplate.opsForStream()
+                .trim(trackingProperties.getStreamKey(), trackingProperties.getStreamMaxLen(), true);
+        if (trimmed != null && trimmed > 0) {
+            log.info("[STREAM] 트리밍 완료 | {}건 제거 | maxLen={}", trimmed, trackingProperties.getStreamMaxLen());
         }
     }
 }

--- a/src/main/java/com/semosan/api/common/config/RedisStreamConfig.java
+++ b/src/main/java/com/semosan/api/common/config/RedisStreamConfig.java
@@ -2,14 +2,11 @@ package com.semosan.api.common.config;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
 
-@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class RedisStreamConfig {
@@ -27,15 +24,6 @@ public class RedisStreamConfig {
             );
         } catch (RedisSystemException e) {
             // consumer group already exists
-        }
-    }
-
-    @Scheduled(fixedDelay = 60_000L)
-    public void trimStream() {
-        Long trimmed = redisTemplate.opsForStream()
-                .trim(trackingProperties.getStreamKey(), trackingProperties.getStreamMaxLen(), true);
-        if (trimmed != null && trimmed > 0) {
-            log.info("[STREAM] 트리밍 완료 | {}건 제거 | maxLen={}", trimmed, trackingProperties.getStreamMaxLen());
         }
     }
 }

--- a/src/main/java/com/semosan/api/common/config/TrackingProperties.java
+++ b/src/main/java/com/semosan/api/common/config/TrackingProperties.java
@@ -13,4 +13,5 @@ public class TrackingProperties {
 
     private String streamKey;
     private String consumerGroup;
+    private long streamMaxLen = 100_000;
 }

--- a/src/main/java/com/semosan/api/domain/tracking/scheduler/TrackingStreamTrimScheduler.java
+++ b/src/main/java/com/semosan/api/domain/tracking/scheduler/TrackingStreamTrimScheduler.java
@@ -1,0 +1,30 @@
+package com.semosan.api.domain.tracking.scheduler;
+
+import com.semosan.api.common.config.TrackingProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TrackingStreamTrimScheduler {
+
+    private final StringRedisTemplate redisTemplate;
+    private final TrackingProperties trackingProperties;
+
+    @Scheduled(fixedDelay = 60_000L)
+    public void trimStream() {
+        try {
+            Long trimmed = redisTemplate.opsForStream()
+                    .trim(trackingProperties.getStreamKey(), trackingProperties.getStreamMaxLen(), true);
+            if (trimmed != null && trimmed > 0) {
+                log.info("[STREAM] 트리밍 완료 | {}건 제거 | maxLen={}", trimmed, trackingProperties.getStreamMaxLen());
+            }
+        } catch (Exception e) {
+            log.warn("[STREAM] 트리밍 실패", e);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,6 +39,7 @@ kakao:
 tracking:
   stream-key: ${TRACKING_STREAM_KEY}
   consumer-group: ${TRACKING_CONSUMER_GROUP}
+  stream-max-len: ${TRACKING_STREAM_MAX_LEN:100000}
 
 test:
   secret-key: ${TEST_SECRET_KEY}


### PR DESCRIPTION
## 🧾 요약
- Redis Stream 메모리 무한 증가 방지를 위한 XTRIM 스케줄러 추가

## 🔗 이슈
- close #206

## ✨ 변경 내용
- `TrackingProperties`에 `streamMaxLen` 설정 추가 (기본값 100,000)
- `application.yaml`에 `stream-max-len` 환경변수 오버라이드 지원
- `RedisStreamConfig`에 60초 주기 approximate 트리밍 스케줄러 추가

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK