### PR TITLE
[Feat] 온보딩 선택 사항으로 변경 및 미완료 유저 산 추천 기본값 제공

### DIFF
--- a/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
+++ b/src/main/java/com/semosan/api/domain/hiking/service/HikingRecordService.java
@@ -50,7 +50,7 @@ public class HikingRecordService {
     // 유저가 다녀온 산 목록을 산 단위로 묶어 조회합니다.
     @Transactional(readOnly = true)
     public Page<GetUserHikingMountainRecordResponse> getUserHikingMountainRecords(Long userId, Pageable pageable) {
-        userReader.findCompletedOnboardingUserById(userId);
+        userReader.findActiveUserById(userId);
         return hikingRecordRepository.findUserHikingMountainRecordsByUserId(userId, pageable)
                 .map(GetUserHikingMountainRecordResponse::from);
     }
@@ -58,7 +58,7 @@ public class HikingRecordService {
     // 유저의 등산 기록 목록을 기록 단위로 조회합니다.
     @Transactional(readOnly = true)
     public Page<GetUserHikingRecordResponse> getUserHikingRecords(Long userId, Pageable pageable) {
-        userReader.findCompletedOnboardingUserById(userId);
+        userReader.findActiveUserById(userId);
         return hikingRecordRepository.findUserHikingRecordsByUserId(userId, pageable)
                 .map(GetUserHikingRecordResponse::from);
     }
@@ -70,7 +70,7 @@ public class HikingRecordService {
             Long mountainId,
             Pageable pageable
     ) {
-        userReader.findCompletedOnboardingUserById(userId);
+        userReader.findActiveUserById(userId);
         if (!mountainRepository.existsById(mountainId)) {
             throw new GeneralException(ErrorStatus.MOUNTAIN_NOT_FOUND);
         }
@@ -81,7 +81,7 @@ public class HikingRecordService {
     // 등산 기록 단건 상세를 조회합니다. (이동 경로 + 마일스톤 사진 포함)
     @Transactional(readOnly = true)
     public HikingRecordDetailResponse getHikingRecordDetail(Long userId, Long hikingRecordId) {
-        User user = userReader.findCompletedOnboardingUserById(userId);
+        User user = userReader.findActiveUserById(userId);
         // Mountain / Course 를 fetch join 으로 함께 가져와 응답 조립 시 추가 SELECT 를 막는다.
         HikingRecord record = hikingRecordRepository.findWithMountainAndCourseById(hikingRecordId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.HIKING_RECORD_NOT_FOUND));
@@ -109,7 +109,7 @@ public class HikingRecordService {
     // 유저의 등산 기록 요약 정보를 조회합니다.
     @Transactional(readOnly = true)
     public GetUserHikingRecordSummaryResponse getUserHikingRecordSummary(Long userId) {
-        userReader.findCompletedOnboardingUserById(userId);
+        userReader.findActiveUserById(userId);
         UserHikingRecordSummaryProjection projection =
                 hikingRecordRepository.findUserHikingRecordSummaryByUserId(userId);
         if (projection == null) {
@@ -125,7 +125,7 @@ public class HikingRecordService {
             Long hikingRecordId,
             CreateCourseDifficultyFeedbackRequest request
     ) {
-        User user = userReader.findCompletedOnboardingUserById(userId);
+        User user = userReader.findActiveUserById(userId);
         HikingRecord hikingRecord = hikingRecordRepository.findById(hikingRecordId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.HIKING_RECORD_NOT_FOUND));
 

--- a/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainRecommendationResponse.java
+++ b/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainRecommendationResponse.java
@@ -27,6 +27,17 @@ public record MountainRecommendationResponse(
         );
     }
 
+    public static MountainRecommendationResponse fromDefaultMountain(Mountain mountain) {
+        return new MountainRecommendationResponse(
+                mountain.getId(),
+                mountain.getName(),
+                firstImageUrl(mountain),
+                difficultyLabel(mountain.getDifficulty()),
+                mountain.getAltitude().intValue(),
+                mountain.getAddress()
+        );
+    }
+
     private static String difficultyLabel(Difficulty difficulty) {
         return switch (difficulty) {
             case EASY -> "초";

--- a/src/main/java/com/semosan/api/domain/mountain/service/CourseLikeService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/CourseLikeService.java
@@ -32,7 +32,7 @@ public class CourseLikeService {
     }
 
     private boolean toggle(Long userId, Long courseId) {
-        User user = userReader.findCompletedOnboardingUserById(userId);
+        User user = userReader.findActiveUserById(userId);
         Course course = findCourseById(courseId);
 
         return courseLikeRepository.findByUser_IdAndCourse_Id(userId, courseId)

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainLikeService.java
@@ -27,7 +27,7 @@ public class MountainLikeService {
     // 로그인한 사용자가 산에 좋아요를 등록합니다.
     @Transactional
     public void likeMountain(Long userId, Long mountainId) {
-        User user = userReader.findCompletedOnboardingUserById(userId);
+        User user = userReader.findActiveUserById(userId);
         Mountain mountain = findMountainById(mountainId);
         if (mountainLikeRepository.existsByUser_IdAndMountain_Id(userId, mountainId)) {
             throw new GeneralException(ErrorStatus.MOUNTAIN_LIKE_ALREADY_EXISTS);
@@ -44,7 +44,7 @@ public class MountainLikeService {
     @Transactional
     public void unlikeMountain(Long userId, Long mountainId) {
         // 탈퇴 후 남은 access token으로 조회되는 것을 방지합니다.
-        userReader.findCompletedOnboardingUserById(userId);
+        userReader.findActiveUserById(userId);
         MountainLike mountainLike = mountainLikeRepository.findByUser_IdAndMountain_Id(userId, mountainId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MOUNTAIN_LIKE_NOT_FOUND));
         mountainLikeRepository.delete(mountainLike);
@@ -54,7 +54,7 @@ public class MountainLikeService {
     @Transactional(readOnly = true)
     public Page<LikedMountainResponse> getLikedMountains(Long userId, Pageable pageable) {
         // 탈퇴 후 남은 access token으로 조회되는 것을 방지합니다.
-        userReader.findCompletedOnboardingUserById(userId);
+        userReader.findActiveUserById(userId);
         return mountainLikeRepository.findAllByUserId(userId, pageable)
                 .map(LikedMountainResponse::from);
     }

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
@@ -18,7 +18,9 @@ import com.semosan.api.domain.review.service.ReviewService;
 import com.semosan.api.domain.mountain.service.recommendation.FitnessLevelCalculator;
 import com.semosan.api.domain.mountain.service.recommendation.TrackScorer;
 import com.semosan.api.domain.mountain.service.recommendation.TrackScorer.TrackEvaluation;
+import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.entity.UserOnboarding;
+import com.semosan.api.domain.user.enums.user.OnboardingStatus;
 import com.semosan.api.domain.user.service.UserReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,6 +32,8 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +45,7 @@ public class MountainService {
     private static final double DEFAULT_SEOUL_SW_LNG = 126.764;
     private static final double DEFAULT_SEOUL_NE_LAT = 37.715;
     private static final double DEFAULT_SEOUL_NE_LNG = 127.184;
+    private static final List<Long> DEFAULT_RECOMMENDED_MOUNTAIN_IDS = List.of(1L, 5L, 8L);
 
     private final MountainRepository mountainRepository;
     private final CourseRepository courseRepository;
@@ -54,7 +59,7 @@ public class MountainService {
     private final TrackScorer trackScorer;
 
     public Page<MountainListResponse> getMountains(Long userId, Pageable pageable) {
-        userReader.findCompletedOnboardingUserById(userId);
+        userReader.findActiveUserById(userId);
         return mountainRepository.findAll(pageable)
                 .map(MountainListResponse::from);
     }
@@ -92,6 +97,11 @@ public class MountainService {
             Double lat,
             Double lng
     ) {
+        User user = userReader.findActiveUserById(userId);
+        if (user.getOnboardingStatus() != OnboardingStatus.COMPLETE) {
+            return getDefaultRecommendedMountains();
+        }
+
         UserOnboarding onboarding = userReader.findCompletedOnboardingByUserId(userId);
         FitnessLevel fitnessLevel = fitnessLevelCalculator.calculate(onboarding.getUser(), onboarding);
 
@@ -125,6 +135,18 @@ public class MountainService {
         return next.rankingScore() > current.rankingScore() ? next : current;
     }
 
+    private List<MountainRecommendationResponse> getDefaultRecommendedMountains() {
+        Map<Long, Mountain> mountainById = mountainRepository.findAllById(DEFAULT_RECOMMENDED_MOUNTAIN_IDS)
+                .stream()
+                .collect(Collectors.toMap(Mountain::getId, mountain -> mountain));
+
+        return DEFAULT_RECOMMENDED_MOUNTAIN_IDS.stream()
+                .map(mountainById::get)
+                .filter(Objects::nonNull)
+                .map(MountainRecommendationResponse::fromDefaultMountain)
+                .toList();
+    }
+
     private record RecommendationCandidate(Mountain mountain, TrackEvaluation evaluation) {
 
         private double rankingScore() {
@@ -140,7 +162,7 @@ public class MountainService {
     }
 
     public Page<MountainListResponse> searchMountains(Long userId, String keyword, Pageable pageable) {
-        userReader.findCompletedOnboardingUserById(userId);
+        userReader.findActiveUserById(userId);
         if (keyword == null || keyword.isBlank()) {
             throw new GeneralException(ErrorStatus.BAD_REQUEST);
         }
@@ -149,7 +171,7 @@ public class MountainService {
     }
 
     public MountainDetailResponse getMountainDetail(Long userId, Long mountainId) {
-        userReader.findCompletedOnboardingUserById(userId);
+        userReader.findActiveUserById(userId);
         Mountain mountain = findMountainById(mountainId);
 
         return new MountainDetailResponse(

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
@@ -18,7 +18,6 @@ import com.semosan.api.domain.review.service.ReviewService;
 import com.semosan.api.domain.mountain.service.recommendation.FitnessLevelCalculator;
 import com.semosan.api.domain.mountain.service.recommendation.TrackScorer;
 import com.semosan.api.domain.mountain.service.recommendation.TrackScorer.TrackEvaluation;
-import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.entity.UserOnboarding;
 import com.semosan.api.domain.user.enums.user.OnboardingStatus;
 import com.semosan.api.domain.user.service.UserReader;
@@ -97,12 +96,16 @@ public class MountainService {
             Double lat,
             Double lng
     ) {
-        User user = userReader.findActiveUserById(userId);
-        if (user.getOnboardingStatus() != OnboardingStatus.COMPLETE) {
+        UserOnboarding onboarding = userReader.findOnboardingByUserId(userId)
+                .orElse(null);
+        if (onboarding == null) {
+            userReader.findActiveUserById(userId);
+            return getDefaultRecommendedMountains();
+        }
+        if (onboarding.getUser().getOnboardingStatus() != OnboardingStatus.COMPLETE) {
             return getDefaultRecommendedMountains();
         }
 
-        UserOnboarding onboarding = userReader.findCompletedOnboardingByUserId(userId);
         FitnessLevel fitnessLevel = fitnessLevelCalculator.calculate(onboarding.getUser(), onboarding);
 
         Map<Long, RecommendationCandidate> candidateByMountainId = new LinkedHashMap<>();

--- a/src/main/java/com/semosan/api/domain/user/entity/UserOnboarding.java
+++ b/src/main/java/com/semosan/api/domain/user/entity/UserOnboarding.java
@@ -40,11 +40,11 @@ public class UserOnboarding extends BaseEntity {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "hiking_level", nullable = false, length = 20)
+    @Column(name = "hiking_level", length = 20)
     private HikingLevel hikingLevel;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "exercise_type", nullable = false, length = 30)
+    @Column(name = "exercise_type", length = 30)
     private ExerciseType exerciseType;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/semosan/api/domain/user/service/UserNotificationSettingService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserNotificationSettingService.java
@@ -40,13 +40,13 @@ public class UserNotificationSettingService {
     // 로그인한 사용자의 알림 설정을 조회합니다.
     @Transactional(readOnly = true)
     public GetNotificationSettingResponse getNotificationSetting(Long userId) {
-        userReader.findCompletedOnboardingUserById(userId);
+        userReader.findActiveUserById(userId);
         return GetNotificationSettingResponse.from(findSetting(userId));
     }
 
     // 사용자 알림 설정을 조회한 뒤 전달받은 변경 동작을 적용합니다.
     private void updateSetting(Long userId, Consumer<UserNotificationSetting> updater) {
-        userReader.findCompletedOnboardingUserById(userId);
+        userReader.findActiveUserById(userId);
         UserNotificationSetting setting = findSetting(userId);
         updater.accept(setting);
     }

--- a/src/main/java/com/semosan/api/domain/user/service/UserReader.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserReader.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class UserReader {
@@ -25,6 +27,11 @@ public class UserReader {
         }
         return userRepository.findByIdAndDeletedFalse(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<UserOnboarding> findOnboardingByUserId(Long userId) {
+        return userOnboardingRepository.findByUserIdWithUser(userId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/semosan/api/domain/user/service/UserService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.semosan.api.domain.mountain.repository.CourseLikeRepository;
 import com.semosan.api.domain.mountain.repository.MountainLikeRepository;
 import com.semosan.api.domain.notification.repository.NotificationRepository;
 import com.semosan.api.domain.review.repository.ReviewRepository;
+import com.semosan.api.domain.user.dto.command.CreateUserOnboardingCommand;
 import com.semosan.api.domain.user.dto.command.UpdateUserProfileCommand;
 import com.semosan.api.domain.user.dto.request.UpdateUserProfileRequest;
 import com.semosan.api.domain.user.entity.User;
@@ -96,9 +97,9 @@ public class UserService {
     public void updateUserProfile(Long userId, UpdateUserProfileRequest request) {
         validateProfileUpdateRequest(request);
         validateNicknameIfPresent(request.nickname());
-        User user = userReader.findCompletedOnboardingUserById(userId);
+        User user = userReader.findActiveUserById(userId);
         user.updateProfile(toUpdateUserProfileCommand(request));
-        updateUserOnboardingProfile(userId, request);
+        updateUserOnboardingProfile(user, request);
     }
 
     // 프로필 수정 요청에 최소 하나 이상의 수정 값이 있는지 검증합니다.
@@ -123,12 +124,20 @@ public class UserService {
     }
 
     // 프로필 수정 요청에 포함된 온보딩 항목을 갱신합니다.
-    private void updateUserOnboardingProfile(Long userId, UpdateUserProfileRequest request) {
+    private void updateUserOnboardingProfile(User user, UpdateUserProfileRequest request) {
         if (request.hikingLevel() == null && request.exerciseType() == null) {
             return;
         }
-        UserOnboarding userOnboarding = userOnboardingRepository.findByUser_Id(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.ONBOARDING_NOT_FOUND));
+        UserOnboarding userOnboarding = userOnboardingRepository.findByUser_Id(user.getId())
+                .orElseGet(() -> userOnboardingRepository.save(UserOnboarding.create(
+                        new CreateUserOnboardingCommand(
+                                user,
+                                request.hikingLevel(),
+                                request.exerciseType(),
+                                null,
+                                null
+                        )
+                )));
         if (request.hikingLevel() != null) {
             userOnboarding.updateHikingLevel(request.hikingLevel());
         }

--- a/src/main/java/com/semosan/api/domain/user/service/UserService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserService.java
@@ -132,8 +132,8 @@ public class UserService {
                 .orElseGet(() -> userOnboardingRepository.save(UserOnboarding.create(
                         new CreateUserOnboardingCommand(
                                 user,
-                                request.hikingLevel(),
-                                request.exerciseType(),
+                                null,
+                                null,
                                 null,
                                 null
                         )

--- a/src/main/resources/db/migration/V29__make_user_onboarding_profile_fields_nullable.sql
+++ b/src/main/resources/db/migration/V29__make_user_onboarding_profile_fields_nullable.sql
@@ -1,0 +1,3 @@
+ALTER TABLE user_onboardings
+    ALTER COLUMN hiking_level DROP NOT NULL,
+    ALTER COLUMN exercise_type DROP NOT NULL;

--- a/src/test/java/com/semosan/api/domain/hiking/service/HikingRecordServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/hiking/service/HikingRecordServiceTest.java
@@ -68,7 +68,7 @@ class HikingRecordServiceTest {
         CreateCourseDifficultyFeedbackRequest request =
                 new CreateCourseDifficultyFeedbackRequest(DifficultyFeedbackType.HARDER);
 
-        when(userReader.findCompletedOnboardingUserById(1L)).thenReturn(user);
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(hikingRecordRepository.findById(10L)).thenReturn(Optional.of(hikingRecord));
         when(hikingMemberRepository.existsByHikingRecordAndUser(hikingRecord, user)).thenReturn(true);
         when(courseDifficultyFeedbackRepository.existsByHikingRecord_Id(10L)).thenReturn(false);
@@ -94,7 +94,7 @@ class HikingRecordServiceTest {
         User user = user(1L);
         HikingRecord hikingRecord = hikingRecord(10L, course(mountain(20L, "관악산"), 30L, "과천향교 출발 코스"));
 
-        when(userReader.findCompletedOnboardingUserById(1L)).thenReturn(user);
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(hikingRecordRepository.findById(10L)).thenReturn(Optional.of(hikingRecord));
         when(hikingMemberRepository.existsByHikingRecordAndUser(hikingRecord, user)).thenReturn(false);
 
@@ -114,7 +114,7 @@ class HikingRecordServiceTest {
         User user = user(1L);
         HikingRecord hikingRecord = hikingRecord(10L, null);
 
-        when(userReader.findCompletedOnboardingUserById(1L)).thenReturn(user);
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(hikingRecordRepository.findById(10L)).thenReturn(Optional.of(hikingRecord));
         when(hikingMemberRepository.existsByHikingRecordAndUser(hikingRecord, user)).thenReturn(true);
 
@@ -134,7 +134,7 @@ class HikingRecordServiceTest {
         User user = user(1L);
         HikingRecord hikingRecord = hikingRecord(10L, course(mountain(20L, "관악산"), 30L, "과천향교 출발 코스"));
 
-        when(userReader.findCompletedOnboardingUserById(1L)).thenReturn(user);
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(hikingRecordRepository.findById(10L)).thenReturn(Optional.of(hikingRecord));
         when(hikingMemberRepository.existsByHikingRecordAndUser(hikingRecord, user)).thenReturn(true);
         when(courseDifficultyFeedbackRepository.existsByHikingRecord_Id(10L)).thenReturn(true);
@@ -155,7 +155,7 @@ class HikingRecordServiceTest {
         User user = user(1L);
         HikingRecord hikingRecord = hikingRecord(10L, course(mountain(20L, "관악산"), 30L, "과천향교 출발 코스"));
 
-        when(userReader.findCompletedOnboardingUserById(1L)).thenReturn(user);
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(hikingRecordRepository.findById(10L)).thenReturn(Optional.of(hikingRecord));
         when(hikingMemberRepository.existsByHikingRecordAndUser(hikingRecord, user)).thenReturn(true);
         when(courseDifficultyFeedbackRepository.existsByHikingRecord_Id(10L)).thenReturn(false);
@@ -178,7 +178,7 @@ class HikingRecordServiceTest {
         HikingRecord hikingRecord = hikingRecord(10L, course(mountain(20L, "관악산"), 30L, "과천향교 출발 코스"));
         DataIntegrityViolationException exception = new DataIntegrityViolationException("other constraint");
 
-        when(userReader.findCompletedOnboardingUserById(1L)).thenReturn(user);
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(hikingRecordRepository.findById(10L)).thenReturn(Optional.of(hikingRecord));
         when(hikingMemberRepository.existsByHikingRecordAndUser(hikingRecord, user)).thenReturn(true);
         when(courseDifficultyFeedbackRepository.existsByHikingRecord_Id(10L)).thenReturn(false);

--- a/src/test/java/com/semosan/api/domain/mountain/service/CourseLikeServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/mountain/service/CourseLikeServiceTest.java
@@ -44,7 +44,7 @@ class CourseLikeServiceTest {
         User user = user(1L);
         Course course = course(10L);
 
-        when(userReader.findCompletedOnboardingUserById(1L)).thenReturn(user);
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(courseRepository.findById(10L)).thenReturn(Optional.of(course));
         when(courseLikeRepository.findByUser_IdAndCourse_Id(1L, 10L)).thenReturn(Optional.empty());
 
@@ -60,7 +60,7 @@ class CourseLikeServiceTest {
         Course course = course(10L);
         CourseLike courseLike = CourseLike.create(user, course);
 
-        when(userReader.findCompletedOnboardingUserById(1L)).thenReturn(user);
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(courseRepository.findById(10L)).thenReturn(Optional.of(course));
         when(courseLikeRepository.findByUser_IdAndCourse_Id(1L, 10L)).thenReturn(Optional.of(courseLike));
 
@@ -75,7 +75,7 @@ class CourseLikeServiceTest {
         User user = user(1L);
         Course course = course(10L);
 
-        when(userReader.findCompletedOnboardingUserById(1L)).thenReturn(user);
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(courseRepository.findById(10L)).thenReturn(Optional.of(course));
         when(courseLikeRepository.findByUser_IdAndCourse_Id(1L, 10L)).thenReturn(Optional.empty());
         when(courseLikeRepository.save(any(CourseLike.class))).thenThrow(new DataIntegrityViolationException("duplicate"));

--- a/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -88,6 +89,7 @@ class MountainServiceTest {
         Course thirdCourse = course(third);
         Course fourthCourse = course(fourth);
 
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(userReader.findCompletedOnboardingByUserId(1L)).thenReturn(onboarding);
         when(courseRepository.findAllWithMountainForRecommendation())
                 .thenReturn(List.of(fourthCourse, secondCourse, firstCourse, thirdCourse));
@@ -114,6 +116,32 @@ class MountainServiceTest {
         assertThat(result).hasSize(3);
         assertThat(result.get(0).difficultyLabel()).isEqualTo("중");
         assertThat(result.get(0).mountainHeightM()).isEqualTo(123);
+    }
+
+    @Test
+    void getRecommendedMountainsReturnsDefaultMountainsWhenOnboardingIsIncomplete() throws Exception {
+        User user = User.createTestUser("recommendation-incomplete-user", DeviceType.IOS);
+        Mountain first = mountain(1L, "북한산");
+        Mountain second = mountain(5L, "아차산");
+        Mountain third = mountain(8L, "관악산");
+
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
+        when(mountainRepository.findAllById(List.of(1L, 5L, 8L)))
+                .thenReturn(List.of(third, first, second));
+
+        List<MountainRecommendationResponse> result = mountainService.getRecommendedMountains(
+                1L,
+                37.0,
+                127.0
+        );
+
+        assertThat(result)
+                .extracting(MountainRecommendationResponse::mountainId)
+                .containsExactly(1L, 5L, 8L);
+        assertThat(result)
+                .extracting(MountainRecommendationResponse::name)
+                .containsExactly("북한산", "아차산", "관악산");
+        verifyNoInteractions(courseRepository, fitnessLevelCalculator, trackScorer);
     }
 
     private User user() {

--- a/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/mountain/service/MountainServiceTest.java
@@ -89,8 +89,7 @@ class MountainServiceTest {
         Course thirdCourse = course(third);
         Course fourthCourse = course(fourth);
 
-        when(userReader.findActiveUserById(1L)).thenReturn(user);
-        when(userReader.findCompletedOnboardingByUserId(1L)).thenReturn(onboarding);
+        when(userReader.findOnboardingByUserId(1L)).thenReturn(Optional.of(onboarding));
         when(courseRepository.findAllWithMountainForRecommendation())
                 .thenReturn(List.of(fourthCourse, secondCourse, firstCourse, thirdCourse));
         when(fitnessLevelCalculator.calculate(user, onboarding))
@@ -125,6 +124,33 @@ class MountainServiceTest {
         Mountain second = mountain(5L, "아차산");
         Mountain third = mountain(8L, "관악산");
 
+        when(userReader.findOnboardingByUserId(1L)).thenReturn(Optional.of(onboarding(user)));
+        when(mountainRepository.findAllById(List.of(1L, 5L, 8L)))
+                .thenReturn(List.of(third, first, second));
+
+        List<MountainRecommendationResponse> result = mountainService.getRecommendedMountains(
+                1L,
+                37.0,
+                127.0
+        );
+
+        assertThat(result)
+                .extracting(MountainRecommendationResponse::mountainId)
+                .containsExactly(1L, 5L, 8L);
+        assertThat(result)
+                .extracting(MountainRecommendationResponse::name)
+                .containsExactly("북한산", "아차산", "관악산");
+        verifyNoInteractions(courseRepository, fitnessLevelCalculator, trackScorer);
+    }
+
+    @Test
+    void getRecommendedMountainsReturnsDefaultMountainsWhenOnboardingRowIsMissing() throws Exception {
+        User user = User.createTestUser("recommendation-no-onboarding-user", DeviceType.IOS);
+        Mountain first = mountain(1L, "북한산");
+        Mountain second = mountain(5L, "아차산");
+        Mountain third = mountain(8L, "관악산");
+
+        when(userReader.findOnboardingByUserId(1L)).thenReturn(Optional.empty());
         when(userReader.findActiveUserById(1L)).thenReturn(user);
         when(mountainRepository.findAllById(List.of(1L, 5L, 8L)))
                 .thenReturn(List.of(third, first, second));

--- a/src/test/java/com/semosan/api/domain/user/service/UserReaderTest.java
+++ b/src/test/java/com/semosan/api/domain/user/service/UserReaderTest.java
@@ -45,6 +45,18 @@ class UserReaderTest {
     }
 
     @Test
+    void findOnboardingByUserIdReturnsRepositoryResult() {
+        User user = user();
+        UserOnboarding onboarding = onboarding(user);
+        when(userOnboardingRepository.findByUserIdWithUser(1L)).thenReturn(Optional.of(onboarding));
+
+        Optional<UserOnboarding> result = new UserReader(userRepository, userOnboardingRepository)
+                .findOnboardingByUserId(1L);
+
+        assertThat(result).containsSame(onboarding);
+    }
+
+    @Test
     void findCompletedOnboardingByUserIdReturnsOnboardingWhenUserIsCompleted() {
         User user = user();
         UserOnboarding onboarding = onboarding(user);

--- a/src/test/java/com/semosan/api/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/user/service/UserServiceTest.java
@@ -7,7 +7,12 @@ import com.semosan.api.domain.mountain.repository.CourseLikeRepository;
 import com.semosan.api.domain.mountain.repository.MountainLikeRepository;
 import com.semosan.api.domain.notification.repository.NotificationRepository;
 import com.semosan.api.domain.review.repository.ReviewRepository;
+import com.semosan.api.domain.user.dto.command.CreateUserOnboardingCommand;
+import com.semosan.api.domain.user.dto.request.UpdateUserProfileRequest;
 import com.semosan.api.domain.user.entity.User;
+import com.semosan.api.domain.user.entity.UserOnboarding;
+import com.semosan.api.domain.user.enums.onboarding.ExerciseType;
+import com.semosan.api.domain.user.enums.onboarding.HikingLevel;
 import com.semosan.api.domain.user.enums.user.DeviceType;
 import com.semosan.api.domain.user.enums.user.OAuthProvider;
 import com.semosan.api.domain.user.enums.user.OnboardingStatus;
@@ -28,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
@@ -167,6 +173,64 @@ class UserServiceTest {
         assertThat(result.getOauthProvider()).isEqualTo(OAuthProvider.APPLE);
         assertThat(result.getName()).isEqualTo("apple-name");
         assertThat(result.getNickname()).isEqualTo("빠른하이커1204");
+    }
+
+    @Test
+    void updateUserProfileCreatesOnboardingWhenOneOnboardingFieldProvidedAndRowMissing() {
+        User user = User.createTestUser("profile-test-user", DeviceType.IOS);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                HikingLevel.BEGINNER,
+                null
+        );
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
+        when(userOnboardingRepository.findByUser_Id(1L)).thenReturn(Optional.empty());
+        when(userOnboardingRepository.save(any(UserOnboarding.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        userService.updateUserProfile(1L, request);
+
+        var captor = forClass(UserOnboarding.class);
+        verify(userOnboardingRepository).save(captor.capture());
+        assertThat(captor.getValue().getUser()).isSameAs(user);
+        assertThat(captor.getValue().getHikingLevel()).isEqualTo(HikingLevel.BEGINNER);
+        assertThat(captor.getValue().getExerciseType()).isNull();
+    }
+
+    @Test
+    void updateUserProfileUpdatesExistingOnboardingWithProvidedFieldsOnly() {
+        User user = User.createTestUser("profile-test-user", DeviceType.IOS);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        UserOnboarding onboarding = UserOnboarding.create(new CreateUserOnboardingCommand(
+                user,
+                HikingLevel.EXPERIENCED,
+                ExerciseType.HIKING,
+                null,
+                null
+        ));
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                ExerciseType.NONE
+        );
+        when(userReader.findActiveUserById(1L)).thenReturn(user);
+        when(userOnboardingRepository.findByUser_Id(1L)).thenReturn(Optional.of(onboarding));
+
+        userService.updateUserProfile(1L, request);
+
+        assertThat(onboarding.getHikingLevel()).isEqualTo(HikingLevel.EXPERIENCED);
+        assertThat(onboarding.getExerciseType()).isEqualTo(ExerciseType.NONE);
     }
 
     @Test


### PR DESCRIPTION
## 🧾 요약
- 온보딩 미완료 유저도 앱 전체 기능을 이용할 수 있도록 온보딩 게이트를 제거하고, 홈 산 추천은 고정 3개(북한산·아차산·관악산)로 반환

## 🔗 이슈
- close #244

## ✨ 변경 내용
- 전체 서비스에서 `findCompletedOnboardingUserById()` → `findActiveUserById()` 교체 (등산 기록, 산 좋아요/코스 좋아요, 지도, 알림 설정, 프로필 수정)
- `MountainService.getRecommendedMountains()` — 온보딩 미완료 유저는 mountain ID 1·5·8 고정 반환
- `UserReader.findOnboardingByUserId()` 추가 — Optional 반환으로 단일 쿼리 처리
- `UserService.updateUserOnboardingProfile()` — 온보딩 미완료 유저도 프로필 수정 시 UserOnboarding row 자동 생성
- `UserOnboarding.hikingLevel` / `exerciseType` nullable 변경 + Flyway V29 마이그레이션 추가

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
