### PR TITLE
[Fix] JWT 페이로드 이메일 클레임 제거

### DIFF
--- a/src/main/java/com/semosan/api/common/jwt/JwtService.java
+++ b/src/main/java/com/semosan/api/common/jwt/JwtService.java
@@ -53,7 +53,6 @@ public class JwtService {
 
         return Jwts.builder()
                 .subject(user.getId().toString())
-                .claim("email", user.getEmail())
                 .claim("loginType", user.getOauthProvider().name())
                 .issuedAt(now)
                 .expiration(expiration)


### PR DESCRIPTION
## 🧾 요약
- JWT 페이로드에 포함된 이메일 클레임 제거 - Base64 디코딩으로 이메일이 노출되는 보안 이슈 수정

## 🔗 이슈
- close #216

## ✨ 변경 내용
- `JwtService.generateAccessToken()`에서 `.claim("email", ...)` 제거

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
