### PR TITLE
[Refactor] RecordPostService 응답 변환 위치 서비스 계층으로 통일

### DIFF
--- a/src/main/java/com/semosan/api/domain/community/post/controller/RecordPostController.java
+++ b/src/main/java/com/semosan/api/domain/community/post/controller/RecordPostController.java
@@ -6,11 +6,9 @@ import com.semosan.api.common.status.SuccessStatus;
 import com.semosan.api.domain.community.post.controller.docs.RecordPostControllerDocs;
 import com.semosan.api.domain.community.post.dto.RecordPostCreateRequest;
 import com.semosan.api.domain.community.post.dto.RecordPostResponse;
-import com.semosan.api.domain.community.post.entity.RecordPost;
 import com.semosan.api.domain.community.post.service.RecordPostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -30,8 +28,11 @@ public class RecordPostController implements RecordPostControllerDocs {
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody RecordPostCreateRequest request
     ) {
-        RecordPost post = recordPostService.create(userId, request.hikingRecordId(), request.content());
-        return ApiResponse.success(SuccessStatus.RECORD_POST_CREATE_SUCCESS, RecordPostResponse.from(post));
+        return ApiResponse.success(SuccessStatus.RECORD_POST_CREATE_SUCCESS, recordPostService.create(
+                userId,
+                request.hikingRecordId(),
+                request.content()
+        ));
     }
 
     @GetMapping
@@ -39,8 +40,10 @@ public class RecordPostController implements RecordPostControllerDocs {
             @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<RecordPostResponse> page = recordPostService.getList(userId, pageable).map(RecordPostResponse::from);
-        return ApiResponse.success(SuccessStatus.RECORD_POST_LIST_SUCCESS, PageResponse.from(page));
+        return ApiResponse.success(
+                SuccessStatus.RECORD_POST_LIST_SUCCESS,
+                PageResponse.from(recordPostService.getList(userId, pageable))
+        );
     }
 
     @GetMapping("/me")
@@ -48,8 +51,10 @@ public class RecordPostController implements RecordPostControllerDocs {
             @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<RecordPostResponse> page = recordPostService.getMyList(userId, pageable).map(RecordPostResponse::from);
-        return ApiResponse.success(SuccessStatus.RECORD_POST_MY_LIST_SUCCESS, PageResponse.from(page));
+        return ApiResponse.success(
+                SuccessStatus.RECORD_POST_MY_LIST_SUCCESS,
+                PageResponse.from(recordPostService.getMyList(userId, pageable))
+        );
     }
 
     @GetMapping("/{postId}")
@@ -57,8 +62,10 @@ public class RecordPostController implements RecordPostControllerDocs {
             @AuthenticationPrincipal Long userId,
             @PathVariable Long postId
     ) {
-        RecordPost post = recordPostService.getDetail(userId, postId);
-        return ApiResponse.success(SuccessStatus.RECORD_POST_DETAIL_SUCCESS, RecordPostResponse.from(post));
+        return ApiResponse.success(
+                SuccessStatus.RECORD_POST_DETAIL_SUCCESS,
+                recordPostService.getDetail(userId, postId)
+        );
     }
 
     @DeleteMapping("/{postId}")

--- a/src/main/java/com/semosan/api/domain/community/post/repository/RecordPostRepository.java
+++ b/src/main/java/com/semosan/api/domain/community/post/repository/RecordPostRepository.java
@@ -12,19 +12,55 @@ public interface RecordPostRepository extends JpaRepository<RecordPost, Long> {
 
     Page<RecordPost> findAllByDeletedFalse(Pageable pageable);
 
-    Page<RecordPost> findByAuthorAndDeletedFalse(User author, Pageable pageable);
+    @Query(
+            value = """
+                    SELECT rp
+                    FROM RecordPost rp
+                    JOIN FETCH rp.author
+                    JOIN FETCH rp.hikingRecord hr
+                    JOIN FETCH hr.mountain
+                    LEFT JOIN FETCH hr.course
+                    WHERE rp.author = :author
+                      AND rp.deleted = false
+                    ORDER BY rp.createdAt DESC
+                    """,
+            countQuery = """
+                    SELECT COUNT(rp)
+                    FROM RecordPost rp
+                    WHERE rp.author = :author
+                      AND rp.deleted = false
+                    """
+    )
+    Page<RecordPost> findByAuthorAndDeletedFalseWithSummary(@Param("author") User author, Pageable pageable);
 
-    @Query("""
-            SELECT rp
-            FROM RecordPost rp
-            WHERE rp.deleted = false
-              AND NOT EXISTS (
-                  SELECT 1
-                  FROM UserBlock ub
-                  WHERE ub.blocker.id = :viewerId
-                    AND ub.blockedUser.id = rp.author.id
-              )
-            ORDER BY rp.createdAt DESC
-            """)
+    @Query(
+            value = """
+                    SELECT rp
+                    FROM RecordPost rp
+                    JOIN FETCH rp.author
+                    JOIN FETCH rp.hikingRecord hr
+                    JOIN FETCH hr.mountain
+                    LEFT JOIN FETCH hr.course
+                    WHERE rp.deleted = false
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM UserBlock ub
+                          WHERE ub.blocker.id = :viewerId
+                            AND ub.blockedUser.id = rp.author.id
+                      )
+                    ORDER BY rp.createdAt DESC
+                    """,
+            countQuery = """
+                    SELECT COUNT(rp)
+                    FROM RecordPost rp
+                    WHERE rp.deleted = false
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM UserBlock ub
+                          WHERE ub.blocker.id = :viewerId
+                            AND ub.blockedUser.id = rp.author.id
+                      )
+                    """
+    )
     Page<RecordPost> findVisibleByViewerId(@Param("viewerId") Long viewerId, Pageable pageable);
 }

--- a/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
@@ -48,7 +48,7 @@ public class RecordPostService {
 
     public Page<RecordPostResponse> getMyList(Long authorId, Pageable pageable) {
         User author = userReader.findActiveUserById(authorId);
-        return recordPostRepository.findByAuthorAndDeletedFalse(author, pageable)
+        return recordPostRepository.findByAuthorAndDeletedFalseWithSummary(author, pageable)
                 .map(RecordPostResponse::from);
     }
 

--- a/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
+++ b/src/main/java/com/semosan/api/domain/community/post/service/RecordPostService.java
@@ -2,6 +2,7 @@ package com.semosan.api.domain.community.post.service;
 
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.community.post.dto.RecordPostResponse;
 import com.semosan.api.domain.community.post.entity.RecordPost;
 import com.semosan.api.domain.community.post.repository.RecordPostRepository;
 import com.semosan.api.domain.hiking.entity.HikingRecord;
@@ -27,7 +28,7 @@ public class RecordPostService {
     private final UserReader userReader;
 
     @Transactional
-    public RecordPost create(Long authorId, Long hikingRecordId, String content) {
+    public RecordPostResponse create(Long authorId, Long hikingRecordId, String content) {
         User author = userReader.findActiveUserById(authorId);
         HikingRecord hikingRecord = hikingRecordRepository.findById(hikingRecordId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.HIKING_RECORD_NOT_FOUND));
@@ -37,24 +38,26 @@ public class RecordPostService {
         }
 
         RecordPost post = RecordPost.create(author, content, hikingRecord);
-        return recordPostRepository.save(post);
+        return RecordPostResponse.from(recordPostRepository.save(post));
     }
 
-    public Page<RecordPost> getList(Long viewerId, Pageable pageable) {
-        return recordPostRepository.findVisibleByViewerId(viewerId, pageable);
+    public Page<RecordPostResponse> getList(Long viewerId, Pageable pageable) {
+        return recordPostRepository.findVisibleByViewerId(viewerId, pageable)
+                .map(RecordPostResponse::from);
     }
 
-    public Page<RecordPost> getMyList(Long authorId, Pageable pageable) {
+    public Page<RecordPostResponse> getMyList(Long authorId, Pageable pageable) {
         User author = userReader.findActiveUserById(authorId);
-        return recordPostRepository.findByAuthorAndDeletedFalse(author, pageable);
+        return recordPostRepository.findByAuthorAndDeletedFalse(author, pageable)
+                .map(RecordPostResponse::from);
     }
 
     @Transactional
-    public RecordPost getDetail(Long viewerId, Long postId) {
+    public RecordPostResponse getDetail(Long viewerId, Long postId) {
         RecordPost post = findActivePostOrThrow(postId);
         postAccessPolicy.validateReadable(viewerId, post);
         post.increaseViewCount();
-        return post;
+        return RecordPostResponse.from(post);
     }
 
     @Transactional

--- a/src/test/java/com/semosan/api/domain/community/post/service/RecordPostServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/RecordPostServiceTest.java
@@ -93,6 +93,23 @@ class RecordPostServiceTest {
     }
 
     @Test
+    void getMyListUsesSummaryFetchQuery() throws Exception {
+        User author = user(1L, "author");
+        RecordPost post = recordPost(10L, author);
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<RecordPost> page = new PageImpl<>(List.of(post), pageable, 1);
+
+        when(userReader.findActiveUserById(1L)).thenReturn(author);
+        when(recordPostRepository.findByAuthorAndDeletedFalseWithSummary(author, pageable)).thenReturn(page);
+
+        Page<RecordPostResponse> result = recordPostService.getMyList(1L, pageable);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getContent().get(0).author().id()).isEqualTo(1L);
+        verify(recordPostRepository).findByAuthorAndDeletedFalseWithSummary(eq(author), eq(pageable));
+    }
+
+    @Test
     void getDetailValidatesBlockPolicyBeforeIncreasingViewCount() throws Exception {
         RecordPost post = recordPost(10L, user(2L, "author"));
 

--- a/src/test/java/com/semosan/api/domain/community/post/service/RecordPostServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/community/post/service/RecordPostServiceTest.java
@@ -2,10 +2,14 @@ package com.semosan.api.domain.community.post.service;
 
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.community.post.dto.RecordPostResponse;
 import com.semosan.api.domain.community.post.entity.RecordPost;
 import com.semosan.api.domain.community.post.repository.RecordPostRepository;
+import com.semosan.api.domain.hiking.entity.HikingRecord;
 import com.semosan.api.domain.hiking.repository.HikingMemberRepository;
 import com.semosan.api.domain.hiking.repository.HikingRecordRepository;
+import com.semosan.api.domain.mountain.entity.Course;
+import com.semosan.api.domain.mountain.entity.Mountain;
 import com.semosan.api.domain.user.entity.User;
 import com.semosan.api.domain.user.enums.user.DeviceType;
 import com.semosan.api.domain.user.service.UserReader;
@@ -19,11 +23,13 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -51,34 +57,56 @@ class RecordPostServiceTest {
     private RecordPostService recordPostService;
 
     @Test
-    void getListUsesViewerSpecificVisibleQuery() {
+    void createReturnsResponse() throws Exception {
+        User author = user(1L, "author");
+        HikingRecord hikingRecord = hikingRecord(100L, course(mountain(20L, "관악산"), 30L, "과천향교 출발 코스"));
+        RecordPost savedPost = RecordPost.create(author, "본문", hikingRecord);
+        ReflectionTestUtils.setField(savedPost, "id", 10L);
+
+        when(userReader.findActiveUserById(1L)).thenReturn(author);
+        when(hikingRecordRepository.findById(100L)).thenReturn(Optional.of(hikingRecord));
+        when(hikingMemberRepository.existsByHikingRecordAndUser(hikingRecord, author)).thenReturn(true);
+        when(recordPostRepository.save(any(RecordPost.class))).thenReturn(savedPost);
+
+        RecordPostResponse result = recordPostService.create(1L, 100L, "본문");
+
+        assertThat(result.id()).isEqualTo(10L);
+        assertThat(result.content()).isEqualTo("본문");
+        assertThat(result.hikingRecord().courseName()).isEqualTo("과천향교 출발 코스");
+    }
+
+    @Test
+    void getListUsesViewerSpecificVisibleQuery() throws Exception {
         RecordPost post = recordPost(10L, user(2L, "author"));
         PageRequest pageable = PageRequest.of(0, 10);
         Page<RecordPost> page = new PageImpl<>(List.of(post), pageable, 1);
 
         when(recordPostRepository.findVisibleByViewerId(1L, pageable)).thenReturn(page);
 
-        Page<RecordPost> result = recordPostService.getList(1L, pageable);
+        Page<RecordPostResponse> result = recordPostService.getList(1L, pageable);
 
         assertThat(result).hasSize(1);
+        assertThat(result.getContent().get(0).id()).isEqualTo(10L);
+        assertThat(result.getContent().get(0).hikingRecord().mountainName()).isEqualTo("관악산");
         verify(recordPostRepository).findVisibleByViewerId(eq(1L), eq(pageable));
         verify(recordPostRepository, never()).findAllByDeletedFalse(pageable);
     }
 
     @Test
-    void getDetailValidatesBlockPolicyBeforeIncreasingViewCount() {
+    void getDetailValidatesBlockPolicyBeforeIncreasingViewCount() throws Exception {
         RecordPost post = recordPost(10L, user(2L, "author"));
 
         when(recordPostRepository.findById(10L)).thenReturn(Optional.of(post));
 
-        RecordPost result = recordPostService.getDetail(1L, 10L);
+        RecordPostResponse result = recordPostService.getDetail(1L, 10L);
 
-        assertThat(result.getViewCount()).isEqualTo(1);
+        assertThat(result.viewCount()).isEqualTo(1);
+        assertThat(post.getViewCount()).isEqualTo(1);
         verify(postAccessPolicy).validateReadable(1L, post);
     }
 
     @Test
-    void getDetailThrowsWhenViewerBlockedAuthor() {
+    void getDetailThrowsWhenViewerBlockedAuthor() throws Exception {
         RecordPost post = recordPost(10L, user(2L, "author"));
 
         when(recordPostRepository.findById(10L)).thenReturn(Optional.of(post));
@@ -93,7 +121,7 @@ class RecordPostServiceTest {
     }
 
     @Test
-    void deleteSoftDeletesWhenRequesterOwnsPost() {
+    void deleteSoftDeletesWhenRequesterOwnsPost() throws Exception {
         RecordPost post = recordPost(10L, user(2L, "author"));
 
         when(recordPostRepository.findById(10L)).thenReturn(Optional.of(post));
@@ -104,7 +132,7 @@ class RecordPostServiceTest {
     }
 
     @Test
-    void deleteThrowsWhenRequesterDoesNotOwnPost() {
+    void deleteThrowsWhenRequesterDoesNotOwnPost() throws Exception {
         RecordPost post = recordPost(10L, user(2L, "author"));
 
         when(recordPostRepository.findById(10L)).thenReturn(Optional.of(post));
@@ -123,9 +151,41 @@ class RecordPostServiceTest {
         return user;
     }
 
-    private RecordPost recordPost(Long id, User author) {
-        RecordPost post = RecordPost.create(author, "본문", null);
+    private RecordPost recordPost(Long id, User author) throws Exception {
+        RecordPost post = RecordPost.create(author, "본문", hikingRecord(100L, course(mountain(20L, "관악산"), 30L, "과천향교 출발 코스")));
         ReflectionTestUtils.setField(post, "id", id);
         return post;
+    }
+
+    private Mountain mountain(Long id, String name) throws Exception {
+        Constructor<Mountain> constructor = Mountain.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Mountain mountain = constructor.newInstance();
+        ReflectionTestUtils.setField(mountain, "id", id);
+        ReflectionTestUtils.setField(mountain, "name", name);
+        return mountain;
+    }
+
+    private Course course(Mountain mountain, Long id, String name) throws Exception {
+        Constructor<Course> constructor = Course.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Course course = constructor.newInstance();
+        ReflectionTestUtils.setField(course, "id", id);
+        ReflectionTestUtils.setField(course, "mountain", mountain);
+        ReflectionTestUtils.setField(course, "name", name);
+        return course;
+    }
+
+    private HikingRecord hikingRecord(Long id, Course course) throws Exception {
+        Constructor<HikingRecord> constructor = HikingRecord.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        HikingRecord hikingRecord = constructor.newInstance();
+        ReflectionTestUtils.setField(hikingRecord, "id", id);
+        ReflectionTestUtils.setField(hikingRecord, "mountain", course.getMountain());
+        ReflectionTestUtils.setField(hikingRecord, "course", course);
+        ReflectionTestUtils.setField(hikingRecord, "duration", 3600);
+        ReflectionTestUtils.setField(hikingRecord, "maxAltitude", 629.0);
+        ReflectionTestUtils.setField(hikingRecord, "calories", 500);
+        return hikingRecord;
     }
 }


### PR DESCRIPTION
## 🧾 요약
- RecordPostService의 Entity 직접 반환을 DTO 반환으로 변경해 FreePostService 패턴과 통일

## 🔗 이슈
- close #232

## ✨ 변경 내용
- `RecordPostService`: `create`, `getList`, `getMyList`, `getDetail` 반환 타입을 `RecordPost` → `RecordPostResponse`로 변경
- `RecordPostController`: Controller에서의 `RecordPostResponse::from` 변환 로직 제거
- `RecordPostServiceTest`: `createReturnsResponse` 테스트 추가 및 기존 테스트 반환 타입 업데이트

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
