### PR TITLE
[Fix] Apple OAuth audience(aud) 클레임 검증 추가

### DIFF
--- a/src/main/java/com/semosan/api/domain/oauth/client/OAuthAppleClient.java
+++ b/src/main/java/com/semosan/api/domain/oauth/client/OAuthAppleClient.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -30,6 +31,9 @@ public class OAuthAppleClient {
     private final WebClient appleApiWebClient;
     private final ObjectMapper objectMapper;
 
+    @Value("${apple.client-id}")
+    private String appleClientId;
+
     // identity token 검증 후 Claims 반환
     public Claims getAppleClaims(String identityToken) {
         List<Map<String, String>> keys = getApplePublicKeys();
@@ -46,6 +50,7 @@ public class OAuthAppleClient {
             return Jwts.parser()
                     .verifyWith(publicKey)
                     .requireIssuer(APPLE_ISSUER)
+                    .requireAudience(appleClientId)
                     .build()
                     .parseSignedClaims(identityToken)
                     .getPayload();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,6 +39,9 @@ kakao:
   client-secret: ${KAKAO_CLIENT_SECRET}
   admin-key: ${KAKAO_ADMIN_KEY}
 
+apple:
+  client-id: ${APPLE_CLIENT_ID}
+
 tracking:
   stream-key: ${TRACKING_STREAM_KEY}
   consumer-group: ${TRACKING_CONSUMER_GROUP}


### PR DESCRIPTION
## 🧾 요약
- Apple OAuth 로그인 시 audience(aud) 클레임 검증 누락 수정 — 타 앱 토큰으로 로그인 가능한 보안 취약점 차단

## 🔗 이슈
- close #198

## ✨ 변경 내용
- `application.yaml`에 `apple.client-id` 설정 추가
- `OAuthAppleClient`에서 JWT 파싱 시 `requireAudience(appleClientId)` 검증 추가

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK
