### PR TITLE
[Refactor] PostBlockPolicy → PostAccessPolicy 클래스명 개선

### DIFF
--- a/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/FreePostService.java
@@ -32,7 +32,7 @@ public class FreePostService {
     private final PostImageRepository postImageRepository;
     private final PostLikeRepository postLikeRepository;
     private final CommentRepository commentRepository;
-    private final PostBlockPolicy postBlockPolicy;
+    private final PostAccessPolicy postAccessPolicy;
     private final UserReader userReader;
 
     @Transactional
@@ -76,7 +76,7 @@ public class FreePostService {
     @Transactional
     public FreePostDetailResponse getDetail(Long viewerId, Long postId) {
         FreePost post = findActivePostOrThrow(postId);
-        postBlockPolicy.validateReadable(viewerId, post);
+        postAccessPolicy.validateReadable(viewerId, post);
         post.increaseViewCount();
 
         List<PostImage> images = postImageRepository.findByPostOrderBySortOrderAsc(post);

--- a/src/main/java/com/semosan/api/domain/community/post/service/PostAccessPolicy.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/PostAccessPolicy.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class PostBlockPolicy {
+public class PostAccessPolicy {
 
     private final UserBlockRepository userBlockRepository;
 

--- a/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
@@ -23,7 +23,7 @@ public class RecordPostService {
     private final RecordPostRepository recordPostRepository;
     private final HikingRecordRepository hikingRecordRepository;
     private final HikingMemberRepository hikingMemberRepository;
-    private final PostBlockPolicy postBlockPolicy;
+    private final PostAccessPolicy postAccessPolicy;
     private final UserReader userReader;
 
     @Transactional
@@ -52,7 +52,7 @@ public class RecordPostService {
     @Transactional
     public RecordPost getDetail(Long viewerId, Long postId) {
         RecordPost post = findActivePostOrThrow(postId);
-        postBlockPolicy.validateReadable(viewerId, post);
+        postAccessPolicy.validateReadable(viewerId, post);
         post.increaseViewCount();
         return post;
     }

--- a/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/FreePostServiceTest.java
@@ -51,7 +51,7 @@ class FreePostServiceTest {
     private CommentRepository commentRepository;
 
     @Mock
-    private PostBlockPolicy postBlockPolicy;
+    private PostAccessPolicy postAccessPolicy;
 
     @Mock
     private UserReader userReader;
@@ -93,7 +93,7 @@ class FreePostServiceTest {
         assertThat(result.likedByMe()).isTrue();
         assertThat(result.likeCount()).isEqualTo(3L);
         assertThat(result.commentCount()).isEqualTo(2L);
-        verify(postBlockPolicy).validateReadable(1L, post);
+        verify(postAccessPolicy).validateReadable(1L, post);
     }
 
     @Test
@@ -103,7 +103,7 @@ class FreePostServiceTest {
 
         when(freePostRepository.findById(10L)).thenReturn(Optional.of(post));
         org.mockito.Mockito.doThrow(new GeneralException(ErrorStatus.POST_AUTHOR_BLOCKED))
-                .when(postBlockPolicy).validateReadable(1L, post);
+                .when(postAccessPolicy).validateReadable(1L, post);
 
         assertThatThrownBy(() -> freePostService.getDetail(1L, 10L))
                 .isInstanceOf(GeneralException.class)

--- a/src/test/java/com/semosan/api/domain/community/post/service/PostAccessPolicyTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/PostAccessPolicyTest.java
@@ -19,13 +19,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class PostBlockPolicyTest {
+class PostAccessPolicyTest {
 
     @Mock
     private UserBlockRepository userBlockRepository;
 
     @InjectMocks
-    private PostBlockPolicy postBlockPolicy;
+    private PostAccessPolicy postAccessPolicy;
 
     @Test
     void validateReadableThrowsWhenViewerBlockedAuthor() throws Exception {
@@ -33,7 +33,7 @@ class PostBlockPolicyTest {
 
         when(userBlockRepository.existsByBlocker_IdAndBlockedUser_Id(1L, 2L)).thenReturn(true);
 
-        assertThatThrownBy(() -> postBlockPolicy.validateReadable(1L, post))
+        assertThatThrownBy(() -> postAccessPolicy.validateReadable(1L, post))
                 .isInstanceOf(GeneralException.class)
                 .extracting("errorStatus")
                 .isEqualTo(ErrorStatus.POST_AUTHOR_BLOCKED);

--- a/src/test/java/com/semosan/api/domain/community/post/service/RecordPostServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/RecordPostServiceTest.java
@@ -42,7 +42,7 @@ class RecordPostServiceTest {
     private HikingMemberRepository hikingMemberRepository;
 
     @Mock
-    private PostBlockPolicy postBlockPolicy;
+    private PostAccessPolicy postAccessPolicy;
 
     @Mock
     private UserReader userReader;
@@ -74,7 +74,7 @@ class RecordPostServiceTest {
         RecordPost result = recordPostService.getDetail(1L, 10L);
 
         assertThat(result.getViewCount()).isEqualTo(1);
-        verify(postBlockPolicy).validateReadable(1L, post);
+        verify(postAccessPolicy).validateReadable(1L, post);
     }
 
     @Test
@@ -83,7 +83,7 @@ class RecordPostServiceTest {
 
         when(recordPostRepository.findById(10L)).thenReturn(Optional.of(post));
         org.mockito.Mockito.doThrow(new GeneralException(ErrorStatus.POST_AUTHOR_BLOCKED))
-                .when(postBlockPolicy).validateReadable(1L, post);
+                .when(postAccessPolicy).validateReadable(1L, post);
 
         assertThatThrownBy(() -> recordPostService.getDetail(1L, 10L))
                 .isInstanceOf(GeneralException.class)


### PR DESCRIPTION
## 🧾 요약
- `PostBlockPolicy` → `PostAccessPolicy`로 rename — 클래스 역할(게시글 접근 가능 여부 검증)을 더 명확히 표현

## 🔗 이슈
- close #237

## ✨ 변경 내용
- `PostBlockPolicy` → `PostAccessPolicy` 클래스 및 파일명 rename
- `FreePostService`, `RecordPostService` 참조 위치 일괄 변경
- `PostBlockPolicyTest` → `PostAccessPolicyTest` 테스트 파일 rename 및 내부 참조 변경

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
