### PR TITLE
[Fix] RecordPost 목록·상세 조회 차단 유저 필터링 누락 수정

### DIFF
--- a/src/main/java/com/semosan/api/domain/community/post/controller/RecordPostController.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/RecordPostController.java
@@ -36,9 +36,10 @@ public class RecordPostController implements RecordPostControllerDocs {
 
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<RecordPostResponse>>> getList(
+            @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<RecordPostResponse> page = recordPostService.getList(pageable).map(RecordPostResponse::from);
+        Page<RecordPostResponse> page = recordPostService.getList(userId, pageable).map(RecordPostResponse::from);
         return ApiResponse.success(SuccessStatus.RECORD_POST_LIST_SUCCESS, PageResponse.from(page));
     }
 
@@ -53,9 +54,10 @@ public class RecordPostController implements RecordPostControllerDocs {
 
     @GetMapping("/{postId}")
     public ResponseEntity<ApiResponse<RecordPostResponse>> getDetail(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long postId
     ) {
-        RecordPost post = recordPostService.getDetail(postId);
+        RecordPost post = recordPostService.getDetail(userId, postId);
         return ApiResponse.success(SuccessStatus.RECORD_POST_DETAIL_SUCCESS, RecordPostResponse.from(post));
     }
 

--- a/src/main/java/com/semosan/api/domain/community/post/controller/docs/RecordPostControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/docs/RecordPostControllerDocs.java
@@ -31,7 +31,10 @@ public interface RecordPostControllerDocs {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
     })
-    ResponseEntity<ApiResponse<PageResponse<RecordPostResponse>>> getList(Pageable pageable);
+    ResponseEntity<ApiResponse<PageResponse<RecordPostResponse>>> getList(
+            @AuthenticationPrincipal Long userId,
+            Pageable pageable
+    );
 
     @Operation(summary = "내 기록공유 목록", description = "내가 쓴 기록공유 게시글 목록을 조회합니다.")
     @ApiResponses({
@@ -45,9 +48,13 @@ public interface RecordPostControllerDocs {
     @Operation(summary = "기록공유 상세", description = "게시글 상세를 조회합니다. 호출 시 조회수가 1 증가합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "차단한 사용자의 게시글"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 없음 또는 삭제됨")
     })
-    ResponseEntity<ApiResponse<RecordPostResponse>> getDetail(@PathVariable Long postId);
+    ResponseEntity<ApiResponse<RecordPostResponse>> getDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    );
 
     @Operation(summary = "기록공유 삭제", description = "본인의 게시글을 soft delete 합니다.")
     @ApiResponses({

--- a/src/main/java/com/semosan/api/domain/community/post/repository/FreePostRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/FreePostRepository.java
@@ -20,29 +20,21 @@ public interface FreePostRepository extends JpaRepository<FreePost, Long> {
             SELECT fp
             FROM FreePost fp
             WHERE fp.deleted = false
-              AND fp.author.id NOT IN :blockedAuthorIds
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM UserBlock ub
+                  WHERE ub.blocker.id = :viewerId
+                    AND ub.blockedUser.id = fp.author.id
+              )
+            ORDER BY fp.createdAt DESC
             """)
-    Page<FreePost> findVisibleExcludingAuthors(
-            @Param("blockedAuthorIds") java.util.List<Long> blockedAuthorIds,
-            Pageable pageable
-    );
+    Page<FreePost> findVisibleByViewerId(@Param("viewerId") Long viewerId, Pageable pageable);
 
     @Query("SELECT fp FROM FreePost fp " +
             "WHERE fp.deleted = false " +
             "AND (LOWER(fp.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "OR LOWER(fp.content) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+            "AND NOT EXISTS (SELECT 1 FROM UserBlock ub WHERE ub.blocker.id = :viewerId AND ub.blockedUser.id = fp.author.id) " +
             "ORDER BY fp.createdAt DESC")
-    Page<FreePost> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
-
-    @Query("SELECT fp FROM FreePost fp " +
-            "WHERE fp.deleted = false " +
-            "AND (LOWER(fp.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
-            "OR LOWER(fp.content) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
-            "AND fp.author.id NOT IN :blockedAuthorIds " +
-            "ORDER BY fp.createdAt DESC")
-    Page<FreePost> searchByKeywordExcludingAuthors(
-            @Param("keyword") String keyword,
-            @Param("blockedAuthorIds") java.util.List<Long> blockedAuthorIds,
-            Pageable pageable
-    );
+    Page<FreePost> searchByKeyword(@Param("viewerId") Long viewerId, @Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/semosan/api/domain/community/post/repository/FreePostRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/FreePostRepository.java
@@ -20,21 +20,29 @@ public interface FreePostRepository extends JpaRepository<FreePost, Long> {
             SELECT fp
             FROM FreePost fp
             WHERE fp.deleted = false
-              AND NOT EXISTS (
-                  SELECT 1
-                  FROM UserBlock ub
-                  WHERE ub.blocker.id = :viewerId
-                    AND ub.blockedUser.id = fp.author.id
-              )
-            ORDER BY fp.createdAt DESC
+              AND fp.author.id NOT IN :blockedAuthorIds
             """)
-    Page<FreePost> findVisibleByViewerId(@Param("viewerId") Long viewerId, Pageable pageable);
+    Page<FreePost> findVisibleExcludingAuthors(
+            @Param("blockedAuthorIds") java.util.List<Long> blockedAuthorIds,
+            Pageable pageable
+    );
 
     @Query("SELECT fp FROM FreePost fp " +
             "WHERE fp.deleted = false " +
             "AND (LOWER(fp.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "OR LOWER(fp.content) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
-            "AND NOT EXISTS (SELECT 1 FROM UserBlock ub WHERE ub.blocker.id = :viewerId AND ub.blockedUser.id = fp.author.id) " +
             "ORDER BY fp.createdAt DESC")
-    Page<FreePost> searchByKeyword(@Param("viewerId") Long viewerId, @Param("keyword") String keyword, Pageable pageable);
+    Page<FreePost> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("SELECT fp FROM FreePost fp " +
+            "WHERE fp.deleted = false " +
+            "AND (LOWER(fp.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(fp.content) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+            "AND fp.author.id NOT IN :blockedAuthorIds " +
+            "ORDER BY fp.createdAt DESC")
+    Page<FreePost> searchByKeywordExcludingAuthors(
+            @Param("keyword") String keyword,
+            @Param("blockedAuthorIds") java.util.List<Long> blockedAuthorIds,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/semosan/api/domain/community/post/repository/RecordPostRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/RecordPostRepository.java
@@ -5,10 +5,23 @@ import com.semosan.api.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RecordPostRepository extends JpaRepository<RecordPost, Long> {
 
     Page<RecordPost> findAllByDeletedFalse(Pageable pageable);
 
     Page<RecordPost> findByAuthorAndDeletedFalse(User author, Pageable pageable);
+
+    @Query("""
+            SELECT rp
+            FROM RecordPost rp
+            WHERE rp.deleted = false
+              AND rp.author.id NOT IN :blockedAuthorIds
+            """)
+    Page<RecordPost> findVisibleExcludingAuthors(
+            @Param("blockedAuthorIds") java.util.List<Long> blockedAuthorIds,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/semosan/api/domain/community/post/repository/RecordPostRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/RecordPostRepository.java
@@ -18,10 +18,13 @@ public interface RecordPostRepository extends JpaRepository<RecordPost, Long> {
             SELECT rp
             FROM RecordPost rp
             WHERE rp.deleted = false
-              AND rp.author.id NOT IN :blockedAuthorIds
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM UserBlock ub
+                  WHERE ub.blocker.id = :viewerId
+                    AND ub.blockedUser.id = rp.author.id
+              )
+            ORDER BY rp.createdAt DESC
             """)
-    Page<RecordPost> findVisibleExcludingAuthors(
-            @Param("blockedAuthorIds") java.util.List<Long> blockedAuthorIds,
-            Pageable pageable
-    );
+    Page<RecordPost> findVisibleByViewerId(@Param("viewerId") Long viewerId, Pageable pageable);
 }

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -57,11 +57,7 @@ public class FreePostService {
     }
 
     public Page<FreePostListResponse> getList(Long viewerId, Pageable pageable) {
-        List<Long> blockedAuthorIds = postBlockPolicy.findBlockedAuthorIds(viewerId);
-        Page<FreePost> posts = blockedAuthorIds.isEmpty()
-                ? freePostRepository.findAllByDeletedFalse(pageable)
-                : freePostRepository.findVisibleExcludingAuthors(blockedAuthorIds, pageable);
-        return enrichWithCounts(posts);
+        return enrichWithCounts(freePostRepository.findVisibleByViewerId(viewerId, pageable));
     }
 
     public Page<FreePostListResponse> search(Long viewerId, String keyword, Pageable pageable) {
@@ -69,11 +65,7 @@ public class FreePostService {
             return Page.empty(pageable);
         }
         Pageable unsorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        List<Long> blockedAuthorIds = postBlockPolicy.findBlockedAuthorIds(viewerId);
-        Page<FreePost> posts = blockedAuthorIds.isEmpty()
-                ? freePostRepository.searchByKeyword(keyword.strip(), unsorted)
-                : freePostRepository.searchByKeywordExcludingAuthors(keyword.strip(), blockedAuthorIds, unsorted);
-        return enrichWithCounts(posts);
+        return enrichWithCounts(freePostRepository.searchByKeyword(viewerId, keyword.strip(), unsorted));
     }
 
     public Page<FreePostListResponse> getMyList(Long authorId, Pageable pageable) {

--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -10,7 +10,6 @@ import com.semosan.api.domain.community.post.entity.FreePost;
 import com.semosan.api.domain.community.post.entity.PostImage;
 import com.semosan.api.domain.community.post.repository.FreePostRepository;
 import com.semosan.api.domain.community.post.repository.PostImageRepository;
-import com.semosan.api.domain.user.repository.UserBlockRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +32,7 @@ public class FreePostService {
     private final PostImageRepository postImageRepository;
     private final PostLikeRepository postLikeRepository;
     private final CommentRepository commentRepository;
-    private final UserBlockRepository userBlockRepository;
+    private final PostBlockPolicy postBlockPolicy;
     private final UserReader userReader;
 
     @Transactional
@@ -58,7 +57,11 @@ public class FreePostService {
     }
 
     public Page<FreePostListResponse> getList(Long viewerId, Pageable pageable) {
-        return enrichWithCounts(freePostRepository.findVisibleByViewerId(viewerId, pageable));
+        List<Long> blockedAuthorIds = postBlockPolicy.findBlockedAuthorIds(viewerId);
+        Page<FreePost> posts = blockedAuthorIds.isEmpty()
+                ? freePostRepository.findAllByDeletedFalse(pageable)
+                : freePostRepository.findVisibleExcludingAuthors(blockedAuthorIds, pageable);
+        return enrichWithCounts(posts);
     }
 
     public Page<FreePostListResponse> search(Long viewerId, String keyword, Pageable pageable) {
@@ -66,7 +69,11 @@ public class FreePostService {
             return Page.empty(pageable);
         }
         Pageable unsorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        return enrichWithCounts(freePostRepository.searchByKeyword(viewerId, keyword.strip(), unsorted));
+        List<Long> blockedAuthorIds = postBlockPolicy.findBlockedAuthorIds(viewerId);
+        Page<FreePost> posts = blockedAuthorIds.isEmpty()
+                ? freePostRepository.searchByKeyword(keyword.strip(), unsorted)
+                : freePostRepository.searchByKeywordExcludingAuthors(keyword.strip(), blockedAuthorIds, unsorted);
+        return enrichWithCounts(posts);
     }
 
     public Page<FreePostListResponse> getMyList(Long authorId, Pageable pageable) {
@@ -77,9 +84,7 @@ public class FreePostService {
     @Transactional
     public FreePostDetailResponse getDetail(Long viewerId, Long postId) {
         FreePost post = findActivePostOrThrow(postId);
-        if (userBlockRepository.existsByBlocker_IdAndBlockedUser_Id(viewerId, post.getAuthor().getId())) {
-            throw new GeneralException(ErrorStatus.POST_AUTHOR_BLOCKED);
-        }
+        postBlockPolicy.validateReadable(viewerId, post);
         post.increaseViewCount();
 
         List<PostImage> images = postImageRepository.findByPostOrderBySortOrderAsc(post);

--- a/src/main/java/com/semosan/api/domain/community/post/service/PostBlockPolicy.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/PostBlockPolicy.java
@@ -7,19 +7,13 @@ import com.semosan.api.domain.user.repository.UserBlockRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 @RequiredArgsConstructor
 public class PostBlockPolicy {
 
     private final UserBlockRepository userBlockRepository;
 
-    // 게시글 조회 시 차단한 작성자의 콘텐츠를 숨기는 공통 정책.
-    public List<Long> findBlockedAuthorIds(Long viewerId) {
-        return userBlockRepository.findBlockedUserIdsByBlocker_Id(viewerId);
-    }
-
+    // 게시글 상세 조회 시 차단한 작성자의 콘텐츠 접근을 막는 공통 정책.
     public void validateReadable(Long viewerId, Post post) {
         if (userBlockRepository.existsByBlocker_IdAndBlockedUser_Id(viewerId, post.getAuthor().getId())) {
             throw new GeneralException(ErrorStatus.POST_AUTHOR_BLOCKED);

--- a/src/main/java/com/semosan/api/domain/community/post/service/PostBlockPolicy.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/PostBlockPolicy.java
@@ -1,0 +1,28 @@
+package com.semosan.api.domain.community.post.service;
+
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.community.post.entity.Post;
+import com.semosan.api.domain.user.repository.UserBlockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PostBlockPolicy {
+
+    private final UserBlockRepository userBlockRepository;
+
+    // 게시글 조회 시 차단한 작성자의 콘텐츠를 숨기는 공통 정책.
+    public List<Long> findBlockedAuthorIds(Long viewerId) {
+        return userBlockRepository.findBlockedUserIdsByBlocker_Id(viewerId);
+    }
+
+    public void validateReadable(Long viewerId, Post post) {
+        if (userBlockRepository.existsByBlocker_IdAndBlockedUser_Id(viewerId, post.getAuthor().getId())) {
+            throw new GeneralException(ErrorStatus.POST_AUTHOR_BLOCKED);
+        }
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
@@ -23,6 +23,7 @@ public class RecordPostService {
     private final RecordPostRepository recordPostRepository;
     private final HikingRecordRepository hikingRecordRepository;
     private final HikingMemberRepository hikingMemberRepository;
+    private final PostBlockPolicy postBlockPolicy;
     private final UserReader userReader;
 
     @Transactional
@@ -39,8 +40,12 @@ public class RecordPostService {
         return recordPostRepository.save(post);
     }
 
-    public Page<RecordPost> getList(Pageable pageable) {
-        return recordPostRepository.findAllByDeletedFalse(pageable);
+    public Page<RecordPost> getList(Long viewerId, Pageable pageable) {
+        java.util.List<Long> blockedAuthorIds = postBlockPolicy.findBlockedAuthorIds(viewerId);
+        if (blockedAuthorIds.isEmpty()) {
+            return recordPostRepository.findAllByDeletedFalse(pageable);
+        }
+        return recordPostRepository.findVisibleExcludingAuthors(blockedAuthorIds, pageable);
     }
 
     public Page<RecordPost> getMyList(Long authorId, Pageable pageable) {
@@ -49,8 +54,9 @@ public class RecordPostService {
     }
 
     @Transactional
-    public RecordPost getDetail(Long postId) {
+    public RecordPost getDetail(Long viewerId, Long postId) {
         RecordPost post = findActivePostOrThrow(postId);
+        postBlockPolicy.validateReadable(viewerId, post);
         post.increaseViewCount();
         return post;
     }

--- a/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
@@ -41,11 +41,7 @@ public class RecordPostService {
     }
 
     public Page<RecordPost> getList(Long viewerId, Pageable pageable) {
-        java.util.List<Long> blockedAuthorIds = postBlockPolicy.findBlockedAuthorIds(viewerId);
-        if (blockedAuthorIds.isEmpty()) {
-            return recordPostRepository.findAllByDeletedFalse(pageable);
-        }
-        return recordPostRepository.findVisibleExcludingAuthors(blockedAuthorIds, pageable);
+        return recordPostRepository.findVisibleByViewerId(viewerId, pageable);
     }
 
     public Page<RecordPost> getMyList(Long authorId, Pageable pageable) {

--- a/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
@@ -65,8 +65,7 @@ class FreePostServiceTest {
         FreePost post = freePost(10L, author, "제목", "본문");
         Page<FreePost> page = new PageImpl<>(List.of(post), PageRequest.of(0, 10), 1);
 
-        when(postBlockPolicy.findBlockedAuthorIds(1L)).thenReturn(List.of(2L));
-        when(freePostRepository.findVisibleExcludingAuthors(List.of(2L), PageRequest.of(0, 10))).thenReturn(page);
+        when(freePostRepository.findVisibleByViewerId(1L, PageRequest.of(0, 10))).thenReturn(page);
         when(postLikeRepository.countByPostIdsGrouped(anyList())).thenReturn(List.<Object[]>of(new Object[]{10L, 3L}));
         when(commentRepository.countByPostIdsGrouped(anyList())).thenReturn(List.<Object[]>of(new Object[]{10L, 2L}));
         when(postImageRepository.findMainImagesByPostIds(anyList())).thenReturn(List.of());
@@ -75,8 +74,7 @@ class FreePostServiceTest {
         Page<FreePostListResponse> result = freePostService.getList(1L, PageRequest.of(0, 10));
 
         assertThat(result).hasSize(1);
-        verify(postBlockPolicy).findBlockedAuthorIds(1L);
-        verify(freePostRepository).findVisibleExcludingAuthors(eq(List.of(2L)), eq(PageRequest.of(0, 10)));
+        verify(freePostRepository).findVisibleByViewerId(eq(1L), eq(PageRequest.of(0, 10)));
     }
 
     @Test

--- a/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
@@ -12,7 +12,6 @@ import com.semosan.api.domain.community.post.repository.FreePostRepository;
 import com.semosan.api.domain.community.post.repository.PostImageRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.enums.user.DeviceType;
-import com.semosan.api.domain.user.repository.UserBlockRepository;
 import com.semosan.api.domain.user.service.UserReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,7 +51,7 @@ class FreePostServiceTest {
     private CommentRepository commentRepository;
 
     @Mock
-    private UserBlockRepository userBlockRepository;
+    private PostBlockPolicy postBlockPolicy;
 
     @Mock
     private UserReader userReader;
@@ -66,7 +65,8 @@ class FreePostServiceTest {
         FreePost post = freePost(10L, author, "제목", "본문");
         Page<FreePost> page = new PageImpl<>(List.of(post), PageRequest.of(0, 10), 1);
 
-        when(freePostRepository.findVisibleByViewerId(1L, PageRequest.of(0, 10))).thenReturn(page);
+        when(postBlockPolicy.findBlockedAuthorIds(1L)).thenReturn(List.of(2L));
+        when(freePostRepository.findVisibleExcludingAuthors(List.of(2L), PageRequest.of(0, 10))).thenReturn(page);
         when(postLikeRepository.countByPostIdsGrouped(anyList())).thenReturn(List.<Object[]>of(new Object[]{10L, 3L}));
         when(commentRepository.countByPostIdsGrouped(anyList())).thenReturn(List.<Object[]>of(new Object[]{10L, 2L}));
         when(postImageRepository.findMainImagesByPostIds(anyList())).thenReturn(List.of());
@@ -75,7 +75,8 @@ class FreePostServiceTest {
         Page<FreePostListResponse> result = freePostService.getList(1L, PageRequest.of(0, 10));
 
         assertThat(result).hasSize(1);
-        verify(freePostRepository).findVisibleByViewerId(eq(1L), eq(PageRequest.of(0, 10)));
+        verify(postBlockPolicy).findBlockedAuthorIds(1L);
+        verify(freePostRepository).findVisibleExcludingAuthors(eq(List.of(2L)), eq(PageRequest.of(0, 10)));
     }
 
     @Test
@@ -84,7 +85,6 @@ class FreePostServiceTest {
         FreePost post = freePost(10L, author, "제목", "본문");
 
         when(freePostRepository.findById(10L)).thenReturn(Optional.of(post));
-        when(userBlockRepository.existsByBlocker_IdAndBlockedUser_Id(1L, 2L)).thenReturn(false);
         when(postImageRepository.findByPostOrderBySortOrderAsc(post)).thenReturn(List.of());
         when(postLikeRepository.countByPost(post)).thenReturn(3L);
         when(commentRepository.countByPostAndDeletedFalse(post)).thenReturn(2L);
@@ -95,6 +95,7 @@ class FreePostServiceTest {
         assertThat(result.likedByMe()).isTrue();
         assertThat(result.likeCount()).isEqualTo(3L);
         assertThat(result.commentCount()).isEqualTo(2L);
+        verify(postBlockPolicy).validateReadable(1L, post);
     }
 
     @Test
@@ -103,7 +104,8 @@ class FreePostServiceTest {
         FreePost post = freePost(10L, author, "제목", "본문");
 
         when(freePostRepository.findById(10L)).thenReturn(Optional.of(post));
-        when(userBlockRepository.existsByBlocker_IdAndBlockedUser_Id(1L, 2L)).thenReturn(true);
+        org.mockito.Mockito.doThrow(new GeneralException(ErrorStatus.POST_AUTHOR_BLOCKED))
+                .when(postBlockPolicy).validateReadable(1L, post);
 
         assertThatThrownBy(() -> freePostService.getDetail(1L, 10L))
                 .isInstanceOf(GeneralException.class)

--- a/src/test/java/com/semosan/api/domain/community/post/service/PostBlockPolicyTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/PostBlockPolicyTest.java
@@ -1,0 +1,66 @@
+package com.semosan.api.domain.community.post.service;
+
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.community.post.entity.FreePost;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.enums.user.DeviceType;
+import com.semosan.api.domain.user.repository.UserBlockRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PostBlockPolicyTest {
+
+    @Mock
+    private UserBlockRepository userBlockRepository;
+
+    @InjectMocks
+    private PostBlockPolicy postBlockPolicy;
+
+    @Test
+    void findBlockedAuthorIdsDelegatesToRepository() {
+        when(userBlockRepository.findBlockedUserIdsByBlocker_Id(1L)).thenReturn(List.of(2L, 3L));
+
+        List<Long> result = postBlockPolicy.findBlockedAuthorIds(1L);
+
+        assertThat(result).containsExactly(2L, 3L);
+    }
+
+    @Test
+    void validateReadableThrowsWhenViewerBlockedAuthor() throws Exception {
+        FreePost post = freePost(10L, user(2L, "author"));
+
+        when(userBlockRepository.existsByBlocker_IdAndBlockedUser_Id(1L, 2L)).thenReturn(true);
+
+        assertThatThrownBy(() -> postBlockPolicy.validateReadable(1L, post))
+                .isInstanceOf(GeneralException.class)
+                .extracting("errorStatus")
+                .isEqualTo(ErrorStatus.POST_AUTHOR_BLOCKED);
+    }
+
+    private User user(Long id, String oauthId) {
+        User user = User.createTestUser(oauthId, DeviceType.IOS);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private FreePost freePost(Long id, User author) throws Exception {
+        Constructor<FreePost> constructor = FreePost.class.getDeclaredConstructor(User.class, String.class, String.class);
+        constructor.setAccessible(true);
+        FreePost post = constructor.newInstance(author, "제목", "본문");
+        ReflectionTestUtils.setField(post, "id", id);
+        return post;
+    }
+}

--- a/src/test/java/com/semosan/api/domain/community/post/service/PostBlockPolicyTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/PostBlockPolicyTest.java
@@ -14,9 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Constructor;
-import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
@@ -28,15 +26,6 @@ class PostBlockPolicyTest {
 
     @InjectMocks
     private PostBlockPolicy postBlockPolicy;
-
-    @Test
-    void findBlockedAuthorIdsDelegatesToRepository() {
-        when(userBlockRepository.findBlockedUserIdsByBlocker_Id(1L)).thenReturn(List.of(2L, 3L));
-
-        List<Long> result = postBlockPolicy.findBlockedAuthorIds(1L);
-
-        assertThat(result).containsExactly(2L, 3L);
-    }
 
     @Test
     void validateReadableThrowsWhenViewerBlockedAuthor() throws Exception {

--- a/src/test/java/com/semosan/api/domain/community/post/service/RecordPostServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/RecordPostServiceTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,36 +51,18 @@ class RecordPostServiceTest {
     private RecordPostService recordPostService;
 
     @Test
-    void getListExcludesBlockedAuthorsWhenViewerHasBlocks() {
+    void getListUsesViewerSpecificVisibleQuery() {
         RecordPost post = recordPost(10L, user(2L, "author"));
         PageRequest pageable = PageRequest.of(0, 10);
         Page<RecordPost> page = new PageImpl<>(List.of(post), pageable, 1);
 
-        when(postBlockPolicy.findBlockedAuthorIds(1L)).thenReturn(List.of(3L));
-        when(recordPostRepository.findVisibleExcludingAuthors(List.of(3L), pageable)).thenReturn(page);
+        when(recordPostRepository.findVisibleByViewerId(1L, pageable)).thenReturn(page);
 
         Page<RecordPost> result = recordPostService.getList(1L, pageable);
 
         assertThat(result).hasSize(1);
-        verify(postBlockPolicy).findBlockedAuthorIds(1L);
-        verify(recordPostRepository).findVisibleExcludingAuthors(eq(List.of(3L)), eq(pageable));
+        verify(recordPostRepository).findVisibleByViewerId(eq(1L), eq(pageable));
         verify(recordPostRepository, never()).findAllByDeletedFalse(pageable);
-    }
-
-    @Test
-    void getListUsesDefaultQueryWhenViewerHasNoBlocks() {
-        RecordPost post = recordPost(10L, user(2L, "author"));
-        PageRequest pageable = PageRequest.of(0, 10);
-        Page<RecordPost> page = new PageImpl<>(List.of(post), pageable, 1);
-
-        when(postBlockPolicy.findBlockedAuthorIds(1L)).thenReturn(List.of());
-        when(recordPostRepository.findAllByDeletedFalse(pageable)).thenReturn(page);
-
-        Page<RecordPost> result = recordPostService.getList(1L, pageable);
-
-        assertThat(result).hasSize(1);
-        verify(recordPostRepository).findAllByDeletedFalse(pageable);
-        verify(recordPostRepository, never()).findVisibleExcludingAuthors(anyList(), eq(pageable));
     }
 
     @Test

--- a/src/test/java/com/semosan/api/domain/community/post/service/RecordPostServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/RecordPostServiceTest.java
@@ -14,12 +14,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,10 +43,73 @@ class RecordPostServiceTest {
     private HikingMemberRepository hikingMemberRepository;
 
     @Mock
+    private PostBlockPolicy postBlockPolicy;
+
+    @Mock
     private UserReader userReader;
 
     @InjectMocks
     private RecordPostService recordPostService;
+
+    @Test
+    void getListExcludesBlockedAuthorsWhenViewerHasBlocks() {
+        RecordPost post = recordPost(10L, user(2L, "author"));
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<RecordPost> page = new PageImpl<>(List.of(post), pageable, 1);
+
+        when(postBlockPolicy.findBlockedAuthorIds(1L)).thenReturn(List.of(3L));
+        when(recordPostRepository.findVisibleExcludingAuthors(List.of(3L), pageable)).thenReturn(page);
+
+        Page<RecordPost> result = recordPostService.getList(1L, pageable);
+
+        assertThat(result).hasSize(1);
+        verify(postBlockPolicy).findBlockedAuthorIds(1L);
+        verify(recordPostRepository).findVisibleExcludingAuthors(eq(List.of(3L)), eq(pageable));
+        verify(recordPostRepository, never()).findAllByDeletedFalse(pageable);
+    }
+
+    @Test
+    void getListUsesDefaultQueryWhenViewerHasNoBlocks() {
+        RecordPost post = recordPost(10L, user(2L, "author"));
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<RecordPost> page = new PageImpl<>(List.of(post), pageable, 1);
+
+        when(postBlockPolicy.findBlockedAuthorIds(1L)).thenReturn(List.of());
+        when(recordPostRepository.findAllByDeletedFalse(pageable)).thenReturn(page);
+
+        Page<RecordPost> result = recordPostService.getList(1L, pageable);
+
+        assertThat(result).hasSize(1);
+        verify(recordPostRepository).findAllByDeletedFalse(pageable);
+        verify(recordPostRepository, never()).findVisibleExcludingAuthors(anyList(), eq(pageable));
+    }
+
+    @Test
+    void getDetailValidatesBlockPolicyBeforeIncreasingViewCount() {
+        RecordPost post = recordPost(10L, user(2L, "author"));
+
+        when(recordPostRepository.findById(10L)).thenReturn(Optional.of(post));
+
+        RecordPost result = recordPostService.getDetail(1L, 10L);
+
+        assertThat(result.getViewCount()).isEqualTo(1);
+        verify(postBlockPolicy).validateReadable(1L, post);
+    }
+
+    @Test
+    void getDetailThrowsWhenViewerBlockedAuthor() {
+        RecordPost post = recordPost(10L, user(2L, "author"));
+
+        when(recordPostRepository.findById(10L)).thenReturn(Optional.of(post));
+        org.mockito.Mockito.doThrow(new GeneralException(ErrorStatus.POST_AUTHOR_BLOCKED))
+                .when(postBlockPolicy).validateReadable(1L, post);
+
+        assertThatThrownBy(() -> recordPostService.getDetail(1L, 10L))
+                .isInstanceOf(GeneralException.class)
+                .extracting("errorStatus")
+                .isEqualTo(ErrorStatus.POST_AUTHOR_BLOCKED);
+        assertThat(post.getViewCount()).isZero();
+    }
 
     @Test
     void deleteSoftDeletesWhenRequesterOwnsPost() {


### PR DESCRIPTION
## 🧾 요약
- RecordPost 목록·상세 조회 시 차단한 유저의 게시글이 그대로 노출되는 버그 수정

## 🔗 이슈
- close #203

## ✨ 변경 내용
- `PostBlockPolicy` 컴포넌트 신규 추가 — FreePost·RecordPost 공통 차단 필터링 로직 분리
- `RecordPostRepository`에 `findVisibleExcludingAuthors` 쿼리 추가
- `RecordPostService.getList`에 `viewerId` 파라미터 추가 및 차단 유저 필터링 적용
- `RecordPostService.getDetail`에 차단 유저 접근 차단 처리 추가
- `FreePostService`도 `PostBlockPolicy`를 통해 동일 패턴으로 통일
- `PostBlockPolicyTest`, `RecordPostServiceTest` 테스트 추가

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
