### PR TITLE
[Chore] Pageable max size 글로벌 제한 설정

### DIFF
--- a/src/main/java/com/semosan/api/domain/semofeed/controller/SemoFeedController.java
+++ b/src/main/java/com/semosan/api/domain/semofeed/controller/SemoFeedController.java
@@ -12,7 +12,6 @@ import com.semosan.api.domain.semofeed.service.SemoFeedEmojiService;
 import com.semosan.api.domain.semofeed.service.SemoFeedService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -47,9 +46,6 @@ public class SemoFeedController implements SemoFeedControllerDocs {
             @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 100) Pageable pageable
     ) {
-        if (pageable.getPageSize() > 100) {
-            pageable = PageRequest.of(pageable.getPageNumber(), 100, pageable.getSort());
-        }
         PageResponse<SemoFeedResponse> response = PageResponse.from(semoFeedService.listPublic(pageable, userId));
         return ApiResponse.success(SuccessStatus.SEMOFEED_LIST_SUCCESS, response);
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,9 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+    web:
+      pageable:
+        max-page-size: 100
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
## 🧾 요약
- Pageable max size 글로벌 제한 설정 추가

## 🔗 이슈
- close #205

## ✨ 변경 내용
- `spring.data.web.pageable.max-page-size: 100` 글로벌 설정 추가
- SemoFeedController 수동 size 검증 로직 및 미사용 import 제거

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK