### PR TITLE
[Fix] RestaurantSection 불필요 컬럼 제거

### DIFF
--- a/src/main/java/com/semosan/api/domain/mountain/entity/RestaurantSection.java
+++ b/src/main/java/com/semosan/api/domain/mountain/entity/RestaurantSection.java
@@ -26,18 +26,6 @@ public class RestaurantSection extends BaseEntity {
     @Column(name = "title", nullable = false, length = 100)
     private String title;
 
-    @Column(name = "menu", length = 100)
-    private String menu;
-
-    @Column(name = "description", length = 255)
-    private String description;
-
-    @Column(name = "map_url", columnDefinition = "TEXT")
-    private String mapUrl;
-
-    @Column(name = "blog_url", columnDefinition = "TEXT")
-    private String blogUrl;
-
     @OneToMany(mappedBy = "section", fetch = FetchType.LAZY)
     @Builder.Default
     private List<Restaurant> restaurants = new ArrayList<>();

--- a/src/main/resources/db/migration/V32__drop_restaurant_sections_unnecessary_columns.sql
+++ b/src/main/resources/db/migration/V32__drop_restaurant_sections_unnecessary_columns.sql
@@ -1,4 +1,5 @@
-ALTER TABLE restaurant_sections DROP COLUMN menu;
-ALTER TABLE restaurant_sections DROP COLUMN description;
-ALTER TABLE restaurant_sections DROP COLUMN map_url;
-ALTER TABLE restaurant_sections DROP COLUMN blog_url;
+ALTER TABLE restaurant_sections
+    DROP COLUMN menu,
+    DROP COLUMN description,
+    DROP COLUMN map_url,
+    DROP COLUMN blog_url;

--- a/src/main/resources/db/migration/V32__drop_restaurant_sections_unnecessary_columns.sql
+++ b/src/main/resources/db/migration/V32__drop_restaurant_sections_unnecessary_columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE restaurant_sections DROP COLUMN menu;
+ALTER TABLE restaurant_sections DROP COLUMN description;
+ALTER TABLE restaurant_sections DROP COLUMN map_url;
+ALTER TABLE restaurant_sections DROP COLUMN blog_url;


### PR DESCRIPTION
## 🧾 요약
- #258 에서 RestaurantSection에 잘못 추가된 menu, description, map_url, blog_url 컬럼 제거

## 🔗 이슈
- close #260

## ✨ 변경 내용
- `restaurant_sections` 테이블에서 불필요 컬럼 4개 DROP 마이그레이션 (V32)
- `RestaurantSection` 엔티티에서 해당 필드 제거

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK
