### PR TITLE
[Feat] 산(Mountain) 공개/비공개 컬럼 추가

### DIFF
--- a/src/main/java/com/semosan/api/domain/mountain/entity/Mountain.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/Mountain.java
@@ -60,6 +60,10 @@ public class Mountain extends BaseEntity {
     @Column(name = "location", columnDefinition = "geography(Point, 4326)")
     private Point location;
 
+    @Builder.Default
+    @Column(name = "is_public", nullable = false)
+    private boolean isPublic = true;
+
     public void updateCoordinates(Double latitude, Double longitude) {
         this.latitude = latitude;
         this.longitude = longitude;

--- a/src/main/java/com/semosan/api/domain/mountain/repository/CourseRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/CourseRepository.java
@@ -16,8 +16,9 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     @Query("""
             SELECT c
             FROM Course c
-            JOIN FETCH c.mountain
-            ORDER BY c.mountain.id ASC, c.id ASC
+            JOIN FETCH c.mountain m
+            WHERE m.isPublic = true
+            ORDER BY m.id ASC, c.id ASC
             """)
     List<Course> findAllWithMountainForRecommendation();
 

--- a/src/main/java/com/semosan/api/domain/mountain/repository/MountainRepository.java
+++ b/src/main/java/com/semosan/api/domain/mountain/repository/MountainRepository.java
@@ -14,8 +14,10 @@ import java.util.Optional;
 
 public interface MountainRepository extends JpaRepository<Mountain, Long> {
 
-    @Query("SELECT m FROM Mountain m WHERE m.name LIKE CONCAT('%', :keyword, '%') OR m.address LIKE CONCAT('%', :keyword, '%')")
+    @Query("SELECT m FROM Mountain m WHERE m.isPublic = true AND (m.name LIKE CONCAT('%', :keyword, '%') OR m.address LIKE CONCAT('%', :keyword, '%'))")
     Page<Mountain> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    Page<Mountain> findByIsPublicTrue(Pageable pageable);
 
     /**
      * 주어진 좌표(lat, lng)에서 가장 가까운 산 1개를 PostGIS 거리 연산자로 조회한다.
@@ -27,6 +29,7 @@ public interface MountainRepository extends JpaRepository<Mountain, Long> {
             value = """
                     SELECT * FROM mountains
                     WHERE location IS NOT NULL
+                      AND is_public = true
                     ORDER BY location <-> ST_SetSRID(ST_MakePoint(:lng, :lat), 4326)::geography
                     LIMIT 1
                     """,
@@ -53,6 +56,7 @@ public interface MountainRepository extends JpaRepository<Mountain, Long> {
                     WHERE difficulty IN (:difficulties)
                       AND latitude IS NOT NULL
                       AND longitude IS NOT NULL
+                      AND is_public = true
                     ORDER BY (POWER(latitude - :lat, 2) + POWER((longitude - :lng) * COS(RADIANS(:lat)), 2)) ASC, id ASC
                     """,
             countQuery = """
@@ -60,6 +64,7 @@ public interface MountainRepository extends JpaRepository<Mountain, Long> {
                     WHERE difficulty IN (:difficulties)
                       AND latitude IS NOT NULL
                       AND longitude IS NOT NULL
+                      AND is_public = true
                     """,
             nativeQuery = true
     )
@@ -84,6 +89,7 @@ public interface MountainRepository extends JpaRepository<Mountain, Long> {
                     LEFT JOIN hiking_members hm ON hm.hiking_record_id = hr.id AND hm.user_id = :userId
                     WHERE m.latitude BETWEEN :swLat AND :neLat
                       AND m.longitude BETWEEN :swLng AND :neLng
+                      AND m.is_public = true
                     GROUP BY m.id
                     ORDER BY m.id
                     """,

--- a/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
+++ b/src/main/java/com/semosan/api/domain/mountain/service/MountainService.java
@@ -59,7 +59,7 @@ public class MountainService {
 
     public Page<MountainListResponse> getMountains(Long userId, Pageable pageable) {
         userReader.findActiveUserById(userId);
-        return mountainRepository.findAll(pageable)
+         return mountainRepository.findByIsPublicTrue(pageable)
                 .map(MountainListResponse::from);
     }
 

--- a/src/main/resources/db/migration/V30__add_mountain_is_public.sql
+++ b/src/main/resources/db/migration/V30__add_mountain_is_public.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mountains
+    ADD COLUMN is_public BOOLEAN NOT NULL DEFAULT true;


### PR DESCRIPTION
## 🧾 요약
- 산 데이터에 공개/비공개 구분을 추가하여 비공개 산은 사용자에게 노출되지 않도록 제어

## 🔗 이슈
- close #255

## ✨ 변경 내용
- `mountains` 테이블에 `is_public` (boolean, default true) 컬럼 추가 Flyway 마이그레이션
- `Mountain` 엔티티에 `isPublic` 필드 추가
- 산 목록/검색/추천/지도/nearest 조회 쿼리에 `is_public = true` 조건 추가

## ✅ 확인
- [x] 빌드 OK
- [ ] 테스트 OK
