### PR TITLE
[Feat] Admin 인증/권한 체계 구현

### DIFF
--- a/src/main/java/com/semosan/api/common/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/semosan/api/common/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.semosan.api.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/semosan/api/common/config/SecurityConfig.java
+++ b/src/main/java/com/semosan/api/common/config/SecurityConfig.java
@@ -75,6 +75,9 @@ public class SecurityConfig {
                         .requestMatchers(AUTH_URIS).permitAll()
                         .requestMatchers(WEBSOCKET_URIS).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/app-version").permitAll()
+                        .requestMatchers("/api/admin/login").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/app-version").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/semosan/api/common/jwt/JwtFilter.java
+++ b/src/main/java/com/semosan/api/common/jwt/JwtFilter.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.stereotype.Component;
@@ -72,8 +73,14 @@ public class JwtFilter extends OncePerRequestFilter {
                 Long userId = jwtService.getUserIdFromClaims(claims);
                 MDC.put("userId", String.valueOf(userId));
 
+                List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+                String tokenType = claims.get("tokenType", String.class);
+                if ("ADMIN".equals(tokenType)) {
+                    authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+                }
+
                 UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userId, null, new ArrayList<>());
+                        new UsernamePasswordAuthenticationToken(userId, null, authorities);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
             filterChain.doFilter(request, response);

--- a/src/main/java/com/semosan/api/common/jwt/JwtService.java
+++ b/src/main/java/com/semosan/api/common/jwt/JwtService.java
@@ -2,6 +2,7 @@ package com.semosan.api.common.jwt;
 
 import com.semosan.api.common.exception.GeneralException;
 import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.admin.entity.Admin;
 import com.semosan.api.domain.user.entity.User;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
@@ -82,6 +83,19 @@ public class JwtService {
         } catch (NoSuchAlgorithmException e) {
             throw new GeneralException(ErrorStatus.JWT_GENERAL_ERROR);
         }
+    }
+
+    public String generateAdminAccessToken(Admin admin) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + accessTokenExpiration);
+
+        return Jwts.builder()
+                .subject(admin.getId().toString())
+                .claim("tokenType", "ADMIN")
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
     }
 
     // Access Token 검증 후 Claims를 반환해 호출부에서 같은 토큰을 다시 파싱하지 않도록 한다.

--- a/src/main/java/com/semosan/api/common/status/ErrorStatus.java
+++ b/src/main/java/com/semosan/api/common/status/ErrorStatus.java
@@ -158,7 +158,12 @@ public enum ErrorStatus implements BaseStatus {
      */
     APP_VERSION_NOT_FOUND(HttpStatus.NOT_FOUND, "APPV_404_1", "앱 버전 정보를 찾을 수 없습니다."),
     APP_VERSION_READ_FAILED(HttpStatus.BAD_GATEWAY, "APPV_502_1", "앱 버전 정보 조회에 실패했습니다."),
-    APP_VERSION_UPDATE_FAILED(HttpStatus.BAD_GATEWAY, "APPV_502_2", "앱 버전 정보 저장에 실패했습니다.");
+    APP_VERSION_UPDATE_FAILED(HttpStatus.BAD_GATEWAY, "APPV_502_2", "앱 버전 정보 저장에 실패했습니다."),
+
+    /**
+     * Admin
+     */
+    ADMIN_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "ADM_401_1", "아이디 또는 비밀번호가 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/semosan/api/common/status/SuccessStatus.java
+++ b/src/main/java/com/semosan/api/common/status/SuccessStatus.java
@@ -133,7 +133,12 @@ public enum SuccessStatus implements BaseStatus {
      * App Version
      */
     APP_VERSION_GET_SUCCESS(HttpStatus.OK, "APPV_200_1", "앱 버전 정보 조회에 성공했습니다."),
-    APP_VERSION_UPDATE_SUCCESS(HttpStatus.OK, "APPV_200_2", "앱 버전 정보 수정에 성공했습니다.");
+    APP_VERSION_UPDATE_SUCCESS(HttpStatus.OK, "APPV_200_2", "앱 버전 정보 수정에 성공했습니다."),
+
+    /**
+     * Admin
+     */
+    ADMIN_LOGIN_SUCCESS(HttpStatus.OK, "ADM_200_1", "관리자 로그인에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/semosan/api/domain/admin/controller/AdminAuthController.java
+++ b/src/main/java/com/semosan/api/domain/admin/controller/AdminAuthController.java
@@ -1,0 +1,36 @@
+package com.semosan.api.domain.admin.controller;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.common.status.SuccessStatus;
+import com.semosan.api.domain.admin.controller.docs.AdminAuthControllerDocs;
+import com.semosan.api.domain.admin.dto.request.AdminLoginRequest;
+import com.semosan.api.domain.admin.dto.response.AdminLoginResponse;
+import com.semosan.api.domain.admin.service.AdminAuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminAuthController implements AdminAuthControllerDocs {
+
+    private final AdminAuthService adminAuthService;
+
+    @PostMapping("/login")
+    @Override
+    public ResponseEntity<ApiResponse<AdminLoginResponse>> login(
+            @Valid @RequestBody AdminLoginRequest request,
+            HttpServletRequest httpRequest
+    ) {
+        String ipAddress = httpRequest.getRemoteAddr();
+        String userAgent = httpRequest.getHeader("User-Agent");
+        AdminLoginResponse response = adminAuthService.login(request, ipAddress, userAgent);
+        return ApiResponse.success(SuccessStatus.ADMIN_LOGIN_SUCCESS, response);
+    }
+}

--- a/src/main/java/com/semosan/api/domain/admin/controller/docs/AdminAuthControllerDocs.java
+++ b/src/main/java/com/semosan/api/domain/admin/controller/docs/AdminAuthControllerDocs.java
@@ -1,0 +1,26 @@
+package com.semosan.api.domain.admin.controller.docs;
+
+import com.semosan.api.common.response.ApiResponse;
+import com.semosan.api.domain.admin.dto.request.AdminLoginRequest;
+import com.semosan.api.domain.admin.dto.response.AdminLoginResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Admin Auth", description = "관리자 인증 API")
+public interface AdminAuthControllerDocs {
+
+    @Operation(summary = "관리자 로그인", description = "관리자 아이디/비밀번호로 로그인하여 JWT를 발급받습니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "관리자 로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "아이디 또는 비밀번호 불일치")
+    })
+    ResponseEntity<ApiResponse<AdminLoginResponse>> login(
+            @Valid @RequestBody AdminLoginRequest request,
+            HttpServletRequest httpRequest
+    );
+}

--- a/src/main/java/com/semosan/api/domain/admin/dto/request/AdminLoginRequest.java
+++ b/src/main/java/com/semosan/api/domain/admin/dto/request/AdminLoginRequest.java
@@ -1,0 +1,12 @@
+package com.semosan.api.domain.admin.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginRequest(
+
+        @NotBlank(message = "아이디는 필수입니다.")
+        String username,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {}

--- a/src/main/java/com/semosan/api/domain/admin/dto/response/AdminLoginResponse.java
+++ b/src/main/java/com/semosan/api/domain/admin/dto/response/AdminLoginResponse.java
@@ -1,0 +1,7 @@
+package com.semosan.api.domain.admin.dto.response;
+
+public record AdminLoginResponse(
+        Long adminId,
+        String name,
+        String accessToken
+) {}

--- a/src/main/java/com/semosan/api/domain/admin/entity/Admin.java
+++ b/src/main/java/com/semosan/api/domain/admin/entity/Admin.java
@@ -1,0 +1,39 @@
+package com.semosan.api.domain.admin.entity;
+
+import com.semosan.api.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "admins")
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Admin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "username", nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled = true;
+
+    public static Admin create(String username, String password, String name) {
+        return Admin.builder()
+                .username(username)
+                .password(password)
+                .name(name)
+                .enabled(true)
+                .build();
+    }
+}

--- a/src/main/java/com/semosan/api/domain/admin/entity/Admin.java
+++ b/src/main/java/com/semosan/api/domain/admin/entity/Admin.java
@@ -25,15 +25,11 @@ public class Admin extends BaseEntity {
     @Column(name = "name", nullable = false, length = 50)
     private String name;
 
-    @Column(name = "enabled", nullable = false)
-    private boolean enabled = true;
-
     public static Admin create(String username, String password, String name) {
         return Admin.builder()
                 .username(username)
                 .password(password)
                 .name(name)
-                .enabled(true)
                 .build();
     }
 }

--- a/src/main/java/com/semosan/api/domain/admin/entity/AdminLoginLog.java
+++ b/src/main/java/com/semosan/api/domain/admin/entity/AdminLoginLog.java
@@ -1,0 +1,58 @@
+package com.semosan.api.domain.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "admin_login_logs")
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminLoginLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "username", nullable = false, length = 50)
+    private String username;
+
+    @Column(name = "success", nullable = false)
+    private boolean success;
+
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    @Column(name = "user_agent", length = 500)
+    private String userAgent;
+
+    @Column(name = "fail_reason", length = 255)
+    private String failReason;
+
+    @Column(name = "attempted_at", nullable = false, updatable = false)
+    private LocalDateTime attemptedAt;
+
+    public static AdminLoginLog success(String username, String ipAddress, String userAgent) {
+        return AdminLoginLog.builder()
+                .username(username)
+                .success(true)
+                .ipAddress(ipAddress)
+                .userAgent(userAgent)
+                .attemptedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static AdminLoginLog fail(String username, String ipAddress, String userAgent, String failReason) {
+        return AdminLoginLog.builder()
+                .username(username)
+                .success(false)
+                .ipAddress(ipAddress)
+                .userAgent(userAgent)
+                .failReason(failReason)
+                .attemptedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/semosan/api/domain/admin/repository/AdminLoginLogRepository.java
+++ b/src/main/java/com/semosan/api/domain/admin/repository/AdminLoginLogRepository.java
@@ -1,0 +1,7 @@
+package com.semosan.api.domain.admin.repository;
+
+import com.semosan.api.domain.admin.entity.AdminLoginLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminLoginLogRepository extends JpaRepository<AdminLoginLog, Long> {
+}

--- a/src/main/java/com/semosan/api/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/semosan/api/domain/admin/repository/AdminRepository.java
@@ -1,0 +1,11 @@
+package com.semosan.api.domain.admin.repository;
+
+import com.semosan.api.domain.admin.entity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findByUsername(String username);
+}

--- a/src/main/java/com/semosan/api/domain/admin/service/AdminAuthService.java
+++ b/src/main/java/com/semosan/api/domain/admin/service/AdminAuthService.java
@@ -1,0 +1,48 @@
+package com.semosan.api.domain.admin.service;
+
+import com.semosan.api.common.exception.GeneralException;
+import com.semosan.api.common.jwt.JwtService;
+import com.semosan.api.common.status.ErrorStatus;
+import com.semosan.api.domain.admin.dto.request.AdminLoginRequest;
+import com.semosan.api.domain.admin.dto.response.AdminLoginResponse;
+import com.semosan.api.domain.admin.entity.Admin;
+import com.semosan.api.domain.admin.entity.AdminLoginLog;
+import com.semosan.api.domain.admin.repository.AdminLoginLogRepository;
+import com.semosan.api.domain.admin.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAuthService {
+
+    private final AdminRepository adminRepository;
+    private final AdminLoginLogRepository adminLoginLogRepository;
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public AdminLoginResponse login(AdminLoginRequest request, String ipAddress, String userAgent) {
+        Admin admin = adminRepository.findByUsername(request.username())
+                .orElseThrow(() -> {
+                    saveFailLog(request.username(), ipAddress, userAgent, "존재하지 않는 계정");
+                    return new GeneralException(ErrorStatus.ADMIN_LOGIN_FAILED);
+                });
+
+        if (!passwordEncoder.matches(request.password(), admin.getPassword())) {
+            saveFailLog(request.username(), ipAddress, userAgent, "비밀번호 불일치");
+            throw new GeneralException(ErrorStatus.ADMIN_LOGIN_FAILED);
+        }
+
+        adminLoginLogRepository.save(AdminLoginLog.success(request.username(), ipAddress, userAgent));
+
+        String accessToken = jwtService.generateAdminAccessToken(admin);
+        return new AdminLoginResponse(admin.getId(), admin.getName(), accessToken);
+    }
+
+    private void saveFailLog(String username, String ipAddress, String userAgent, String reason) {
+        adminLoginLogRepository.save(AdminLoginLog.fail(username, ipAddress, userAgent, reason));
+    }
+}

--- a/src/main/resources/db/migration/V33__create_admin_tables.sql
+++ b/src/main/resources/db/migration/V33__create_admin_tables.sql
@@ -1,0 +1,22 @@
+CREATE TABLE admins (
+    id         BIGSERIAL    PRIMARY KEY,
+    username   VARCHAR(50)  NOT NULL UNIQUE,
+    password   VARCHAR(255) NOT NULL,
+    name       VARCHAR(50)  NOT NULL,
+    enabled    BOOLEAN      NOT NULL DEFAULT true,
+    created_at TIMESTAMP    NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP    NOT NULL DEFAULT now()
+);
+
+CREATE TABLE admin_login_logs (
+    id           BIGSERIAL    PRIMARY KEY,
+    username     VARCHAR(50)  NOT NULL,
+    success      BOOLEAN      NOT NULL,
+    ip_address   VARCHAR(45),
+    user_agent   VARCHAR(500),
+    fail_reason  VARCHAR(255),
+    attempted_at TIMESTAMP    NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_admin_login_logs_username ON admin_login_logs (username);
+CREATE INDEX idx_admin_login_logs_attempted_at ON admin_login_logs (attempted_at);

--- a/src/main/resources/db/migration/V33__create_admin_tables.sql
+++ b/src/main/resources/db/migration/V33__create_admin_tables.sql
@@ -3,7 +3,6 @@ CREATE TABLE admins (
     username   VARCHAR(50)  NOT NULL UNIQUE,
     password   VARCHAR(255) NOT NULL,
     name       VARCHAR(50)  NOT NULL,
-    enabled    BOOLEAN      NOT NULL DEFAULT true,
     created_at TIMESTAMP    NOT NULL DEFAULT now(),
     updated_at TIMESTAMP    NOT NULL DEFAULT now()
 );


### PR DESCRIPTION
## 🧾 요약
- 관리자 로그인 API 및 JWT 기반 권한 체계 구현

## 🔗 이슈
- close #267

## ✨ 변경 내용
- Admin, AdminLoginLog 엔티티 및 Flyway 마이그레이션 추가
- 관리자 로그인 API (POST /api/admin/login) 구현 (BCrypt 비밀번호 검증)
- JWT에 tokenType=ADMIN claim 추가, JwtFilter에서 ROLE_ADMIN 권한 부여
- SecurityConfig에 /api/admin/** ADMIN 전용, PUT /api/app-version ADMIN 전용 설정
- 로그인 시도 감사 로그 기록 (성공/실패, IP, User-Agent)

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK
