### PR TITLE
[Feat] 댓글 작성자 차단 API 추가

### DIFF
--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -109,6 +109,7 @@ public enum SuccessStatus implements BaseStatus {
     COMMENT_DELETE_SUCCESS(HttpStatus.OK, "CMT_200_3", "댓글이 삭제되었습니다."),
     COMMENT_CREATE_SUCCESS(HttpStatus.CREATED, "CMT_201_1", "댓글이 작성되었습니다."),
     COMMENT_REPLY_SUCCESS(HttpStatus.CREATED, "CMT_201_2", "대댓글이 작성되었습니다."),
+    COMMENT_BLOCK_SUCCESS(HttpStatus.CREATED, "CMT_201_3", "사용자를 차단했습니다."),
 
     /**
      * Post Like (좋아요)

--- a/src/main/java/com/semosan/api/domain/community/comment/controller/CommentController.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/controller/CommentController.java
@@ -8,6 +8,7 @@ import com.semosan.api.domain.community.comment.dto.CommentCreateRequest;
 import com.semosan.api.domain.community.comment.dto.CommentReplyRequest;
 import com.semosan.api.domain.community.comment.dto.CommentResponse;
 import com.semosan.api.domain.community.comment.service.CommentService;
+import com.semosan.api.domain.user.service.UserBlockService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,13 +22,14 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/community")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class CommentController implements CommentControllerDocs {
 
     private final CommentService commentService;
+    private final UserBlockService userBlockService;
 
-    @PostMapping("/posts/{postId}/comments")
+    @PostMapping("/community/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<CommentResponse>> create(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long postId,
@@ -37,7 +39,7 @@ public class CommentController implements CommentControllerDocs {
                 CommentResponse.from(commentService.create(postId, userId, request.content())));
     }
 
-    @PostMapping("/posts/{postId}/comments/replies")
+    @PostMapping("/community/posts/{postId}/comments/replies")
     public ResponseEntity<ApiResponse<CommentResponse>> reply(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long postId,
@@ -49,7 +51,7 @@ public class CommentController implements CommentControllerDocs {
                 )));
     }
 
-    @GetMapping("/posts/{postId}/comments")
+    @GetMapping("/community/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<PageResponse<CommentResponse>>> getComments(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long postId,
@@ -61,7 +63,7 @@ public class CommentController implements CommentControllerDocs {
         );
     }
 
-    @GetMapping("/comments/{commentId}/replies")
+    @GetMapping("/community/comments/{commentId}/replies")
     public ResponseEntity<ApiResponse<List<CommentResponse>>> getReplies(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long commentId
@@ -72,12 +74,21 @@ public class CommentController implements CommentControllerDocs {
         );
     }
 
-    @DeleteMapping("/comments/{commentId}")
+    @DeleteMapping("/community/comments/{commentId}")
     public ResponseEntity<ApiResponse<Void>> delete(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long commentId
     ) {
         commentService.delete(commentId, userId);
         return ApiResponse.success(SuccessStatus.COMMENT_DELETE_SUCCESS);
+    }
+
+    @PostMapping("/comments/{commentId}/block")
+    public ResponseEntity<ApiResponse<Void>> block(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long commentId
+    ) {
+        userBlockService.blockByComment(userId, commentId);
+        return ApiResponse.success(SuccessStatus.COMMENT_BLOCK_SUCCESS);
     }
 }

--- a/src/main/java/com/semosan/api/domain/community/comment/controller/CommentController.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/controller/CommentController.java
@@ -83,7 +83,7 @@ public class CommentController implements CommentControllerDocs {
         return ApiResponse.success(SuccessStatus.COMMENT_DELETE_SUCCESS);
     }
 
-    @PostMapping("/comments/{commentId}/block")
+    @PostMapping("/community/comments/{commentId}/blocks")
     public ResponseEntity<ApiResponse<Void>> block(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long commentId

--- a/src/main/java/com/semosan/api/domain/community/comment/controller/CommentController.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/controller/CommentController.java
@@ -22,14 +22,14 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/community")
 @RequiredArgsConstructor
 public class CommentController implements CommentControllerDocs {
 
     private final CommentService commentService;
     private final UserBlockService userBlockService;
 
-    @PostMapping("/community/posts/{postId}/comments")
+    @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<CommentResponse>> create(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long postId,
@@ -39,7 +39,7 @@ public class CommentController implements CommentControllerDocs {
                 CommentResponse.from(commentService.create(postId, userId, request.content())));
     }
 
-    @PostMapping("/community/posts/{postId}/comments/replies")
+    @PostMapping("/posts/{postId}/comments/replies")
     public ResponseEntity<ApiResponse<CommentResponse>> reply(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long postId,
@@ -51,7 +51,7 @@ public class CommentController implements CommentControllerDocs {
                 )));
     }
 
-    @GetMapping("/community/posts/{postId}/comments")
+    @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<PageResponse<CommentResponse>>> getComments(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long postId,
@@ -63,7 +63,7 @@ public class CommentController implements CommentControllerDocs {
         );
     }
 
-    @GetMapping("/community/comments/{commentId}/replies")
+    @GetMapping("/comments/{commentId}/replies")
     public ResponseEntity<ApiResponse<List<CommentResponse>>> getReplies(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long commentId
@@ -74,7 +74,7 @@ public class CommentController implements CommentControllerDocs {
         );
     }
 
-    @DeleteMapping("/community/comments/{commentId}")
+    @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<ApiResponse<Void>> delete(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long commentId
@@ -83,7 +83,7 @@ public class CommentController implements CommentControllerDocs {
         return ApiResponse.success(SuccessStatus.COMMENT_DELETE_SUCCESS);
     }
 
-    @PostMapping("/community/comments/{commentId}/blocks")
+    @PostMapping("/comments/{commentId}/blocks")
     public ResponseEntity<ApiResponse<Void>> block(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long commentId

--- a/src/main/java/com/semosan/api/domain/community/comment/controller/docs/CommentControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/community/comment/controller/docs/CommentControllerDocs.java
@@ -75,4 +75,15 @@ public interface CommentControllerDocs {
             @AuthenticationPrincipal Long userId,
             @PathVariable Long commentId
     );
+
+    @Operation(summary = "댓글 작성자 차단", description = "댓글 작성자를 차단합니다. 차단 후 해당 사용자의 댓글은 목록 조회 시 마스킹됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "차단 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "자기 자신 차단 불가"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "댓글 또는 유저 없음")
+    })
+    ResponseEntity<ApiResponse<Void>> block(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long commentId
+    );
 }

--- a/src/main/java/com/semosan/api/domain/user/service/UserBlockService.java
+++ b/src/main/java/com/semosan/api/domain/user/service/UserBlockService.java
@@ -3,6 +3,8 @@ package com.semosan.api.domain.user.service;
 import com.semosan.api.common.exception.ConstraintViolationUtils;
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.community.comment.entity.Comment;
+import com.semosan.api.domain.community.comment.repository.CommentRepository;
 import com.semosan.api.domain.community.post.entity.FreePost;
 import com.semosan.api.domain.community.post.repository.FreePostRepository;
 import com.semosan.api.domain.user.entity.User;
@@ -24,6 +26,7 @@ public class UserBlockService {
     private final UserRepository userRepository;
     private final UserBlockRepository userBlockRepository;
     private final FreePostRepository freePostRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public void block(Long blockerId, Long blockedUserId) {
@@ -52,6 +55,13 @@ public class UserBlockService {
         FreePost post = freePostRepository.findByIdAndDeletedFalse(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
         block(blockerId, post.getAuthor().getId());
+    }
+
+    @Transactional
+    public void blockByComment(Long blockerId, Long commentId) {
+        Comment comment = commentRepository.findByIdAndDeletedFalse(commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+        block(blockerId, comment.getAuthor().getId());
     }
 
     private User findActiveUserOrThrow(Long userId) {

--- a/src/test/java/com/semosan/api/domain/user/service/UserBlockServiceTest.java
+++ b/src/test/java/com/semosan/api/domain/user/service/UserBlockServiceTest.java
@@ -2,6 +2,8 @@ package com.semosan.api.domain.user.service;
 
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.community.comment.entity.Comment;
+import com.semosan.api.domain.community.comment.repository.CommentRepository;
 import com.semosan.api.domain.community.post.entity.FreePost;
 import com.semosan.api.domain.community.post.repository.FreePostRepository;
 import com.semosan.api.domain.user.entity.User;
@@ -37,6 +39,9 @@ class UserBlockServiceTest {
     @Mock
     private FreePostRepository freePostRepository;
 
+    @Mock
+    private CommentRepository commentRepository;
+
     @InjectMocks
     private UserBlockService userBlockService;
 
@@ -63,9 +68,39 @@ class UserBlockServiceTest {
         FreePost post = freePost(10L, user);
 
         when(freePostRepository.findByIdAndDeletedFalse(10L)).thenReturn(Optional.of(post));
-        when(userRepository.findByIdAndDeletedFalse(1L)).thenReturn(Optional.of(user));
 
         assertThatThrownBy(() -> userBlockService.blockByPost(1L, 10L))
+                .isInstanceOf(GeneralException.class)
+                .extracting("errorStatus")
+                .isEqualTo(ErrorStatus.USER_BLOCK_SELF_NOT_ALLOWED);
+        verify(userBlockRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void blockByCommentBlocksCommentAuthor() throws Exception {
+        User blocker = user(1L, "blocker");
+        User blockedUser = user(2L, "blocked");
+        Comment comment = comment(20L, blockedUser);
+
+        when(commentRepository.findByIdAndDeletedFalse(20L)).thenReturn(Optional.of(comment));
+        when(userRepository.findByIdAndDeletedFalse(1L)).thenReturn(Optional.of(blocker));
+        when(userRepository.findByIdAndDeletedFalse(2L)).thenReturn(Optional.of(blockedUser));
+        when(userBlockRepository.existsByBlocker_IdAndBlockedUser_Id(1L, 2L)).thenReturn(false);
+        when(userBlockRepository.saveAndFlush(any(UserBlock.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        userBlockService.blockByComment(1L, 20L);
+
+        verify(userBlockRepository).saveAndFlush(any(UserBlock.class));
+    }
+
+    @Test
+    void blockByCommentThrowsWhenBlockingSelf() throws Exception {
+        User user = user(1L, "user");
+        Comment comment = comment(20L, user);
+
+        when(commentRepository.findByIdAndDeletedFalse(20L)).thenReturn(Optional.of(comment));
+
+        assertThatThrownBy(() -> userBlockService.blockByComment(1L, 20L))
                 .isInstanceOf(GeneralException.class)
                 .extracting("errorStatus")
                 .isEqualTo(ErrorStatus.USER_BLOCK_SELF_NOT_ALLOWED);
@@ -85,5 +120,11 @@ class UserBlockServiceTest {
         FreePost post = constructor.newInstance(author, "title", "content");
         ReflectionTestUtils.setField(post, "id", id);
         return post;
+    }
+
+    private Comment comment(Long id, User author) throws Exception {
+        Comment comment = Comment.create(freePost(10L, author), author, "content");
+        ReflectionTestUtils.setField(comment, "id", id);
+        return comment;
     }
 }


### PR DESCRIPTION
## 🧾 요약
- 앱 심사 리젝 대응으로 댓글 작성자 차단 API 추가 — 게시글 차단과 동일한 방식으로 구현

## 🔗 이슈
- close #252

## ✨ 변경 내용
- `UserBlockService`: `blockByComment(blockerId, commentId)` 메서드 추가
- `CommentController`: `POST /api/community/comments/{commentId}/blocks` 엔드포인트 추가
- `CommentControllerDocs`: Swagger 문서 추가
- `SuccessStatus`: `COMMENT_BLOCK_SUCCESS` 추가
- `UserBlockServiceTest`: 댓글 차단 정상 동작 및 자기 자신 차단 예외 케이스 추가

## ✅ 확인
- [ ] 빌드 OK
- [ ] 테스트 OK
