### PR TITLE
[Fix] Actuator 포트 네트워크 접근 제한

### DIFF
--- a/k8s/app/network-policy.yaml
+++ b/k8s/app/network-policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: semosan-api-ingress
+  namespace: semosan
+spec:
+  podSelector:
+    matchLabels:
+      app: semosan-api
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8080
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 9090

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - namespace.yaml
   - app/deployment.yaml
   - app/service.yaml
+  - app/network-policy.yaml
   - postgres/deployment.yaml
   - postgres/service.yaml
   - postgres/pvc.yaml


### PR DESCRIPTION
## 🧾 요약
- Actuator 관리 포트(9090)를 Kubernetes NetworkPolicy로 monitoring 네임스페이스에서만 접근 가능하도록 제한

## 🔗 이슈
- close #215

## ✨ 변경 내용
- `k8s/app/network-policy.yaml` 추가 — 앱 포트(8080) 전체 허용, 관리 포트(9090)는 monitoring 네임스페이스만 허용
- `k8s/kustomization.yaml`에 network-policy 리소스 등록

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
