### PR TITLE
[Fix] PostLikeService 좋아요 알림 이벤트 기반 트랜잭션 분리

### DIFF
--- a/src/main/java/com/semosan/api/domain/community/like/event/PostLikedEvent.java
+++ b/src/main/java/com/semosan/api/domain/community/like/event/PostLikedEvent.java
@@ -1,0 +1,4 @@
+package com.semosan.api.domain.community.like.event;
+
+public record PostLikedEvent(Long postId, Long actorId) {
+}

--- a/src/main/java/com/semosan/api/domain/community/like/event/PostLikedEventListener.java
+++ b/src/main/java/com/semosan/api/domain/community/like/event/PostLikedEventListener.java
@@ -9,6 +9,7 @@ import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -23,7 +24,7 @@ public class PostLikedEventListener {
     private final CommunityNotificationService communityNotificationService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onPostLiked(PostLikedEvent event) {
         try {
             Post post = postRepository.findByIdAndDeletedFalse(event.postId())

--- a/src/main/java/com/semosan/api/domain/community/like/event/PostLikedEventListener.java
+++ b/src/main/java/com/semosan/api/domain/community/like/event/PostLikedEventListener.java
@@ -1,0 +1,44 @@
+package com.semosan.api.domain.community.like.event;
+
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.domain.community.notification.service.CommunityNotificationService;
+import com.semosan.api.domain.community.post.entity.Post;
+import com.semosan.api.domain.community.post.repository.PostRepository;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.service.UserReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostLikedEventListener {
+
+    private final PostRepository postRepository;
+    private final UserReader userReader;
+    private final CommunityNotificationService communityNotificationService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional
+    public void onPostLiked(PostLikedEvent event) {
+        try {
+            Post post = postRepository.findByIdAndDeletedFalse(event.postId())
+                    .orElse(null);
+            if (post == null) {
+                return;
+            }
+            User actor = userReader.findActiveUserById(event.actorId());
+            communityNotificationService.sendPostLikeNotification(post, actor);
+        } catch (GeneralException e) {
+            log.warn("게시글 좋아요 알림 생성 실패: postId={}, actorId={}, code={}, msg={}",
+                    event.postId(), event.actorId(), e.getErrorStatus().getCode(), e.getMessage());
+        } catch (Exception e) {
+            log.warn("게시글 좋아요 알림 생성 중 알 수 없는 오류: postId={}, actorId={}, msg={}",
+                    event.postId(), event.actorId(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
+++ b/src/main/java/com/semosan/api/domain/community/like/service/PostLikeService.java
@@ -5,14 +5,15 @@ import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.common.util.LikeConflictHandler;
 import com.semosan.api.domain.community.like.dto.PostLikeToggleResponse;
 import com.semosan.api.domain.community.like.entity.PostLike;
+import com.semosan.api.domain.community.like.event.PostLikedEvent;
 import com.semosan.api.domain.community.like.repository.PostLikeRepository;
-import com.semosan.api.domain.community.notification.service.CommunityNotificationService;
 import com.semosan.api.domain.community.post.entity.Post;
 import com.semosan.api.domain.community.post.repository.PostRepository;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +29,7 @@ public class PostLikeService {
     private final PostLikeRepository postLikeRepository;
     private final PostRepository postRepository;
     private final UserReader userReader;
-    private final CommunityNotificationService communityNotificationService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * @return true = 좋아요 누름 / false = 좋아요 취소
@@ -45,7 +46,7 @@ public class PostLikeService {
 
         return LikeConflictHandler.handleConcurrentCreate(() -> {
             postLikeRepository.save(PostLike.create(post, user));
-            communityNotificationService.sendPostLikeNotification(post, user);
+            eventPublisher.publishEvent(new PostLikedEvent(post.getId(), user.getId()));
         }, () -> log.warn("PostLike 동시 요청 감지: postId={}, userId={}", postId, userId));
     }
 

--- a/src/test/java/com/semosan/api/domain/community/like/event/PostLikedEventListenerTest.java
+++ b/src/test/java/com/semosan/api/domain/community/like/event/PostLikedEventListenerTest.java
@@ -1,0 +1,77 @@
+package com.semosan.api.domain.community.like.event;
+
+import com.semosan.api.domain.community.notification.service.CommunityNotificationService;
+import com.semosan.api.domain.community.post.entity.FreePost;
+import com.semosan.api.domain.community.post.repository.PostRepository;
+import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.enums.user.DeviceType;
+import com.semosan.api.domain.user.service.UserReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PostLikedEventListenerTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private UserReader userReader;
+
+    @Mock
+    private CommunityNotificationService communityNotificationService;
+
+    @InjectMocks
+    private PostLikedEventListener listener;
+
+    @Test
+    void onPostLikedSendsNotificationWithReloadedPostAndActor() throws Exception {
+        User author = user(1L, "author");
+        User actor = user(2L, "actor");
+        FreePost post = freePost(10L, author);
+
+        when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
+        when(userReader.findActiveUserById(2L)).thenReturn(actor);
+
+        listener.onPostLiked(new PostLikedEvent(10L, 2L));
+
+        verify(communityNotificationService).sendPostLikeNotification(post, actor);
+    }
+
+    @Test
+    void onPostLikedSkipsNotificationWhenPostNotFound() {
+        when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.empty());
+
+        listener.onPostLiked(new PostLikedEvent(10L, 2L));
+
+        verify(userReader, never()).findActiveUserById(2L);
+        verify(communityNotificationService, never()).sendPostLikeNotification(any(), any());
+    }
+
+    private User user(Long id, String nickname) {
+        User user = User.createTestUser(nickname, DeviceType.IOS);
+        ReflectionTestUtils.setField(user, "id", id);
+        ReflectionTestUtils.setField(user, "nickname", nickname);
+        return user;
+    }
+
+    private FreePost freePost(Long id, User author) throws Exception {
+        Constructor<FreePost> constructor = FreePost.class.getDeclaredConstructor(User.class, String.class, String.class);
+        constructor.setAccessible(true);
+        FreePost post = constructor.newInstance(author, "제목", "본문");
+        ReflectionTestUtils.setField(post, "id", id);
+        return post;
+    }
+}

--- a/src/test/java/com/semosan/api/domain/community/like/event/PostLikedEventListenerTest.java
+++ b/src/test/java/com/semosan/api/domain/community/like/event/PostLikedEventListenerTest.java
@@ -1,5 +1,7 @@
 package com.semosan.api.domain.community.like.event;
 
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.community.notification.service.CommunityNotificationService;
 import com.semosan.api.domain.community.post.entity.FreePost;
 import com.semosan.api.domain.community.post.repository.PostRepository;
@@ -16,6 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.lang.reflect.Constructor;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -57,6 +60,21 @@ class PostLikedEventListenerTest {
         listener.onPostLiked(new PostLikedEvent(10L, 2L));
 
         verify(userReader, never()).findActiveUserById(2L);
+        verify(communityNotificationService, never()).sendPostLikeNotification(any(), any());
+    }
+
+    @Test
+    void onPostLikedSkipsNotificationWhenActorNotFound() throws Exception {
+        User author = user(1L, "author");
+        FreePost post = freePost(10L, author);
+
+        when(postRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
+        when(userReader.findActiveUserById(2L))
+                .thenThrow(new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        assertThatCode(() -> listener.onPostLiked(new PostLikedEvent(10L, 2L)))
+                .doesNotThrowAnyException();
+
         verify(communityNotificationService, never()).sendPostLikeNotification(any(), any());
     }
 

--- a/src/test/java/com/semosan/api/domain/community/like/service/PostLikeServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/like/service/PostLikeServiceTest.java
@@ -2,8 +2,8 @@ package com.semosan.api.domain.community.like.service;
 
 import com.semosan.api.domain.community.like.dto.PostLikeToggleResponse;
 import com.semosan.api.domain.community.like.entity.PostLike;
+import com.semosan.api.domain.community.like.event.PostLikedEvent;
 import com.semosan.api.domain.community.like.repository.PostLikeRepository;
-import com.semosan.api.domain.community.notification.service.CommunityNotificationService;
 import com.semosan.api.domain.community.post.entity.FreePost;
 import com.semosan.api.domain.community.post.repository.PostRepository;
 import com.semosan.api.domain.user.entity.User;
@@ -11,9 +11,11 @@ import com.semosan.api.domain.user.enums.user.DeviceType;
 import com.semosan.api.domain.user.service.UserReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -39,13 +41,13 @@ class PostLikeServiceTest {
     private UserReader userReader;
 
     @Mock
-    private CommunityNotificationService communityNotificationService;
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private PostLikeService postLikeService;
 
     @Test
-    void toggleWithCountDelegatesNotificationWhenLikeCreated() throws Exception {
+    void toggleWithCountPublishesEventWhenLikeCreated() throws Exception {
         User postAuthor = user(1L, "post-author");
         User liker = user(2L, "liker");
         FreePost post = freePost(10L, postAuthor, "제목", "본문");
@@ -59,11 +61,14 @@ class PostLikeServiceTest {
 
         assertThat(result.liked()).isTrue();
         assertThat(result.count()).isEqualTo(1L);
-        verify(communityNotificationService).sendPostLikeNotification(post, liker);
+        ArgumentCaptor<PostLikedEvent> eventCaptor = ArgumentCaptor.forClass(PostLikedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().postId()).isEqualTo(10L);
+        assertThat(eventCaptor.getValue().actorId()).isEqualTo(2L);
     }
 
     @Test
-    void toggleWithCountDoesNotDelegateNotificationWhenUnlike() throws Exception {
+    void toggleWithCountDoesNotPublishEventWhenUnlike() throws Exception {
         User postAuthor = user(1L, "post-author");
         User liker = user(2L, "liker");
         FreePost post = freePost(10L, postAuthor, "제목", "본문");
@@ -78,11 +83,11 @@ class PostLikeServiceTest {
 
         assertThat(result.liked()).isFalse();
         assertThat(result.count()).isZero();
-        verify(communityNotificationService, never()).sendPostLikeNotification(any(), any());
+        verify(eventPublisher, never()).publishEvent(any(Object.class));
     }
 
     @Test
-    void toggleWithCountDoesNotDelegateNotificationWhenConcurrentDuplicateDetected() throws Exception {
+    void toggleWithCountDoesNotPublishEventWhenConcurrentDuplicateDetected() throws Exception {
         User postAuthor = user(1L, "post-author");
         User liker = user(2L, "liker");
         FreePost post = freePost(10L, postAuthor, "제목", "본문");
@@ -97,7 +102,7 @@ class PostLikeServiceTest {
 
         assertThat(result.liked()).isTrue();
         assertThat(result.count()).isEqualTo(1L);
-        verify(communityNotificationService, never()).sendPostLikeNotification(any(), any());
+        verify(eventPublisher, never()).publishEvent(any(Object.class));
     }
 
     private User user(Long id, String nickname) {


### PR DESCRIPTION
## 🧾 요약
- 좋아요 저장 트랜잭션 내에서 직접 알림을 발송하던 구조를 이벤트 기반으로 분리해 트랜잭션 경계를 명확히 함

## 🔗 이슈
- close #231

## ✨ 변경 내용
- `PostLikedEvent` 레코드 추가 (postId, actorId)
- `PostLikedEventListener` 추가 — `@TransactionalEventListener(AFTER_COMMIT)` + `@Transactional(REQUIRES_NEW)`로 커밋 후 별도 트랜잭션에서 알림 처리
- `PostLikeService`에서 `CommunityNotificationService` 직접 호출 제거 → `ApplicationEventPublisher`로 교체
- `PostLikedEventListenerTest` 추가 (정상 발송 / 게시글 없음 / 사용자 없음 3케이스)
- `PostLikeServiceTest` 업데이트 — 이벤트 발행 여부 검증으로 전환

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
