### PR TITLE
[Fix] 관리자 로그인 JwtFilter 우회 및 실패 로그 롤백 수정

### DIFF
--- a/src/main/java/com/semosan/api/common/config/SecurityConfig.java
+++ b/src/main/java/com/semosan/api/common/config/SecurityConfig.java
@@ -59,6 +59,10 @@ public class SecurityConfig {
             "/ws/tracking/**"
     };
 
+    public static final String[] ADMIN_PUBLIC_URIS = {
+            "/api/admin/login"
+    };
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -75,7 +79,7 @@ public class SecurityConfig {
                         .requestMatchers(AUTH_URIS).permitAll()
                         .requestMatchers(WEBSOCKET_URIS).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/app-version").permitAll()
-                        .requestMatchers("/api/admin/login").permitAll()
+                        .requestMatchers(ADMIN_PUBLIC_URIS).permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/app-version").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/java/com/semosan/api/common/jwt/JwtFilter.java
+++ b/src/main/java/com/semosan/api/common/jwt/JwtFilter.java
@@ -43,7 +43,8 @@ public class JwtFilter extends OncePerRequestFilter {
                             SecurityConfig.SWAGGER_URIS,
                             SecurityConfig.OAUTH_URIS,
                             SecurityConfig.AUTH_URIS,
-                            SecurityConfig.WEBSOCKET_URIS
+                            SecurityConfig.WEBSOCKET_URIS,
+                            SecurityConfig.ADMIN_PUBLIC_URIS
                     )
                     .flatMap(Arrays::stream)
                     .map(PathPatternRequestMatcher.withDefaults()::matcher)

--- a/src/main/java/com/semosan/api/domain/admin/service/AdminAuthService.java
+++ b/src/main/java/com/semosan/api/domain/admin/service/AdminAuthService.java
@@ -6,8 +6,6 @@ import com.semosan.api.common.status.ErrorStatus;
 import com.semosan.api.domain.admin.dto.request.AdminLoginRequest;
 import com.semosan.api.domain.admin.dto.response.AdminLoginResponse;
 import com.semosan.api.domain.admin.entity.Admin;
-import com.semosan.api.domain.admin.entity.AdminLoginLog;
-import com.semosan.api.domain.admin.repository.AdminLoginLogRepository;
 import com.semosan.api.domain.admin.repository.AdminRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,30 +17,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminAuthService {
 
     private final AdminRepository adminRepository;
-    private final AdminLoginLogRepository adminLoginLogRepository;
+    private final AdminLoginLogService adminLoginLogService;
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public AdminLoginResponse login(AdminLoginRequest request, String ipAddress, String userAgent) {
         Admin admin = adminRepository.findByUsername(request.username())
                 .orElseThrow(() -> {
-                    saveFailLog(request.username(), ipAddress, userAgent, "존재하지 않는 계정");
+                    adminLoginLogService.saveFailLog(request.username(), ipAddress, userAgent, "존재하지 않는 계정");
                     return new GeneralException(ErrorStatus.ADMIN_LOGIN_FAILED);
                 });
 
         if (!passwordEncoder.matches(request.password(), admin.getPassword())) {
-            saveFailLog(request.username(), ipAddress, userAgent, "비밀번호 불일치");
+            adminLoginLogService.saveFailLog(request.username(), ipAddress, userAgent, "비밀번호 불일치");
             throw new GeneralException(ErrorStatus.ADMIN_LOGIN_FAILED);
         }
 
-        adminLoginLogRepository.save(AdminLoginLog.success(request.username(), ipAddress, userAgent));
+        adminLoginLogService.saveSuccessLog(request.username(), ipAddress, userAgent);
 
         String accessToken = jwtService.generateAdminAccessToken(admin);
         return new AdminLoginResponse(admin.getId(), admin.getName(), accessToken);
-    }
-
-    private void saveFailLog(String username, String ipAddress, String userAgent, String reason) {
-        adminLoginLogRepository.save(AdminLoginLog.fail(username, ipAddress, userAgent, reason));
     }
 }

--- a/src/main/java/com/semosan/api/domain/admin/service/AdminLoginLogService.java
+++ b/src/main/java/com/semosan/api/domain/admin/service/AdminLoginLogService.java
@@ -1,0 +1,25 @@
+package com.semosan.api.domain.admin.service;
+
+import com.semosan.api.domain.admin.entity.AdminLoginLog;
+import com.semosan.api.domain.admin.repository.AdminLoginLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminLoginLogService {
+
+    private final AdminLoginLogRepository adminLoginLogRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveSuccessLog(String username, String ipAddress, String userAgent) {
+        adminLoginLogRepository.save(AdminLoginLog.success(username, ipAddress, userAgent));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveFailLog(String username, String ipAddress, String userAgent, String reason) {
+        adminLoginLogRepository.save(AdminLoginLog.fail(username, ipAddress, userAgent, reason));
+    }
+}


### PR DESCRIPTION
## 🧾 요약
- 관리자 로그인 API가 JwtFilter에 차단되는 문제와 실패 로그가 트랜잭션 롤백으로 유실되는 버그 수정

## 🔗 이슈
- close #271

## ✨ 변경 내용
- `SecurityConfig`에 `ADMIN_PUBLIC_URIS` 상수 추가 및 `JwtFilter` 제외 경로에 반영
- `AdminLoginLogService` 별도 빈 분리 (`REQUIRES_NEW` 트랜잭션으로 로그 유실 방지)
- `AdminAuthService`를 `readOnly` 트랜잭션으로 변경, 로그 저장을 `AdminLoginLogService`에 위임

## ✅ 확인
- [x] 빌드 OK
- [x] 테스트 OK
