### PR TITLE
[Fix] JwtFilter JWT 토큰 중복 파싱 제거

### DIFF
--- a/src/main/java/com/semosan/api/common/jwt/JwtFilter.java
+++ b/src/main/java/com/semosan/api/common/jwt/JwtFilter.java
@@ -5,6 +5,7 @@ import com.semosan.api.common.config.SecurityConfig;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.response.ApiResponse;
 import com.semosan.api.common.status.ErrorStatus;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -64,11 +65,11 @@ public class JwtFilter extends OncePerRequestFilter {
             // 토큰이 없는 경우 인증 객체를 설정하지 않고 넘김
             // SecurityConfig의 .anyRequest().authenticated()에서 인가 처리됨
             if (accessToken != null) {
-                jwtService.validateAccessToken(accessToken);
+                Claims claims = jwtService.validateAccessTokenAndGetClaims(accessToken);
                 if (jwtService.isAccessTokenBlacklisted(accessToken)) {
                     throw new GeneralException(ErrorStatus.JWT_BLACKLISTED);
                 }
-                Long userId = jwtService.getUserIdFromJwtToken(accessToken);
+                Long userId = jwtService.getUserIdFromClaims(claims);
                 MDC.put("userId", String.valueOf(userId));
 
                 UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/com/semosan/api/common/jwt/JwtService.java
+++ b/src/main/java/com/semosan/api/common/jwt/JwtService.java
@@ -126,14 +126,10 @@ public class JwtService {
 
     public Long getUserIdFromClaims(Claims claims) {
         try {
-            return parseUserId(claims);
+            return Long.parseLong(claims.getSubject());
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus.JWT_EXTRACT_ID_FAILED);
         }
-    }
-
-    private Long parseUserId(Claims claims) {
-        return Long.parseLong(claims.getSubject());
     }
 
     // 내부 Claims 파싱 로직

--- a/src/main/java/com/semosan/api/common/jwt/JwtService.java
+++ b/src/main/java/com/semosan/api/common/jwt/JwtService.java
@@ -84,12 +84,12 @@ public class JwtService {
         }
     }
 
-    // Access Token 검증
-    public void validateAccessToken(String accessToken) {
+    // Access Token 검증 후 Claims를 반환해 호출부에서 같은 토큰을 다시 파싱하지 않도록 한다.
+    public Claims validateAccessTokenAndGetClaims(String accessToken) {
         if (accessToken == null || accessToken.isBlank()) {
             throw new GeneralException(ErrorStatus.JWT_TOKEN_NOT_FOUND);
         }
-        parseClaims(accessToken);
+        return parseClaims(accessToken);
     }
 
     // Refresh Token 서명/만료 검증 후 Claims 반환 — DB 비교 전 1차 검증용
@@ -124,14 +124,16 @@ public class JwtService {
         tokenRedisService.deleteRefreshToken(userId);
     }
 
-    // AccessToken에서 userId 추출
-    public Long getUserIdFromJwtToken(String token) {
+    public Long getUserIdFromClaims(Claims claims) {
         try {
-            Claims claims = parseClaims(token);
-            return Long.parseLong(claims.getSubject());
+            return parseUserId(claims);
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus.JWT_EXTRACT_ID_FAILED);
         }
+    }
+
+    private Long parseUserId(Claims claims) {
+        return Long.parseLong(claims.getSubject());
     }
 
     // 내부 Claims 파싱 로직

--- a/src/main/java/com/semosan/api/domain/tracking/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/semosan/api/domain/tracking/websocket/StompAuthChannelInterceptor.java
@@ -3,6 +3,7 @@ package com.semosan.api.domain.tracking.websocket;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.jwt.JwtService;
 import com.semosan.api.common.status.ErrorStatus;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -57,8 +58,9 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             throw new GeneralException(ErrorStatus.JWT_TOKEN_NOT_FOUND);
         }
         String token = authHeader.substring(BEARER_PREFIX.length());
+        Claims claims;
         try {
-            jwtService.validateAccessToken(token);
+            claims = jwtService.validateAccessTokenAndGetClaims(token);
         } catch (GeneralException e) {
             log.warn("STOMP CONNECT 인증 실패: 토큰 검증 실패. sessionId={} code={} msg={}",
                     sessionId, e.getErrorStatus().getCode(), e.getMessage());
@@ -70,7 +72,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         }
         Long userId;
         try {
-            userId = jwtService.getUserIdFromJwtToken(token);
+            userId = jwtService.getUserIdFromClaims(claims);
         } catch (GeneralException e) {
             log.warn("STOMP CONNECT 인증 실패: userId 추출 실패. sessionId={} code={} msg={}",
                     sessionId, e.getErrorStatus().getCode(), e.getMessage());


### PR DESCRIPTION
## 🧾 요약
- JwtFilter와 StompAuthChannelInterceptor에서 동일 토큰을 최대 3번 파싱하던 문제 수정 — Claims를 한 번만 파싱해 재사용

## 🔗 이슈
- close #220

## ✨ 변경 내용
- `JwtService.validateAccessTokenAndGetClaims()` 추가 — 검증과 Claims 반환을 단일 메서드로 통합
- `JwtService.getUserIdFromClaims()` 추가 — 토큰 재파싱 없이 Claims에서 userId 추출
- `JwtFilter`, `StompAuthChannelInterceptor` Claims 재사용 방식으로 변경

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
