### PR TITLE
[Feat] RestaurantInfo 응답에 mapUrl 필드 추가

### DIFF
--- a/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainDetailResponse.java
+++ b/src/main/java/com/semosan/api/domain/mountain/dto/response/MountainDetailResponse.java
@@ -132,14 +132,16 @@ public record MountainDetailResponse(
             Long restaurantId,
             String name,
             String category,
-            String imageUrl
+            String imageUrl,
+            String mapUrl
     ) {
         public static RestaurantInfo from(Restaurant restaurant) {
             return new RestaurantInfo(
                     restaurant.getId(),
                     restaurant.getName(),
                     restaurant.getCategory(),
-                    restaurant.getImageUrl()
+                    restaurant.getImageUrl(),
+                    restaurant.getMapUrl()
             );
         }
     }


### PR DESCRIPTION
## 🧾 요약
- 산 상세 API 응답의 RestaurantInfo에 mapUrl 필드 추가

## 🔗 이슈
- close #262

## ✨ 변경 내용
- RestaurantInfo record에 mapUrl 필드 추가
- from() 매핑에 restaurant.getMapUrl() 추가

## ✅ 확인
- [x] 빌드 OK
- [ ] 테스트 OK
