### PR TITLE
[Fix] SemoFeedService 탈퇴 유저 체크 누락 수정

### DIFF
--- a/src/main/java/com/semosan/api/domain/semofeed/service/SemoFeedService.java
+++ b/src/main/java/com/semosan/api/domain/semofeed/service/SemoFeedService.java
@@ -8,7 +8,7 @@ import com.semosan.api.domain.semofeed.enums.SemoFeedEmojiType;
 import com.semosan.api.domain.semofeed.repository.SemoFeedEmojiRepository;
 import com.semosan.api.domain.semofeed.repository.SemoFeedRepository;
 import com.semosan.api.domain.user.entity.User;
-import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,12 +28,11 @@ public class SemoFeedService {
 
     private final SemoFeedRepository semoFeedRepository;
     private final SemoFeedEmojiRepository semoFeedEmojiRepository;
-    private final UserRepository userRepository;
+    private final UserReader userReader;
 
     @Transactional
     public SemoFeedResponse create(Long userId, String imageUrl) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        User user = userReader.findActiveUserById(userId);
         SemoFeed semoFeed = SemoFeed.create(user, imageUrl);
         return SemoFeedResponse.from(semoFeedRepository.save(semoFeed));
     }

--- a/src/test/java/com/semosan/api/domain/semofeed/service/SemoFeedServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/semofeed/service/SemoFeedServiceTest.java
@@ -7,7 +7,7 @@ import com.semosan.api.domain.semofeed.repository.SemoFeedEmojiRepository;
 import com.semosan.api.domain.semofeed.repository.SemoFeedRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.enums.user.DeviceType;
-import com.semosan.api.domain.user.repository.UserRepository;
+import com.semosan.api.domain.user.service.UserReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,7 +19,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,7 +35,7 @@ class SemoFeedServiceTest {
     private SemoFeedEmojiRepository semoFeedEmojiRepository;
 
     @Mock
-    private UserRepository userRepository;
+    private UserReader userReader;
 
     @InjectMocks
     private SemoFeedService semoFeedService;
@@ -45,7 +44,7 @@ class SemoFeedServiceTest {
     void createReturnsDefaultEmojiFields() {
         User user = user(1L, "author", "https://example.com/profile.png");
 
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(semoFeedRepository.save(any(SemoFeed.class))).thenAnswer(invocation -> {
             SemoFeed semoFeed = invocation.getArgument(0);
             ReflectionTestUtils.setField(semoFeed, "id", 10L);


### PR DESCRIPTION
## 🧾 요약
- SemoFeedService.create()에서 UserRepository.findById 대신 UserReader.findActiveUserById를 사용하여 탈퇴 유저의 세모피드 생성을 차단

## 🔗 이슈
- close #204

## ✨ 변경 내용
- `SemoFeedService`의 의존성을 `UserRepository` → `UserReader`로 교체
- `create()` 메서드에서 `userReader.findActiveUserById(userId)`로 활성 유저만 조회하도록 변경

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK (활성 유저 세모피드 생성 정상 동작 확인)
